### PR TITLE
setup.py tests for correct python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,25 @@
 
 from setuptools import setup
 import re
+import os
+import sys
 
 from fermipy.version import get_git_version
+
+##Check to make sure we're using the python in the STs.
+if os.environ.has_key('GLAST_EXT'):
+    print "Looks like you're using the SLAC version of the tools."
+    print "Not checking for correct python."
+elif os.environ.has_key('FERMI_DIR'):
+    print "Looks like you're using the FSSC version of the tools."
+    fermi_dir = os.getenv('FERMI_DIR')
+    os_file = os.__file__
+    if fermi_dir not in os_file:
+        print "Python executable is not the one in $FERMI_DIR/bin.  Exiting."
+        sys.exit(1)
+else:
+    print "Looks like the Fermi Science Tools are not setup.  Exiting."
+    sys.exit(1)
 
 setup(name='fermipy',
       version=get_git_version(),


### PR DESCRIPTION
Put in a check to make sure that the python executable matches the installed science tools.  Doesn't do this check if the SLAC tools are detected.   Here's the code: 

```python
#Check to make sure we're using the python in the STs.
if os.environ.has_key('GLAST_EXT'):
    print "Looks like you're using the SLAC version of the tools."
    print "Not checking for correct python."
elif os.environ.has_key('FERMI_DIR'):
    print "Looks like you're using the FSSC version of the tools."
    fermi_dir = os.getenv('FERMI_DIR')
    os_file = os.__file__
    if fermi_dir not in os_file:
        print "Python executable is not the one in $FERMI_DIR/bin.  Exiting."
        sys.exit(1)
else:
    print "Looks like the Fermi Science Tools are not setup.  Exiting."
    sys.exit(1)```