### PR TITLE
Code style cleanup: no tabs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ from mock import Mock as MagicMock
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
-            return Mock()
+        return Mock()
 
 MOCK_MODULES = ['pyLikelihood','pyIrfLoader',
                 'BinnedAnalysis','UnbinnedAnalysis','SrcModel','AnalysisBase',
@@ -198,7 +198,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 html_static_path = ['_static']
 
 def setup(app):
-   app.add_stylesheet("theme_overrides.css")
+    app.add_stylesheet("theme_overrides.css")
 
 #html_context = {
 #    'css_files': [
@@ -289,7 +289,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'Fermipy.tex', u'Fermipy Documentation',
+    (master_doc, 'Fermipy.tex', u'Fermipy Documentation',
    u'Matthew Wood', 'manual'),
 ]
 
@@ -333,7 +333,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Fermipy', u'Fermipy Documentation',
+    (master_doc, 'Fermipy', u'Fermipy Documentation',
    author, 'Fermipy', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/make_tables.py
+++ b/docs/make_tables.py
@@ -1,10 +1,10 @@
 import fermipy.defaults as defaults
 
 for k, v in defaults.__dict__.items():
-    
+
     if not isinstance(v,dict) or k.startswith('_'):
         continue
-    
+
     f = open("config/%s.csv"%k, "w")
 
     if 'output' in k:

--- a/fermipy/batch.py
+++ b/fermipy/batch.py
@@ -10,7 +10,7 @@ def check_log(logfile, exited='Exited with exit code',
     string  : Value to check for in existing logfile
     """
     if not os.path.exists(logfile):
-	return not exists
+        return not exists
 
     if exited in open(logfile).read():
         return 'Exited'
@@ -27,7 +27,7 @@ def get_lsf_status():
                     'USUSP': 0,
                     'NJOB' : 0,
                     'UNKNWN' : 0}
-    
+
     p = subprocess.Popen(['bjobs'],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
@@ -39,12 +39,12 @@ def get_lsf_status():
         line = line.strip().split()
 
         status_count['NJOB'] += 1
-        
+
         for k in status_count.keys():
 
             if line[2] == k:
                 status_count[k] += 1
-                
+
     return status_count
 
 
@@ -52,9 +52,9 @@ def dispatch_jobs(exe,args,opts,batch_opts):
 
     batch_opts.setdefault('W',300)
     batch_opts.setdefault('R','rhel60')
-    
+
     #skip_keywords = ['queue','resources','batch','W']
-        
+
     cmd_opts = ''
     for k, v in opts.__dict__.items():
         if isinstance(v,list):
@@ -66,7 +66,7 @@ def dispatch_jobs(exe,args,opts,batch_opts):
             continue
         elif not v is None:
             cmd_opts += ' --%s=\"%s\" '%(k,v)
-        
+
 #    for x in args:
 #            cmd = '%s %s '%(exe,x)
 #            batch_cmd = 'bsub -W %s -R %s '%(W,resources)
@@ -80,7 +80,7 @@ def dispatch_jobs(exe,args,opts,batch_opts):
     batch_optstr = ''
     for k,v in batch_opts.items():
         batch_optstr += ' -%s %s '%(k,v)
-    
+
     batch_cmd = 'bsub %s '%(batch_optstr)
     batch_cmd += ' %s %s '%(cmd,cmd_opts)        
     print(batch_cmd)

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -47,7 +47,7 @@ PAR_NAMES = {"PowerLaw":["Prefactor","Index"],
              "LogParabola":["norm","alpha","beta"],
              "PLExpCutoff":["Prefactor","Index1","Cutoff"]}
 
-        
+
 class Interpolator(object):
     """ Helper class for interpolating a 1-D function from a
     set of tabulated values.  
@@ -57,10 +57,10 @@ class Interpolator(object):
     def __init__(self,x,y):
         """ C'tor, take input array of x and y value         
         """
-        
+
         x = np.squeeze(np.array(x,ndmin=1))
         y = np.squeeze(np.array(y,ndmin=1))
-        
+
         msk = np.isfinite(y)
         x = x[msk]
         y = y[msk]
@@ -76,7 +76,7 @@ class Interpolator(object):
 
         self._fn = UnivariateSpline(x,y,s=0,k=1)        
         self._sp = splrep(x,y,k=1,s=0)
-        
+
     @property
     def xmin(self):
         """ return the minimum value over which the spline is defined
@@ -122,7 +122,7 @@ class Interpolator(object):
 
         below_bounds = x < self._xmin
         above_bounds = x > self._xmax
-        
+
         dxhi = np.array(x-self._xmax)
         dxlo = np.array(x-self._xmin)
 
@@ -130,11 +130,11 @@ class Interpolator(object):
         # passes a flattened version of the array.
         y = self._fn(x.ravel())
         y.resize(x.shape)
-            
+
         y[above_bounds] = (self._ymax + dxhi[above_bounds]*self._dydx_hi)
         y[below_bounds] = (self._ymin + dxlo[below_bounds]*self._dydx_lo)
         return y
-  
+
 
 class LnLFn(object):
     """
@@ -152,7 +152,7 @@ class LnLFn(object):
 
         y : array-like
           Set of values for the _negative_ log-likelhood
-          
+
         norm_type :  code specifying the quantity used for the flux 
 
         Note that class takes and returns the _negative log-likelihood as fitters 
@@ -199,7 +199,7 @@ class LnLFn(object):
 
             while np.sign(self._interp.derivative(self._interp.x[ix0])) == np.sign(self._interp.derivative(self._interp.x[ix1])):
                 ix0 += 1
-            
+
             self._mle = scipy.optimize.brentq(self._interp.derivative,
                                               self._interp.x[ix0], self._interp.x[ix1],
                                               xtol=1e-10*np.median(self._interp.x))    
@@ -211,9 +211,9 @@ class LnLFn(object):
         """
         if self._mle is None:
             self._compute_mle()
-        
+
         return self._mle
-        
+
 
     def fn_mle(self):
         """ return the function value at the maximum likelihood estimate """
@@ -223,7 +223,7 @@ class LnLFn(object):
         """ return the Test Statistic """
         return 2. * (self._interp(0.) - self._interp(self.mle()))
 
-    
+
     def getLimit(self,alpha,upper=True):
         """ Evaluate the limits corresponding to a C.L. of (1-alpha)%.
 
@@ -253,7 +253,7 @@ class LnLFn(object):
         else:
             x = np.linspace(self._mle,self._interp.xmin,100) 
             #return opt.brentq(rf,self._interp.xmin,self._mle,xtol=1e-10*np.abs(self._mle))
-            
+
         retVal =  np.interp(dlnl,self.interp(x)-lnl_max,x)
         return retVal
 
@@ -285,14 +285,14 @@ class SpecData(object):
 
         emax :  `~numpy.ndarray`
            Array of upper bin edges.
- 
+
         dfde :  `~numpy.ndarray`
            Array of differential photon flux values.  
            Typically evaluated at the geometric mean of the energy bins
 
         flux :  `~numpy.ndarray`
            Array of integral photon flux values.
- 
+
         eflux :  `~numpy.ndarray`
            Array of integral energy flux values.
 
@@ -335,7 +335,7 @@ class SpecData(object):
         """ return the lower energy bin edges
         """
         return self._emax
-    
+
     @property
     def bin_widths(self):
         """ return the energy bin widths
@@ -389,12 +389,12 @@ class CastroData_Base(object):
            The normalization values ( N X M array, 
            where N is the number for bins and M
            number of sampled values for each bin )
-           
+
         nll_vals : `~numpy.ndarray`  
            The _negative_ log-likelihood values ( N X M array, 
            where N is the number for bins and M
            number of sampled values for each bin )
-           
+
         norm_type : str
            String specifying the quantity used for the normalization, 
            value depend on the sub-class details
@@ -416,7 +416,7 @@ class CastroData_Base(object):
     def nx(self):
         """ Return the number of profiles """
         return self._nx
-    
+
     @property
     def ny(self):
         """ Return the number of profiles """
@@ -432,7 +432,7 @@ class CastroData_Base(object):
         """ Return the negative log-likelihood for the null-hypothesis """ 
         return self._nll_null
 
- 
+
     def __getitem__(self,i):
         """ return the LnLFn object for the ith energy bin
         """
@@ -456,12 +456,12 @@ class CastroData_Base(object):
         # crude hack to force the fitter away from unphysical values
         if ( x < 0 ).any():
             return 1000.
-        
+
         for i,xv in enumerate(x):
             nll_val += self._loglikes[i].interp(xv)
-            
+
         return nll_val
-        
+
     def derivative(self,x,der=1):
         """Return the derivate of the log-like summed over the energy
         bins
@@ -470,7 +470,7 @@ class CastroData_Base(object):
         ----------
         x   : `~numpy.ndarray`  
            Array of N x M values
-           
+
         der : int
            Order of the derivate
 
@@ -488,7 +488,7 @@ class CastroData_Base(object):
         """ return the maximum likelihood estimates for each of the energy bins
         """
         mle_vals = np.ndarray((self._nx))
-        
+
         for i in range(self._nx):
             mle_vals[i] = self._loglikes[i].mle()
         return mle_vals
@@ -510,7 +510,7 @@ class CastroData_Base(object):
             ts_vals[i] = self._loglikes[i].TS()
             pass
         return ts_vals 
-    
+
     def getLimits(self,alpha,upper=True):
         """ Evaluate the limits corresponding to a C.L. of (1-alpha)%.
 
@@ -522,12 +522,12 @@ class CastroData_Base(object):
         returns an array of values, one for each energy bin
         """
         limit_vals = np.ndarray((self._nx))
-        
+
         for i in range(self._nx):
             limit_vals[i] = self._loglikes[i].getLimit(alpha,upper)
             pass
         return limit_vals
-    
+
     def fitNormalization(self,specVals,xlims):
         """Fit the normalization given a set of spectral values that
         define a spectral shape
@@ -550,12 +550,12 @@ class CastroData_Base(object):
             else:
                 return xlims[1]
         return result
-       
+
     def fitNorm_v2(self,specVals):
         """ Fit the normalization given a set of spectral values that define a spectral shape
 
         This version uses scipy.optimize.fmin
-        
+
         Parameters
         ----------
         specVals :  an array of (nebin values that define a spectral shape
@@ -566,10 +566,10 @@ class CastroData_Base(object):
         fToMin = lambda x : self.__call__(specVals*x)
         result = scipy.optimize.fmin(fToMin,0.,disp=False,xtol=1e-6)   
         return result
-       
+
     def fit_spectrum(self,specFunc,initPars):
         """ Fit for the free parameters of a spectral function
-        
+
         Parameters
         ----------
         specFunc :  The Spectral Function
@@ -588,12 +588,12 @@ class CastroData_Base(object):
 
         def fToMin(x):
             return self.__call__(specFunc(x))
-                
+
         result = scipy.optimize.fmin(fToMin,initPars,disp=False,xtol=1e-6)   
         spec_out = specFunc(result)
         TS_spec = self.TS_spectrum(spec_out)
         return result,spec_out,TS_spec
-        
+
     def TS_spectrum(self,spec_vals):
         """ Calculate and the TS for a given set of spectral values
         """        
@@ -603,7 +603,7 @@ class CastroData_Base(object):
     @staticmethod
     def stack_nll(shape,components,weights=None):
         """ Combine the log-likelihoods from a number of components.
-        
+
         Parameters
         ----------
         shape    :  tuple
@@ -624,7 +624,7 @@ class CastroData_Base(object):
         """
         n_bins = shape[0]
         n_vals = shape[1]
-   
+
         if weights is None:
             weights = np.ones((len(components)))
 
@@ -644,7 +644,7 @@ class CastroData_Base(object):
             nll_min = nll_obj.fn_mle()
             nll_vals[i] = nll_min - nll_vals[i]
             pass
- 
+
         nll_vals *= -1.
         return norm_vals,nll_vals
 
@@ -662,14 +662,14 @@ class CastroData(CastroData_Base):
         norm_vals : `~numpy.ndarray`        
            The normalization values ( nEBins X N array, where N is the
            number of sampled values for each bin )
-           
+
         nll_vals : `~numpy.ndarray`  
            The log-likelihood values ( nEBins X N array, where N is
            the number of sampled values for each bin )
-           
+
         specData : `~fermipy.sed.SpecData`
            The specData object
-           
+
         norm_type : str
            String specifying the quantity used for the normalization:
             NORM: Normalization w.r.t. to test source
@@ -681,7 +681,7 @@ class CastroData(CastroData_Base):
         """
         super(CastroData,self).__init__(norm_vals,nll_vals,norm_type)
         self._specData = specData
- 
+
     @property
     def nE(self):
         """ Return the number of energy bins.  This is also the number of x-axis bins.
@@ -712,7 +712,7 @@ class CastroData(CastroData_Base):
 
         tab_s   : str
            table scan data
- 
+
         tab_e   : str
            table energy binning and normalization data
 
@@ -726,7 +726,7 @@ class CastroData(CastroData_Base):
             norm_vals = np.array(tab_s['NORM_SCAN'])
         else:
             raise Exception('Unrecognized normalization type: %s'%norm_type)
-            
+
         nll_vals = -np.array(tab_s['DLOGLIKE_SCAN'])
         emin = np.array(tab_e['E_MIN'])
         emax = np.array(tab_e['E_MAX'])
@@ -734,11 +734,11 @@ class CastroData(CastroData_Base):
         dfde = np.array(tab_s['NORM']*tab_e['REF_DFDE'])
         flux = np.array(tab_s['NORM']*tab_e['REF_FLUX'])
         eflux = np.array(tab_s['NORM']*tab_e['REF_EFLUX'])
-        
+
         sd = SpecData(emin,emax,dfde,flux,eflux,npred)
-    
+
         return CastroData(norm_vals,nll_vals,sd,norm_type)
-         
+
 
 
     @staticmethod
@@ -764,7 +764,7 @@ class CastroData(CastroData_Base):
 
         hdu_scan  : str
            name of the FITS HDU with the scan data
- 
+
         hdu_energies : str
            name of the FITS HDU with the energy binning and normalization data
 
@@ -782,7 +782,7 @@ class CastroData(CastroData_Base):
             tab_s = Table.read(fitsfile,hdu=hdu_scan)
         tab_e = Table.read(fitsfile,hdu=hdu_energies)
         return CastroData.create_from_tables(norm_type,tab_s,tab_e)
-      
+
 
     @staticmethod
     def create_from_sedfile(fitsfile,norm_type='EFLUX'):
@@ -814,7 +814,7 @@ class CastroData(CastroData_Base):
             norm_vals = np.array(tab_s['NORM_SCAN'])
         else:
             raise Exception('Unrecognized normalization type: %s'%norm_type)
-            
+
         nll_vals = -np.array(tab_s['DLOGLIKE_SCAN'])
         emin = np.array(tab_s['E_MIN'])
         emax = np.array(tab_s['E_MAX'])
@@ -822,16 +822,16 @@ class CastroData(CastroData_Base):
         dfde = np.array(tab_s['NORM']*tab_s['REF_DFDE'])
         flux = np.array(tab_s['NORM']*tab_s['REF_FLUX'])
         eflux = np.array(tab_s['NORM']*tab_s['REF_EFLUX'])
-        
+
         sd = SpecData(emin,emax,dfde,flux,eflux,npred)
-    
+
         return CastroData(norm_vals,nll_vals,sd,norm_type)
 
 
     @staticmethod
     def create_from_stack(shape,components,weights=None):
         """  Combine the log-likelihoods from a number of components.
-        
+
         Parameters
         ----------
         shape    :  tuple
@@ -851,7 +851,7 @@ class CastroData(CastroData_Base):
         norm_vals,nll_vals = CastroData_Base.stack_nll(shape,components,weights)
         return CastroData(norm_vals,nll_vals,components[0].specData,components[0].norm_type)
 
-    
+
     def _buildLnLFn(self,normv,nllv):
         """
         """
@@ -860,7 +860,7 @@ class CastroData(CastroData_Base):
 
     def spectrum_loglike(self,specType,params,scale=1E3):
         """ return the log-likelihood for a particular spectrum
-        
+
         specTypes  : str
             The type of spectrum to try
 
@@ -873,7 +873,7 @@ class CastroData(CastroData_Base):
         sfn = self.create_functor(specType,scale)[0]
         return self.__call__(sfn(params))      
 
-        
+
     def test_spectra(self,spec_types=['PowerLaw','LogParabola','PLExpCutoff']):
         """ Test different spectral types against the SED represented by this CastroData
 
@@ -887,7 +887,7 @@ class CastroData(CastroData_Base):
         retDict : dict
            A dictionary of dictionaries.
            The top level dictionary is keyed by spec_type
-        
+
            The sub-dictionaries each contain:
               "Function"    : '~fermipy.spectrum.SpectralFunction'
               "Result"      : tuple with the output of scipy.optimize.fmin
@@ -899,7 +899,7 @@ class CastroData(CastroData_Base):
         for specType in spec_types:     
             spec_func,init_pars,scaleEnergy = self.create_functor(specType)
             fit_result,fit_spec,fit_ts = self.fit_spectrum(spec_func,init_pars)
-       
+
             specDict = {"Function":spec_func,
                         "Result":fit_result,
                         "Spectrum":fit_spec,
@@ -913,7 +913,7 @@ class CastroData(CastroData_Base):
     def create_functor(self,specType,scale=1E3):
         """ Create a functor object that computes normalizations in a
         sequence of energy bins for a given spectral model.
-      
+
         Parameters
         ----------
         specType   : str
@@ -922,7 +922,7 @@ class CastroData(CastroData_Base):
         scale      : float
             The 'pivot energy' or energy scale to use for the spectrum        
 
-            
+
         Returns:
         ----------
         fn         : 'fermiy.spectrum.SpectralFunction'
@@ -946,7 +946,7 @@ class CastroData(CastroData_Base):
             initPars = np.array([5e-13,-1.0,1E4])
         else:
             raise Exception('Unknown spectral type: %s'%specType)
-            
+
         fn = SpectralFunction.create_functor(specType,
                                              self.norm_type,
                                              emin,
@@ -979,24 +979,24 @@ class TSCube(object):
 
         normmap     : `~fermipy.skymap.Map`
            A Map object with the normalization values in each pixel
-           
+
         tscube      : `~fermipy.skymap.Map`
            A Map object with the TestStatistic values in each pixel & energy bin
 
         normcube    : `~fermipy.skymap.Map`
            A Map object with the normalization values in each pixel & energy bin
-           
+
         norm_vals   : `~numpy.ndarray`        
            The normalization values ( nEBins X N array, where N is the
            number of sampled values for each bin )
-           
+
         nll_vals    : `~numpy.ndarray`        
            The negative log-likelihood values ( nEBins X N array, where N is
            the number of sampled values for each bin )
-           
+
         specData    : `~fermipy.sed.SpecData`
            The specData object
-           
+
         norm_type : str
            String specifying the quantity used for the normalization
             * NORM : Normalization w.r.t. to test source
@@ -1005,7 +1005,7 @@ class TSCube(object):
             * NPRED : Number of predicted photons
             * DFDE : Differential flux of the test source ( ph cm^-2 s^-1 MeV^-1 )
             * E2DFDE : E^2 times Differential energy flux of the test source ( MeV cm^-2 s^-1 )
-           
+
         """
         self._tsmap = tsmap
         self._normmap = normmap
@@ -1023,7 +1023,7 @@ class TSCube(object):
     def tsmap(self):
         """ return the Map of the TestStatistic value """
         return self._tsmap
-    
+
     @property
     def normmap(self):
         """ return the Map of the Best-fit normalization value """
@@ -1068,10 +1068,10 @@ class TSCube(object):
            Path to the tscube FITS file.
         norm_type : str 
            String specifying the quantity used for the normalization
-        
+
         """
         tsmap,f = read_map_from_fits(fitsfile)
- 
+
         tab_e = Table.read(fitsfile,'EBOUNDS')
         tab_s = Table.read(fitsfile,'SCANDATA')
         tab_f = Table.read(fitsfile,'FITDATA')
@@ -1080,7 +1080,7 @@ class TSCube(object):
         emax = np.array(tab_e['E_MAX']/1E3)
         nebins = len(tab_e)
         npred = tab_e['REF_NPRED']
-        
+
         ndim = len(tsmap.counts.shape)
 
         if ndim == 2:
@@ -1098,7 +1098,7 @@ class TSCube(object):
                             npred)
         nll_vals =  -np.array(tab_s["DLOGLIKE_SCAN"])
         norm_vals = np.array(tab_s["NORM_SCAN"])
-        
+
         wcs_3d = wcs_add_energy_axis(tsmap.wcs,emin)
         tscube = Map(np.rollaxis(tab_s["TS"].reshape(cube_shape),2,0),
                      wcs_3d)
@@ -1106,10 +1106,10 @@ class TSCube(object):
                     wcs_3d)
         nmap = Map(tab_f['FIT_NORM'].reshape(tsmap.counts.shape),
                    tsmap.wcs)
-        
+
         ref_colname = 'REF_%s'%norm_type
         norm_vals *= tab_e[ref_colname][np.newaxis,:,np.newaxis]
-        
+
         return TSCube(tsmap,nmap,tscube,ncube,norm_vals,nll_vals,specData,
                       norm_type)
 
@@ -1121,7 +1121,7 @@ class TSCube(object):
         norm_d = self._norm_vals[ipix]
         nll_d = self._nll_vals[ipix]
         return CastroData(norm_d,nll_d,self._specData,self._norm_type)
-    
+
     def castroData_from_pix_xy(self,xy,colwise=False):
         """ Build a CastroData object for a particular pixel """
         ipix = self._tsmap.xy_pix_to_ipix(xy,colwise)
@@ -1142,7 +1142,7 @@ class TSCube(object):
         use_cumul : bool
             If true, used the cumulative TS map (i.e., the TS summed over the energy bins) instead of the 
             TS Map from the fit to and index=2 powerlaw.
-       
+
         Returns
         -------
         peaks    : list
@@ -1153,7 +1153,7 @@ class TSCube(object):
             theMap = self._ts_cumul
         else:
             theMap = self._tsmap
-            
+
         peaks = find_peaks(theMap,threshold,min_separation)
         for peak in peaks:
             #o =  utils.fit_parabola(theMap.counts,peak['iy'],peak['ix'],dpix=2)
@@ -1258,7 +1258,7 @@ def build_source_dict(src_name,peak_dict,spec_dict,spec_type):
     src_dict['pos_r95'] = peak_dict['fit_loc']['r95']
     src_dict['pos_r99'] = peak_dict['fit_loc']['r99']
     src_dict['pos_angle'] = np.degrees(peak_dict['fit_loc']['theta'])
-    
+
     return src_dict
 
 
@@ -1322,5 +1322,5 @@ if __name__ == "__main__":
         print ("TS for PLExpCutoff:   %.1f (Index = %.2f, E_c = %.2f)"%(ts_pc[0],idx_off-result_pc[1],result_pc[2]))
 
     """
-        
-    
+
+

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -64,7 +64,7 @@ def row_to_dict(row):
 class Catalog(object):
     """Source catalog object.  This class provides a simple wrapper around
     FITS catalog tables."""
-    
+
     def __init__(self, table, extdir=''):
         self._table = table
         self._extdir = extdir
@@ -82,7 +82,7 @@ class Catalog(object):
 
         if 'Spatial_Filename' not in self.table.columns:
             self.table['Spatial_Filename'] = Column(dtype='S20',length=len(self.table))
-            
+
         m = (self.table['Spatial_Filename'] != '') & (self.table['Spatial_Filename'] != 'None')
         self.table['extended'] = False
         self.table['extended'][m] = True
@@ -115,18 +115,18 @@ class Catalog(object):
             if not os.path.isfile(fitsfile):
                 fitsfile = os.path.join(fermipy.PACKAGE_DATA, 'catalogs',
                                         fitsfile)
-                
+
             # Try to guess the catalog type form its name
             if 'gll_psc' in fitsfile:                
                 return Catalog3FGL(fitsfile)
 
             tab = Table.read(fitsfile)
-            
+
             if 'NickName' in tab.columns:
                 return Catalog4FGLP(fitsfile)
             else:
                 return Catalog(Table.read(fitsfile))
-            
+
         elif name == '3FGL':
             return Catalog3FGL()
         elif name == '2FHL':
@@ -211,7 +211,7 @@ class Catalog4FGLP(Catalog):
     Because there is currently no dedicated extended source library
     for 4FGL this class reuses the extended source library from the
     3FGL."""
-    
+
     def __init__(self, fitsfile=None, extdir=None):
 
         if extdir is None:
@@ -229,14 +229,14 @@ class Catalog4FGLP(Catalog):
         m = table['Extended'] == True
 
         table['Spatial_Filename'] = Column(dtype='S20',length=len(table))
-        
+
         spatial_filenames = []
         for i, row in enumerate(table[m]):
             spatial_filenames += [table[m][i]['Source_Name'].replace(' ','') + '.fits']
         table['Spatial_Filename'][m] =  np.array(spatial_filenames)
-        
+
         super(Catalog4FGLP, self).__init__(table, extdir)
-        
+
         m = self.table['SpectrumType'] == 'PLExpCutoff'
         self.table['SpectrumType'][m] = 'PLSuperExpCutoff'
 

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -43,7 +43,7 @@ def cast_config(config, defaults):
 
         if key not in defaults:
             continue
-        
+
         if isinstance(item, dict):
             cast_config(config[key], defaults[key])
         elif item is None:
@@ -67,10 +67,10 @@ def validate_config(config, defaults, section=None):
 
             type0 = type(defaults[key])
             type1 = type(item)
-            
+
             raise Exception('Wrong type for configuration key: '
                             '%s\ntype: %s required type: %s'%(key,type1,type0))
-            
+
         if key not in defaults:
 
             if section is None:
@@ -101,7 +101,7 @@ class Configurable(object):
             raise Exception('Invalid path to configuration file: %s'%config)
         else:
             raise Exception('Invalid config argument.')
-            
+
         self.configure(config_dict, **kwargs)
 
         if self.configdir and 'fileio' in self.config and \
@@ -130,7 +130,7 @@ class Configurable(object):
     @property
     def configdir(self):
         return self._configdir
-    
+
     def write_config(self, outfile):
         """Write the configuration dictionary to an output file."""
         utils.write_yaml(self.config, outfile, default_flow_style=False)

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -41,7 +41,7 @@ def read_spectral_data(hdu):
 
 
 def write_maps(primary_map, maps, outfile):
-    
+
     hdu_images = [primary_map.create_primary_hdu()]
     for k, v in sorted(maps.items()):
         hdu_images += [v.create_image_hdu(k)]
@@ -51,7 +51,7 @@ def write_maps(primary_map, maps, outfile):
         h.header['CREATOR'] = 'fermipy ' + fermipy.__version__
     hdulist.writeto(outfile, clobber=True)
 
-    
+
 def read_projection_from_fits(fitsfile, extname=None):
     """
     Load a WCS or HPX projection.
@@ -63,7 +63,7 @@ def read_projection_from_fits(fitsfile, extname=None):
         ebins = read_energy_bounds(f['EBOUNDS'])
     except:
         ebins = None
-    
+
     if extname is None:
         # If there is an image in the Primary HDU we can return a WCS-based projection
         if f[0].header['NAXIS'] != 0:
@@ -81,7 +81,7 @@ def read_projection_from_fits(fitsfile, extname=None):
             except:
                 pass
         return None,f,None 
-            
+
     # Loop on HDU and look for either an image or a table with HEALPix data
     for i in range(1,nhdu):
         # if there is an image we can return a WCS-based projection
@@ -128,4 +128,4 @@ def write_tables_to_fits(filepath,tablelist,clobber=False,
     pyfits.HDUList(outhdulist).writeto(filepath,clobber=clobber)
     for rm in rmlist:
         os.unlink(rm)
-        
+

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -87,24 +87,24 @@ FUNCTION_DEFAULT_PARS = {
     }
 
 def init_function_pars():
-    
+
     global FUNCTION_PAR_NAMES
     global FUNCTION_NORM_PARS
     global FUNCTION_DEFAULT_PARS
-    
+
     FUNCTION_PAR_NAMES = {}
     FUNCTION_NORM_PARS = {}
-    
+
     funcFactory = pyLike.SourceFactory_funcFactory()
-    
+
     names = pyLike.StringVector()
     funcFactory.getFunctionNames(names)
-        
+
     for fname in names:
 
         FUNCTION_DEFAULT_PARS.setdefault(fname,{})
         FUNCTION_PAR_NAMES.setdefault(fname,[])
-        
+
         fn = funcFactory.create(fname)        
         try:
             FUNCTION_NORM_PARS[fname] = fn.normPar().getName()
@@ -118,7 +118,7 @@ def init_function_pars():
 
             pname = p.getName()
             FUNCTION_PAR_NAMES[fname] += [pname]
-            
+
             if pname == 'Scale':
                 FUNCTION_DEFAULT_PARS[fname].setdefault(pname,DEFAULT_SCALE_DICT)
             elif pname == 'Prefactor':
@@ -137,7 +137,7 @@ def init_function_pars():
             par_dict.update(copy.deepcopy(FUNCTION_DEFAULT_PARS[fname][pname]))
             par_dict['name'] = pname            
             FUNCTION_DEFAULT_PARS[fname][pname] = par_dict
-        
+
 
 def get_function_par_names(function_type):
 
@@ -146,7 +146,7 @@ def get_function_par_names(function_type):
 
     if not function_type in FUNCTION_PAR_NAMES.keys():
         raise Exception('Invalid Function Type: %s'%function_type)
-    
+
     return copy.deepcopy(FUNCTION_PAR_NAMES[function_type])
 
 
@@ -181,7 +181,7 @@ def make_parameter_dict(pdict, fixed_par=False, rescale=True):
             value, scale = utils.scale_parameter(o['value'])
         else:
             value, scale = o['value'], 1.0
-            
+
         o['value'] = value
         o['scale'] = scale
         if 'error' in o:
@@ -192,7 +192,7 @@ def make_parameter_dict(pdict, fixed_par=False, rescale=True):
 
     if 'max' not in o:
         o['max'] = o['value']*1E3
-        
+
     if fixed_par:
         o['min'] = o['value']
         o['max'] = o['value']
@@ -222,7 +222,7 @@ def create_spectral_pars_dict(spectrum_type,spectral_pars=None):
 
         if not k in pars_dict:
             continue
-        
+
         if not isinstance(v,dict):
             spectral_pars[k] = {'name' : k, 'value' : v}
 
@@ -254,12 +254,12 @@ def create_spectrum_from_dict(spectrum_type,spectral_pars=None, fn=None):
     for k, v in pars.items():
 
         v = make_parameter_dict(v)
-        
+
         par = fn.getParam(str(k))
 
         vmin = min(float(v['value']), float(v['min']))
         vmax = max(float(v['value']), float(v['max']))
-        
+
         par.setValue(float(v['value']))
         par.setBounds(vmin, vmax)
         par.setScale(float(v['scale']))
@@ -275,7 +275,7 @@ def create_spectrum_from_dict(spectrum_type,spectral_pars=None, fn=None):
 
 def get_spatial_type(spatial_model):
     """Translate a spatial model string to a spatial type."""
-    
+
     if spatial_model in ['SkyDirFunction', 'PointSource',
                          'Gaussian', 'PSFSource']:
         return 'SkyDirFunction'
@@ -289,16 +289,16 @@ def get_spatial_type(spatial_model):
     else:
         return spatial_model
 
-    
+
 def get_source_type(spatial_type):
     """Translate a spatial type string to a source type."""
-    
+
     if spatial_type == 'SkyDirFunction':
         return 'PointSource'
     else:
         return 'DiffuseSource'
 
-    
+
 def gtlike_spectrum_to_dict(spectrum):
     """ Convert a pyLikelihood object to a python dictionary which can
         be easily saved to a file."""
@@ -323,7 +323,7 @@ def get_function_pars_dict(fn):
     pars = get_function_pars(fn)
     pars_dict = { p['name'] : p for p in pars } 
     return pars_dict
-    
+
 def get_function_pars(fn):
     """Extract the parameters of a pyLikelihood function object
     (value, scale, bounds).
@@ -337,9 +337,9 @@ def get_function_pars(fn):
     -------
 
     pars : list
-    
+
     """
-    
+
     pars = []
     par_names = pyLike.StringVector()
     fn.getParamNames(par_names)
@@ -356,7 +356,7 @@ def get_function_pars(fn):
                       max = bounds[1],
                       free = par.isFree(),
                       scale = par.getScale())]
-        
+
     return pars
 
 
@@ -370,7 +370,7 @@ def get_params_dict(like):
         params_dict[p['src_name']] += [p]
 
     return params_dict
-        
+
 def get_params(like):
 
     params = []    
@@ -392,7 +392,7 @@ def get_params(like):
 def get_source_pars(src):
 
     fnmap = src.getSrcFuncs()
-    
+
     keys = fnmap.keys()
 
     if 'Position' in keys:    
@@ -407,16 +407,16 @@ def get_source_pars(src):
 
     for i, p in enumerate(ppars):
         ppars[i]['is_norm'] = False
-        
+
     for i, p in enumerate(spars):
 
         if fn.normPar().getName() == p['name']:
             spars[i]['is_norm'] = True
         else:
             spars[i]['is_norm'] = False
-        
+
     return spars, ppars
-    
+
 
 def cast_pars_dict(pars_dict):
 
@@ -425,7 +425,7 @@ def cast_pars_dict(pars_dict):
     for pname, pdict in pars_dict.items():
 
         o[pname] = {}
-        
+
         for k,v in pdict.items():
 
             if k == 'free':
@@ -447,7 +447,7 @@ class SummedLikelihood(SummedLikelihood.SummedLikelihood):
             if par.isFree():
                 nF += 1
         return nF
-    
+
     def optimize(self, verbosity=3, tol=None, optimizer=None, optObject=None):
         self._syncParams()
         if optimizer is None:
@@ -461,12 +461,12 @@ class SummedLikelihood(SummedLikelihood.SummedLikelihood):
             myOpt = optObject
         myOpt.find_min_only(verbosity, tol, self.tolType)
         self.saveBestFit()
-    
+
     def Ts2(self, srcName, reoptimize=False, approx=True,
            tol=None, MaxIterations=10, verbosity=0):
 
         srcName = str(srcName)
-        
+
         if verbosity > 0:
             print("*** Start Ts_dl ***")
         source_attributes = self.components[0].getExtraSourceAttributes()
@@ -524,7 +524,7 @@ class SummedLikelihood(SummedLikelihood.SummedLikelihood):
         return Ts_value
 
     def _renorm(self, factor=None):
-        
+
         if factor is None:
             freeNpred, totalNpred = self._npredValues()
             deficit = self.total_nobs() - totalNpred
@@ -538,7 +538,7 @@ class SummedLikelihood(SummedLikelihood.SummedLikelihood):
 
             if src == self.components[0]._ts_src.getName():
                 continue
-            
+
             parameter = self.normPar(src)
             if (parameter.isFree() and 
                 self.components[0]._isDiffuseOrNearby(src)):
@@ -548,7 +548,7 @@ class SummedLikelihood(SummedLikelihood.SummedLikelihood):
                 xmin, xmax = parameter.getBounds()
                 if xmin <= newValue and newValue <= xmax:
                     parameter.setValue(newValue)
-    
+
 class BinnedAnalysis(BinnedAnalysis.BinnedAnalysis):
 
     def __init__(self, binnedData, srcModel=None, optimizer='Drmngb',
@@ -585,13 +585,13 @@ class BinnedAnalysis(BinnedAnalysis.BinnedAnalysis):
         self.nobs = self.logLike.countsSpectrum()
         self.sourceFitPlots = []
         self.sourceFitResids  = []
-        
+
     def scaleSource(self,srcName,scale):
         src = self.logLike.getSource(srcName)
         old_scale = src.spectrum().normPar().getScale()
         src.spectrum().normPar().setScale(old_scale*scale)
         self.logLike.syncParams()
-        
+
     def Ts2(self, srcName, reoptimize=False, approx=True,
             tol=None, MaxIterations=10, verbosity=0):
 
@@ -601,7 +601,7 @@ class BinnedAnalysis(BinnedAnalysis.BinnedAnalysis):
         (default is the tolerance selected for the overall fit).  If
         "appox=True" is selected (the default) it will renormalize the
         model (see _renorm).'''
-        
+
         saved_state = LikelihoodState(self)
         if verbosity > 0:
             print("*** Start Ts_dl ***")
@@ -641,7 +641,7 @@ class BinnedAnalysis(BinnedAnalysis.BinnedAnalysis):
         logLike0 = max(self.logLike.value(), logLike0)
         Ts_value = 2*(logLike1 - logLike0)
         self.scaleSource(srcName,1E10)
-        
+
         self.logLike.setFreeParamValues(freeParams)
         self.model = SourceModel(self.logLike)
         for src in source_attributes:

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -51,7 +51,7 @@ def coords_to_vec(lon, lat):
 
 def get_pixel_size_from_nside(nside):
     """ Returns an estimate of the pixel size from the HEALPix nside coordinate
-    
+
     This just uses a lookup table to provide a nice round number for each
     HEALPix order. 
     """
@@ -134,7 +134,7 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     for i,ipix in enumerate(ipixs):
         mult_val[i] /= d_count[ipix]
         pass
-    
+
     ipixs = ipixs.reshape(npix).T.flatten()
     mult_val = mult_val.reshape(npix).T.flatten()
     return ipixs,mult_val,npix
@@ -199,7 +199,7 @@ class HPX(object):
             self._evals = np.sqrt(self._ebins[0:-1]*self._ebins[1:])
         else:
             self._evals = None
-            
+
         if self._ipix is not None:
             for i, ipixel in enumerate(self._ipix.flat):
                 self._rmap[ipixel] = i
@@ -215,7 +215,7 @@ class HPX(object):
         indices in the input array, and -1 for those pixels that are outside the 
         selected region.
         """
-        
+
         if self._rmap is not None:
             retval = np.zeros((sliced.size),'i')
             for i, v in enumerate(sliced.flat):
@@ -226,7 +226,7 @@ class HPX(object):
             retval = retval.reshape(sliced.shape)
             return retval
         return sliced
-            
+
     @property
     def ordering(self):
         if self._nest: 
@@ -328,10 +328,10 @@ class HPX(object):
                  pf.Card("LASTPIX",self._maxpix-1)]
         if self._coordsys=="CEL":
             cards.append(pf.Card("EQUINOX", 2000.0,"Equinox of RA & DEC specifications"))
-            
+
         if self._region:
             cards.append(pf.Card("HPX_REG", self._region))
-            
+
         header = pf.Header(cards)
         return header
 
@@ -358,7 +358,7 @@ class HPX(object):
         header = self.make_header()
         hdu = pf.BinTableHDU.from_columns(cols,header=header,name=extname)
         return hdu
-    
+
     def make_energy_bounds_hdu(self,extname="EBOUNDS"):
         """ Builds and returns a FITs HDU with the energy bin boundries
 
@@ -420,7 +420,7 @@ class HPX(object):
             raise Exception("HPX.get_index_list did not recognize region type %s"%tokens[0])
         return ilist
 
-        
+
     @staticmethod
     def get_ref_dir(region,coordsys):
         """ Finds and returns the reference direction for a given 
@@ -500,7 +500,7 @@ class HPX(object):
             w.wcs.crval[1] = skydir.galactic.b.deg
         else:
             raise Exception('Unrecognized coordinate system.')
-    
+
         pixsize = get_pixel_size_from_nside(self.nside)
         roisize = min(self.get_region_size(self._region),90)
 
@@ -511,7 +511,7 @@ class HPX(object):
         w.wcs.crpix[1] = crpix
         w.wcs.cdelt[0] = -pixsize/oversample
         w.wcs.cdelt[1] = pixsize/oversample
-        
+
         if naxis == 3:
             w.wcs.crpix[2] = 1
             w.wcs.ctype[2] = 'Energy'   
@@ -592,9 +592,9 @@ class HpxToWcsMapping(object):
             wcs_data_flat *= self._mult_val
         wcs_data.flat = wcs_data_flat
 
-        
+
 if __name__ == "__main__":
-    
+
 
     from utils import write_fits_image
 
@@ -603,7 +603,7 @@ if __name__ == "__main__":
     hpx.write_fits(n,"test_hpx.fits",clobber=True)
 
     ebins = np.logspace(2,5,8)
-    
+
     hpx_2 = HPX(1024,False,"GAL",region="DISK(110.,75.,2.)",ebins=ebins)
     #hpx_2 = HPX(1024,False,"GAL",region="HPX_PIXEL(RING,16,500)",ebins=ebins)
     npixels = hpx_2.npix
@@ -619,4 +619,4 @@ if __name__ == "__main__":
 
     wcs_out = hpx_2.make_wcs(3)   
     write_fits_image(wcs_data,wcs_out,"test_hpx_2_wcs.fits")
-    
+

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -35,7 +35,7 @@ class PSFModel(object):
 
         if isinstance(event_types,int):
             event_types = bitmask_to_bits(event_types)
-        
+
         self._dtheta = np.logspace(-4,1.75,1000)
         self._dtheta = np.insert(self._dtheta,0,[0])
 #        self._dtheta = np.linspace(0.0,20.0,1001)
@@ -67,7 +67,7 @@ class PSFModel(object):
     @property
     def exp(self):
         return self._exp
-    
+
     @staticmethod
     def create_average_psf(skydir,ltc,event_class,event_types,dtheta,egy,
                            cth_min=0.2):
@@ -110,11 +110,11 @@ def create_psf(event_class,event_type,dtheta,egy,cth):
 
     theta = np.degrees(np.arccos(cth))
     m = np.zeros((len(dtheta),len(egy),len(cth)))
-    
+
     for i, x in enumerate(egy):
         for j, y in enumerate(theta):
             m[:,i,j] = irf.psf().value(dtheta,10**x,y,0.0)
-            
+
     return m
 
 def create_exposure(event_class,event_type,egy,cth):
@@ -124,14 +124,14 @@ def create_exposure(event_class,event_type,egy,cth):
 
     if isinstance(event_type,int):
         event_type = evtype_string[event_type]
-    
+
     irf_factory=pyIrfLoader.IrfsFactory.instance()
     irf = irf_factory.create('%s::%s'%(event_class,event_type))
 
     irf.aeff().setPhiDependence(False)
-    
+
     theta = np.degrees(np.arccos(cth))
-    
+
     # Exposure Matrix
     # Dimensions are Etrue and incidence angle
     m = np.zeros((len(egy),len(cth)))
@@ -169,12 +169,12 @@ class LTCube(object):
             ltc.load_ltfile(f)
 
         return ltc
-        
+
 
     def load_ltfile(self,ltfile):
-        
+
         hdulist = pyfits.open(ltfile)
-                
+
         if self._ltmap is None:
             self._ltmap = hdulist[1].data.field(0)
             self._tstart = hdulist[0].header['TSTART']
@@ -192,19 +192,19 @@ class LTCube(object):
 
 #        self._domega = (self._cth_axis.edges[1:]-
 #                        self._cth_axis.edges[:-1])*2*np.pi
-            
+
     def get_src_lthist(self,skydir,cth_edges):
 
         ra = skydir.ra.deg
         dec = skydir.dec.deg        
-        
+
         edges = np.linspace(cth_edges[0],cth_edges[-1],(len(cth_edges)-1)*4+1)
         center = edge_to_center(edges)
         width = edge_to_width(edges)
-        
+
         ipix = hp.ang2pix(64,np.pi/2. - np.radians(dec),
                           np.radians(ra),nest=True)
-        
+
         lt = np.interp(center,self._cth_center,
                        self._ltmap[ipix,::-1]/self._cth_width)*width
         lt = np.sum(lt.reshape(-1,4),axis=1)  

--- a/fermipy/logger.py
+++ b/fermipy/logger.py
@@ -28,7 +28,7 @@ def log_level(level):
 class Logger(object):
     """This class provides helper functions which facilitate creating
     instances of the built-in logger class."""
-    
+
     @staticmethod
     def setup(config=None,logfile=None):
         """This method sets up the default configuration of the
@@ -46,7 +46,7 @@ class Logger(object):
             for name, h in config['handlers'].items():
                 if 'file_handler' in name:
                     config['handlers'][name]['filename'] = logfile
-            
+
         logging.config.dictConfig(config)
 
         # get the root logger
@@ -54,17 +54,17 @@ class Logger(object):
 #        for h in logger.handlers:
 #            if 'file_handler' in h.name:
 #                print h.name
-        
+
     @staticmethod
     def get(name, logfile, loglevel=logging.DEBUG):
 
 #        logging.config.dictConfig({
 #                'version': 1,              
 #                'disable_existing_loggers': False})
-        
+
         if logfile is not None:
             logfile = logfile.replace('.log','') + '.log'
-        
+
         logger = logging.getLogger(name)
 
         # Don't propagate to root logger
@@ -75,7 +75,7 @@ class Logger(object):
         format_stream = '%(asctime)s %(levelname)-8s %(name)s.%(funcName)s(): %(message)s'
         format_file = '%(asctime)s %(levelname)-8s %(name)s.%(funcName)s(): %(message)s' 
 #        format_file = '%(asctime)s %(levelname)-8s %(name)s.%(funcName)s() [%(filename)s:%(lineno)d]: %(message)s' 
-        
+
         if not logger.handlers:
 
             formatter = logging.Formatter(format,datefmt)
@@ -86,7 +86,7 @@ class Logger(object):
                 fh.setLevel(logging.DEBUG)
                 fh.setFormatter(logging.Formatter(format_file,datefmt))
                 logger.addHandler(fh)
-            
+
             # Add a stream handler
             ch = logging.StreamHandler()
             ch.setLevel(loglevel)
@@ -94,7 +94,7 @@ class Logger(object):
             logger.addHandler(ch)
         else:
             logger.handlers[-1].setLevel(loglevel)
-            
+
         return logger
 
 class StreamLogger(object):
@@ -132,7 +132,7 @@ class StreamLogger(object):
         self.flush()
         sys.stdout = self.stdout
         self.logger.handlers = []
-        
+
     def write(self, msg, level=logging.DEBUG):
         msg = msg.rstrip('\n')
         if len(msg) > 0:

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -157,7 +157,7 @@ def annotate(**kwargs):
     text = []
 
     if src:
-        
+
         if 'ASSOC1' in src['assoc'] and src['assoc']['ASSOC1']:
             text += ['%s (%s)' % (src['name'], src['assoc']['ASSOC1'])]
         else:
@@ -195,7 +195,7 @@ class ImagePlotter(object):
             self._wcs,data = make_wcs_from_hpx(proj,data)
         else:
             raise Exception("Can't co-add map of unknown type %s"%type(proj))
-                
+
         self._data = data
 
 
@@ -228,7 +228,7 @@ class ImagePlotter(object):
             kwargs_imshow['norm'] = Normalize()
 
         fig = plt.gcf()
-        
+
         ax = fig.add_subplot(subplot,projection=self._wcs)
 
         load_ds9_cmap()
@@ -246,7 +246,7 @@ class ImagePlotter(object):
             cs = ax.contour(data.T, **kwargs_contour)
             cs.levels = ['%.0f'%val for val in cs.levels]
             plt.clabel(cs,inline=1,fontsize=8)
-            
+
         coordsys = wcs_utils.get_coordsys(self._proj)
 
         if coordsys == 'CEL':
@@ -292,7 +292,7 @@ class ROIPlotter(fermipy.config.Configurable):
                 self._catalogs += [catalog.Catalog.create(c)]
             else:
                 self._catalogs += [c]
-                
+
         if isinstance(data_map,Map):
             self._projtype = 'WCS'
             self._data = data_map.counts.T
@@ -307,7 +307,7 @@ class ROIPlotter(fermipy.config.Configurable):
             self._data = dataT.T
         else:
             raise Exception("Can't make ROIPlotter of unknown projection type %s"%type(data_map))
-    
+
         self._loge_bounds = self.config['loge_bounds']
 
         if self._loge_bounds:
@@ -317,7 +317,7 @@ class ROIPlotter(fermipy.config.Configurable):
             imdata = self._data[:, :, i0:i1]
         else:
             imdata = self._data
-        
+
         self._implot = ImagePlotter(imdata, self._wcs)
 
     @property
@@ -358,7 +358,7 @@ class ROIPlotter(fermipy.config.Configurable):
             themap = HpxMap.create_from_hdulist(hdulist,ebounds="EBOUNDS")            
         else:
             raise Exception("Unknown projection type %s"%projtype)        
-        
+
         return ROIPlotter(themap, roi=roi, **kwargs)
 
     def plot_projection(self, iaxis, **kwargs):
@@ -400,7 +400,7 @@ class ROIPlotter(fermipy.config.Configurable):
             j0 = utils.val_to_edge(axes[2], loge_bounds[0])
             j1 = utils.val_to_edge(axes[2], loge_bounds[1])
             s2 = slice(j0, j1)
-            
+
         c = np.apply_over_axes(np.sum, data[s0, s1, s2], axes=saxes)
         c = np.squeeze(c)
         return c
@@ -425,9 +425,9 @@ class ROIPlotter(fermipy.config.Configurable):
                                 np.ones(len(labels),dtype=bool))
         if nolabels:
             label_mask.fill(False)
-        
+
         pixcrd = wcs_utils.skydir_to_pix(skydir, self._implot._wcs)
-        
+
         for i, (x,y,label,show_label) in enumerate(zip(pixcrd[0],pixcrd[1],labels,label_mask)):
 
             if show_label:
@@ -435,14 +435,14 @@ class ROIPlotter(fermipy.config.Configurable):
                                 xytext=(5.0, 5.0), textcoords='offset points',
                                 **text_kwargs)            
                 plt.setp(t, path_effects=[PathEffects.withStroke(linewidth=2.0, foreground="black")])
-            
+
             t = ax.plot(x, y, **plot_kwargs)
             plt.setp(t, path_effects=[PathEffects.withStroke(linewidth=2.0, foreground="black")])
-        
+
     def plot_roi(self, roi, **kwargs):
 
         src_color = 'w'
-        
+
         label_ts_threshold = kwargs.get('label_ts_threshold',0.0)
         plot_kwargs = dict(linestyle='None', marker='+',
                            markerfacecolor='None',mew=0.66,ms=8,
@@ -460,7 +460,7 @@ class ROIPlotter(fermipy.config.Configurable):
             m = np.ones(len(ts),dtype=bool)            
         else:
             m = ts > label_ts_threshold
-            
+
         skydir = roi._src_skydir
         labels = [s.name for s in roi.point_sources]        
         self.plot_sources(skydir,labels,plot_kwargs,text_kwargs,
@@ -469,37 +469,37 @@ class ROIPlotter(fermipy.config.Configurable):
     def plot_catalog(self, catalog):
 
         color = 'lime'
-        
+
         plot_kwargs = dict(linestyle='None', marker='x',
                            markerfacecolor='None',
                            markeredgecolor=color, clip_on=True)
 
         text_kwargs = dict(color=color, size=8, clip_on=True,
                            fontweight='normal')
-                
+
         skydir = catalog.skydir
 
         if 'NickName' in catalog.table.columns:
             labels = catalog.table['NickName']
         else:
             labels = catalog.table['Source_Name']
-            
+
         separation = skydir.separation(self.cmap.skydir).deg
         m = separation < max(self.cmap.width)
 
         self.plot_sources(skydir[m],labels[m],plot_kwargs,text_kwargs,
                           nolabels=True)
 
-            
+
     def plot(self, **kwargs):
-        
+
         zoom = kwargs.get('zoom',None)
         graticule_radii = kwargs.get('graticule_radii',
                                      self.config['graticule_radii'])
         label_ts_threshold = kwargs.get('label_ts_threshold',
                                        self.config['label_ts_threshold'])
         cmap = kwargs.setdefault('cmap',self.config['cmap'])
-        
+
         im_kwargs = dict(cmap='ds9_b',
                          interpolation='nearest',
                          vmin=None, vmax=None, levels=None,
@@ -510,24 +510,24 @@ class ROIPlotter(fermipy.config.Configurable):
 
         im_kwargs = merge_dict(im_kwargs, kwargs)
         cb_kwargs = merge_dict(cb_kwargs, kwargs)
-        
+
         im, ax = self._implot.plot(**im_kwargs)
 
         self._ax = ax
-        
+
         for c in self._catalogs:
             self.plot_catalog(c)
-        
+
         if self._roi is not None:
             self.plot_roi(self._roi,
                           label_ts_threshold=label_ts_threshold)        
-            
+
         self._extent = im.get_extent()
         ax.set_xlim(self._extent[0], self._extent[1])
         ax.set_ylim(self._extent[2], self._extent[3])
-        
+
         self.zoom(zoom)
-            
+
         cb_label = cb_kwargs.pop('cb_label', None)
         cb = plt.colorbar(im, **cb_kwargs)
         if cb_label:
@@ -535,7 +535,7 @@ class ROIPlotter(fermipy.config.Configurable):
 
         for r in graticule_radii:            
             self.draw_circle(self.cmap.skydir,r)
-        
+
 
     def draw_circle(self,skydir,radius):
 
@@ -548,10 +548,10 @@ class ROIPlotter(fermipy.config.Configurable):
         #    c = Circle((skydir.fk5.l.deg,skydir.fk5.b.deg),
         #               radius,facecolor='none',edgecolor='w',linestyle='--',
         #               transform=self._ax.get_transform('fk5'))
-        
+
         c = Circle(self.cmap.pix_center,radius/max(self.cmap.pix_size),
                    facecolor='none',edgecolor='w',linestyle='--',linewidth=0.5)
-        
+
         self._ax.add_patch(c)
 
     def zoom(self,zoom):
@@ -560,15 +560,15 @@ class ROIPlotter(fermipy.config.Configurable):
             return
 
         extent = self._extent
-        
+
         xw = extent[1]-extent[0]
         x0 = 0.5*(extent[0]+extent[1])
         yw = extent[1]-extent[0]
         y0 = 0.5*(extent[0]+extent[1])
-                                
+
         xlim = [x0 - 0.5*xw/zoom,x0 + 0.5*xw/zoom]
         ylim = [y0 - 0.5*yw/zoom,y0 + 0.5*yw/zoom]
-        
+
         self._ax.set_xlim(xlim[0],xlim[1])
         self._ax.set_ylim(ylim[0],ylim[1])
 
@@ -589,7 +589,7 @@ class SEDPlotter(object):
             fmax += 0.5*(2.0-fdelta)
 
         return fmin, fmax
-        
+
     @staticmethod
     def plot_lnlscan(sed, **kwargs):
 
@@ -600,11 +600,11 @@ class SEDPlotter(object):
         lhProf = sed['lnlprofile']
 
         fmin,fmax = SEDPlotter.get_ylims(sed)
-                
+
         fluxM = np.arange(fmin, fmax, 0.01)
         fbins = len(fluxM)
         llhMatrix = np.zeros((len(sed['ectr']), fbins))        
-        
+
         # loop over energy bins
         for i in range(len(lhProf)):
             m = lhProf[i]['dfde'] > 0
@@ -640,7 +640,7 @@ class SEDPlotter(object):
         color = kwargs.get('color', 'k')
 
         fmin,fmax = SEDPlotter.get_ylims(sed)
-        
+
         m = sed['ts'] < ts_thresh
 
         x = sed['ectr']
@@ -667,7 +667,7 @@ class SEDPlotter(object):
         plt.gca().set_xscale('log')
         plt.gca().set_xlim(sed['emin'][0], sed['emax'][-1])
         plt.gca().set_ylim(10**fmin,10**fmax)
-        
+
 
     @staticmethod
     def plot_sed_resid(src, model_flux, **kwargs):
@@ -748,7 +748,7 @@ class SEDPlotter(object):
         SEDPlotter.plot_sed(sed)
 
         if np.any(sed['ts'] > 9.):
-        
+
             if 'model_flux' in sed:
                 SEDPlotter.plot_model(sed['model_flux'], noband=showlnl)        
             elif 'model_flux' in src:
@@ -821,14 +821,14 @@ class AnalysisPlotter(fermipy.config.Configurable):
         self._catalogs = []
         for c in self.config['catalogs']:
             self._catalogs += [catalog.Catalog.create(c)]
-        
+
         self.logger = Logger.get(self.__class__.__name__,
                                  self.config['fileio']['logfile'],
                                  log_level(self.config['logging']['verbosity']))
 
     def run(self, gta, mcube_map, **kwargs):
         """Make all plots."""
-        
+
         prefix = kwargs.get('prefix', 'test')
         format = kwargs.get('format', gta.config['plotting']['format'])
 
@@ -866,7 +866,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
                           self.config['label_ts_threshold'])
         kwargs.setdefault('cmap',self.config['cmap'])
         kwargs.setdefault('catalogs',self._catalogs)
-                 
+
         load_bluered_cmap()
 
         prefix = maps['name']
@@ -912,7 +912,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
         format = kwargs.get('format', gta.config['plotting']['format'])
         suffix = kwargs.get('suffix', 'tsmap')
         zoom = kwargs.get('zoom',None)
-        
+
         if 'ts' not in maps: 
             return
 
@@ -923,7 +923,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
                           self.config['label_ts_threshold'])
         kwargs.setdefault('cmap',self.config['cmap'])
         kwargs.setdefault('catalogs',self.config['catalogs'])
-        
+
         prefix = maps['name']
         fig = plt.figure()
         p = ROIPlotter(maps['sqrt_ts'], roi=gta.roi, **kwargs)
@@ -967,7 +967,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
                               self.config['label_ts_threshold'])
         roi_kwargs.setdefault('cmap',self.config['cmap'])
         roi_kwargs.setdefault('catalogs',self._catalogs)
-        
+
         if loge_bounds is None:
             loge_bounds = (gta.log_energies[0], gta.log_energies[-1])
         esuffix = '_%.3f_%.3f' % (loge_bounds[0], loge_bounds[1])
@@ -988,7 +988,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         fig = plt.figure()
         p = ROIPlotter(gta.counts_map(), roi=gta.roi, **roi_kwargs)
-        
+
         if p.projtype == "WCS":
             model_data = mcube_map.counts.T
             diffuse_data = mcube_diffuse.counts.T
@@ -1007,7 +1007,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
         fig = plt.figure()
         p.plot_projection(0, label='Data', color='k', **data_style)
 
-        
+
         p.plot_projection(0, data=model_data, label='Model',
                           noerror=True)
         p.plot_projection(0, data=diffuse_data, label='Diffuse',
@@ -1053,9 +1053,9 @@ class AnalysisPlotter(fermipy.config.Configurable):
         roi_kwargs.setdefault('cmap',self.config['cmap'])
         roi_kwargs.setdefault('catalogs',self.config['catalogs'])
 
-        
+
         for i, c in enumerate(gta.components):
-                
+
             fig = plt.figure()
             p = ROIPlotter(mcube_maps[i + 1], roi=gta.roi, **roi_kwargs)
 
@@ -1079,7 +1079,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
             plt.figure(figy.number)
             p.plot_projection(1, color=colors[i % 4], label='Component %i' % i,
                               **data_style)
-           
+
             p.plot_projection(1, data=mcube_data,
                               color=colors[i % 4], noerror=True,
                               label='__nolegend__')
@@ -1099,8 +1099,8 @@ class AnalysisPlotter(fermipy.config.Configurable):
                                       prefix, esuffix, format)))
         plt.close(figx)
         plt.close(figy)
-        
-        
+
+
     def make_extension_plots(self, prefix, loge_bounds=None, **kwargs):
 
         format = kwargs.get('format', self.config['plotting']['format'])
@@ -1175,15 +1175,15 @@ class AnalysisPlotter(fermipy.config.Configurable):
         plt.close(fig)
 
     def make_localization_plot(self,gta,name,tsmap,**kwargs):
-        
+
         tsmap_renorm = copy.deepcopy(tsmap['ts'])
         tsmap_renorm._counts -= np.max(tsmap_renorm._counts)
-                
+
         prefix = kwargs.get('prefix','')
         skydir = kwargs.get('skydir',None)
         src = gta.roi[name]
         o = src['localize']
-        
+
         name = src.name.lower().replace(' ', '_')
         format = kwargs.get('format', gta.config['plotting']['format'])
 
@@ -1198,13 +1198,13 @@ class AnalysisPlotter(fermipy.config.Configurable):
         cdelt1 = np.abs(tsmap['ts'].wcs.wcs.cdelt[1])
 
         tsmap_fit = o['tsmap_fit']
-        
+
         peak_skydir = SkyCoord(tsmap_fit['glon'],tsmap_fit['glat'],
                                frame='galactic',unit='deg')
         peak_pix = peak_skydir.to_pixel(tsmap_renorm.wcs)
         peak_r68 = tsmap_fit['r68']
         peak_r99 = tsmap_fit['r99']
-        
+
         scan_skydir = SkyCoord(o['glon'],o['glat'],frame='galactic',unit='deg')
         scan_pix = scan_skydir.to_pixel(tsmap_renorm.wcs)
 
@@ -1212,14 +1212,14 @@ class AnalysisPlotter(fermipy.config.Configurable):
             pix = skydir.to_pixel(tsmap_renorm.wcs)
             plt.gca().plot(pix[0],pix[1],linestyle='None',
                            marker='+',color='r')
-        
+
         if np.isfinite(float(peak_pix[0])):
 
             sigma = tsmap_fit['sigma']
             sigmax = tsmap_fit['sigma_semimajor']
             sigmay = tsmap_fit['sigma_semiminor']
             theta = tsmap_fit['theta']
-            
+
             e0 = Ellipse(xy=(float(peak_pix[0]),float(peak_pix[1])),
                          width=2.0*sigmax/cdelt0*peak_r68/sigma,
                          height=2.0*sigmay/cdelt1*peak_r68/sigma,
@@ -1241,7 +1241,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
             sigmax = o['sigma_semimajor']
             sigmay = o['sigma_semiminor']
-            
+
             e0 = Ellipse(xy=(float(scan_pix[0]),float(scan_pix[1])),
                          width=2.0*sigmax/cdelt0*o['r68']/o['sigma'],
                          height=2.0*sigmay/cdelt1*o['r68']/o['sigma'],
@@ -1256,10 +1256,10 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
             plt.gca().add_artist(e0)
             plt.gca().add_artist(e1)
-            
+
             plt.gca().plot(float(scan_pix[0]),float(scan_pix[1]),
                            marker='x',color='r')
-        
+
 #        if gta.config['binning']['coordsys'] == 'GAL':        
 #            plt.gca().scatter(o['peak_glon'], o['peak_glat'],
 #                              transform=plt.gca().get_transform('galactic'),color='k')
@@ -1270,14 +1270,14 @@ class AnalysisPlotter(fermipy.config.Configurable):
 #                              transform=plt.gca().get_transform('fk5'),color='k')
 #            plt.gca().scatter(o['ra'], o['dec'],
 #                              transform=plt.gca().get_transform('fk5'),color='r')
-       
+
         outfile = utils.format_filename(gta.config['fileio']['workdir'],
                                         'localize', prefix=[prefix, name],
                                         extension=format)
 
         plt.savefig(outfile)
         plt.close(fig)
-        
+
     def _plot_extension(self, gta, prefix, src, loge_bounds=None, **kwargs):
         """Utility function for generating diagnostic plots for the
         extension analysis."""
@@ -1341,5 +1341,5 @@ class AnalysisPlotter(fermipy.config.Configurable):
                                      '%s_%s_extension_yproj%s%s.png' % (
                                          prefix, name, esuffix, suffix)))
             plt.close(fig)
-            
-            
+
+

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -38,11 +38,11 @@ def convolve_map(m, k, cpix, threshold=0.001,imin=0,imax=None):
 
     Parameters
     ----------
-    
+
     m : `~numpy.ndarray`
        3-D map containing a sequence of 2-D spatial maps.  First
        dimension should be energy.
-    
+
     k : `~numpy.ndarray`
        3-D map containing a sequence of convolution kernels (PSF) for
        each slice in m.  This map should have the same dimension as m.
@@ -181,7 +181,7 @@ class ResidMapGenerator(object):
         config['model'].setdefault('SpectrumType', 'PowerLaw')
         config['model'].setdefault('SpatialModel', 'PointSource')
         config['model'].setdefault('Prefactor', 1E-13)
-        
+
         make_plots = kwargs.get('make_plots', True)
         maps = self._make_residual_map(prefix,config,**kwargs)
 
@@ -189,22 +189,22 @@ class ResidMapGenerator(object):
             plotter = plotting.AnalysisPlotter(self.config['plotting'],
                                                fileio=self.config['fileio'],
                                                logging=self.config['logging'])
-            
+
             plotter.make_residual_plots(self, maps)
-            
+
         self.logger.info('Finished residual maps')
-                
+
         return maps
-        
+
     def _make_residual_map(self, prefix, config, **kwargs):
 
         write_fits = kwargs.get('write_fits', True)
         write_npy = kwargs.get('write_npy', True)
-        
+
         src_dict = copy.deepcopy(config.setdefault('model',{}))        
         exclude = config.setdefault('exclude', None)
         loge_bounds = config.setdefault('loge_bounds', None)
-        
+
         if loge_bounds is not None:            
             if len(loge_bounds) == 0:
                 loge_bounds = [None,None]
@@ -322,7 +322,7 @@ class ResidMapGenerator(object):
         fits_file = utils.format_filename(self.config['fileio']['workdir'],
                                           'residmap.fits',
                                           prefix=[prefix,modelname])
-        
+
         if write_fits:            
             fits_utils.write_maps(sigma_map,
                                   {'DATA_MAP': data_map,
@@ -333,5 +333,5 @@ class ResidMapGenerator(object):
 
         if write_npy:
             np.save(os.path.splitext(fits_file)[0] + '.npy', o)
-            
+
         return o

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -32,7 +32,7 @@ def create_source_table(scan_shape):
     -------
     tab : `~astropy.table.Table`
     """
-    
+
     cols_dict = collections.OrderedDict()
     cols_dict['Source_Name'] = dict(dtype='S48', format='%s')
     cols_dict['name'] = dict(dtype='S48', format='%s')
@@ -139,7 +139,7 @@ def get_skydir_distance_mask(src_skydir, skydir, dist, min_dist=None,
 
     Parameters
     ----------
-    
+
     src_skydir : `~astropy.coordinates.SkyCoord` 
       Array of sky directions.
 
@@ -154,7 +154,7 @@ def get_skydir_distance_mask(src_skydir, skydir, dist, min_dist=None,
 
     coordsys : str
       Coordinate system to use when applying a selection with square=True.
-    
+
     """
 
     if dist is None: dist = 180.
@@ -228,7 +228,7 @@ class Model(object):
         self._data.setdefault('catalog', {})
         self._data['assoc'] = {}
         self._data['name'] = name
-        
+
         if data is not None:
             self._data.update(data)
 
@@ -237,7 +237,7 @@ class Model(object):
             self._data['spectral_pars'] = pdict
             for k, v in self.spectral_pars.items():
                 self._data['spectral_pars'][k] = gtutils.make_parameter_dict(v)
-            
+
         self._names = [name]
         catalog = self._data['catalog']
 
@@ -255,7 +255,7 @@ class Model(object):
             self._sync_spectral_pars()
         else:
             self._sync_params()
-            
+
     def __contains__(self, key):
         return key in self._data
 
@@ -321,7 +321,7 @@ class Model(object):
 
     @staticmethod
     def create_from_dict(src_dict, roi_skydir=None):
-        
+
         src_dict.setdefault('SpatialModel','PointSource')
         src_dict.setdefault('SpatialType',
                             gtutils.get_spatial_type(src_dict['SpatialModel']))
@@ -336,13 +336,13 @@ class Model(object):
 
             if 'mapcube' in src_dict:
                 src_dict['Spatial_Filename'] = src_dict.pop('mapcube')
-                
+
         if 'spectral_pars' in src_dict:
             src_dict['spectral_pars'] = gtutils.cast_pars_dict(src_dict['spectral_pars'])
 
         if 'spatial_pars' in src_dict:
             src_dict['spatial_pars'] = gtutils.cast_pars_dict(src_dict['spatial_pars'])
-        
+
         if src_dict['SpatialModel'] == 'ConstantValue':
             return IsoSource(src_dict['name'],src_dict)
         elif src_dict['SpatialModel'] == 'MapCubeFunction':
@@ -352,7 +352,7 @@ class Model(object):
 
     def _sync_spectral_pars(self):
         """Update spectral parameters dictionary."""
-        
+
         sp = self['spectral_pars']
         for k, p in sp.items():
             sp[k]['value'] = self['params'][k][0]/sp[k]['scale']
@@ -378,7 +378,7 @@ class Model(object):
              'beta' : np.nan,
              'Exp_Index' : np.nan,
              'Cutoff' : np.nan}
-        
+
         if self['SpectrumType'] == 'PowerLaw':
             o['Spectral_Index'] = -1.0*self.params['Index'][0]
             o['Flux_Density'] = self.params['Prefactor'][0]
@@ -394,9 +394,9 @@ class Model(object):
             o['Flux_Density'] = self.params['Prefactor'][0]
             o['Pivot_Energy'] = self.params['Scale'][0]
             o['Cutoff'] = self.params['Cutoff'][0]
-            
+
         return o
-    
+
     def check_cuts(self, cuts):
 
         if cuts is None:
@@ -432,7 +432,7 @@ class Model(object):
 
         self._data['spectral_pars'] = utils.merge_dict(self.spectral_pars,spectral_pars)
         self._sync_params()
-        
+
     def set_name(self, name, names=None):
         self._data['name'] = name
         if names is None:
@@ -443,7 +443,7 @@ class Model(object):
     def add_name(self, name):
         if name not in self._names:
             self._names.append(name)
-            
+
     def update_data(self, d):
         self._data = utils.merge_dict(self._data, d, add_new_keys=True)
         #if self.params:
@@ -473,11 +473,11 @@ class IsoSource(Model):
                                   'value': 1.0,
                                   'min': 0.001, 'max': 1000.0,
                                   'free': False }}
-        
+
         super(IsoSource, self).__init__(name, data)
 
         self._init_spatial_pars()
-        
+
     @property
     def filefunction(self):
         return self._data['Spectrum_Filename']
@@ -492,7 +492,7 @@ class IsoSource(Model):
             'Value': {'name': 'Value', 'scale': '1',
                       'value': '1', 'min': '0', 'max': '10',
                       'free': '0'}}
-    
+
     def write_xml(self, root):
 
         source_element = utils.create_xml_element(root, 'source',
@@ -536,7 +536,7 @@ class MapCubeSource(Model):
                           'min': 1000.0, 'max': 1000.0,
                           'free': False},
             }
-        
+
         super(MapCubeSource, self).__init__(name, data)
 
         self._init_spatial_pars()
@@ -556,7 +556,7 @@ class MapCubeSource(Model):
                 {'name': 'Normalization', 'scale': '1',
                  'value': '1', 'min': '0', 'max': '10',
                  'free': '0'}}
-    
+
     def write_xml(self, root):
 
         source_element = utils.create_xml_element(root, 'source',
@@ -598,7 +598,7 @@ class Source(Model):
         data.setdefault('SpectrumType','PowerLaw')
         data.setdefault('SpatialType',gtutils.get_spatial_type(data['SpatialModel']))
         data.setdefault('SourceType',gtutils.get_source_type(data['SpatialType']))
-        
+
         super(Source, self).__init__(name, data)
 
         catalog = self.data.get('catalog', {})
@@ -613,7 +613,7 @@ class Source(Model):
             raise Exception('Failed to infer RADEC for source: %s' % name)
 
         self._init_spatial_pars()
-        
+
     def __str__(self):
 
         data = copy.deepcopy(self.data)
@@ -628,7 +628,7 @@ class Source(Model):
             data['eflux'], data['eflux_err'] = data['eflux'][0], data['eflux'][1]
         except:           
             data['eflux'], data['eflux_err'] = 0., 0.
-        
+
         output = []
         output += ['{:15s}:'.format('Name') + ' {name:s}']
         output += ['{:15s}:'.format('Associations') + ' {names:s}']
@@ -664,7 +664,7 @@ class Source(Model):
 
     def _set_spatial_width(self):
 
-         if self['SpatialModel'] in ['GaussianSource','RadialGaussian']:
+        if self['SpatialModel'] in ['GaussianSource','RadialGaussian']:
 
             if self['SpatialWidth'] is None:
                 self.data.setdefault('Sigma',0.5)                
@@ -672,14 +672,14 @@ class Source(Model):
             else:
                 self.data.setdefault('Sigma',self['SpatialWidth']/1.5095921854516636)   
 
-         elif self['SpatialModel'] in ['DiskSource','RadialDisk']:
+        elif self['SpatialModel'] in ['DiskSource','RadialDisk']:
 
             if self['SpatialWidth'] is None:
                 self.data.setdefault('Radius',0.5)                
                 self['SpatialWidth'] = self['Radius']*0.8246211251235321
             else:
                 self.data.setdefault('Radius',self['SpatialWidth']/0.8246211251235321)   
-            
+
     def _init_spatial_pars(self):
 
         if self['SpatialType'] == 'SkyDirFunction':
@@ -688,9 +688,9 @@ class Source(Model):
         else:
             self._extended = True
             self._data['SourceType'] = 'DiffuseSource'
-        
+
         self._set_spatial_width()
-        
+
         if self['SpatialType'] == 'SpatialMap':
             self._data['spatial_pars'] = {
                 'Prefactor': {'name': 'Prefactor', 'value': 1.0,
@@ -706,7 +706,7 @@ class Source(Model):
                                          {'name': 'DEC', 'value': self['dec'],
                                           'free': False,
                                           'min': -90.0, 'max': 90.0, 'scale': 1.0})
-            
+
         if self['SpatialType'] == 'RadialGaussian':
             self.spatial_pars.setdefault('Sigma',
                                          {'name': 'Sigma', 'value': self['Sigma'],
@@ -717,11 +717,11 @@ class Source(Model):
                                          {'name': 'Radius', 'value': self['Radius'],
                                           'free': False, 'min': 0.001, 'max': 10,
                                           'scale': 1.0})
-       
+
 
     def load_from_catalog(self):
         """Load spectral parameters from catalog values."""
-        
+
         self._data['spectral_pars'] = \
             gtutils.get_function_defaults(self['SpectrumType'])
         sp = self['spectral_pars']
@@ -738,7 +738,7 @@ class Source(Model):
             sp['Index']['max'] = max(5.0, sp['Index']['value'] + 1.0)
             sp['Index']['min'] = min(0.0, sp['Index']['value'] - 1.0)
             sp['Index']['scale'] = -1.0
-            
+
             sp['Prefactor'] = gtutils.make_parameter_dict(sp['Prefactor'])
             sp['Scale'] = gtutils.make_parameter_dict(sp['Scale'], True)
             sp['Index'] = gtutils.make_parameter_dict(sp['Index'])
@@ -787,11 +787,11 @@ class Source(Model):
             self._set_radec([d['ra'],d['dec']])
         #if self.params:
         #    self._sync_spectral_pars()
-                          
+
     def set_position(self, skydir):
         """
         Set the position of the source.
-        
+
         Parameters
         ----------
         skydir : `~astropy.coordinates.SkyCoord` 
@@ -806,7 +806,7 @@ class Source(Model):
 
         radec = np.array([skydir.icrs.ra.deg, skydir.icrs.dec.deg])
         self._set_radec(radec)
-                
+
     def set_roi_direction(self,roidir):
 
         offset = roidir.separation(self.skydir).deg
@@ -823,9 +823,9 @@ class Source(Model):
 
         if proj is None:
             return
-        
+
         self['offset_roi_edge'] = proj.distance_to_edge(self.skydir)
-        
+
     def set_spatial_model(self, spatial_model, spatial_width=None):
 
         self._data['SpatialModel'] = spatial_model
@@ -889,7 +889,7 @@ class Source(Model):
         spatial_type = \
             src_dict.setdefault('SpatialType',
                                 gtutils.get_spatial_type(src_dict['SpatialModel']))
-        
+
         spectral_pars = \
             src_dict.setdefault('spectral_pars',
                                 gtutils.get_function_defaults(spectrum_type))
@@ -904,11 +904,11 @@ class Source(Model):
         if spectrum_type == 'DMFitFunction' and src_dict['Spectrum_Filename'] is None:
             src_dict['Spectrum_Filename'] = os.path.join('$FERMIPY_DATA_DIR',
                                                          'gammamc_dif.dat')
-            
+
         for k in ['RA','DEC','Prefactor']:
             if k in spatial_pars:
                 del spatial_pars[k]
-            
+
         for k, v in spectral_pars.items():
 
             if k not in src_dict: 
@@ -930,19 +930,19 @@ class Source(Model):
                 spatial_pars[k].update({'name': k, 'value': src_dict[k]})
             else:
                 spatial_pars[k].update(src_dict.pop(k))
-                
-                
+
+
         for k, v in spectral_pars.items():
             spectral_pars[k] = gtutils.make_parameter_dict(spectral_pars[k])
 
         for k, v in spatial_pars.items():
             spatial_pars[k] = gtutils.make_parameter_dict(spatial_pars[k],
                                                           rescale=False)
-            
+
         src_dict['spectral_pars'] = gtutils.cast_pars_dict(spectral_pars)
         src_dict['spatial_pars'] = gtutils.cast_pars_dict(spatial_pars)
         #        validate_config(src_dict,default_src_dict)
-            
+
         if 'name' in src_dict:
             name = src_dict['name']
             src_dict['Source_Name'] = src_dict.pop('name')
@@ -952,12 +952,12 @@ class Source(Model):
             raise Exception('Source name undefined.')
 
         skydir = wcs_utils.get_target_skydir(src_dict, roi_skydir)
-        
+
         src_dict['RAJ2000'] = skydir.ra.deg
         src_dict['DEJ2000'] = skydir.dec.deg
 
         radec = np.array([skydir.ra.deg, skydir.dec.deg])
-        
+
         return Source(name, src_dict, radec=radec)
 
     @staticmethod
@@ -971,7 +971,7 @@ class Source(Model):
 
         spectral_pars = gtutils.cast_pars_dict(spectral_pars)
         spatial_pars = gtutils.cast_pars_dict(spatial_pars)
-        
+
         src_type = root.attrib['type']
         spatial_type = spat['type']
         spectral_type = spec['type']
@@ -992,17 +992,17 @@ class Source(Model):
                 src_dict['Spatial_Filename'] = \
                     os.path.join(extdir, 'Templates',
                                  src_dict['Spatial_Filename'])
-                    
+
         if 'file' in spec:
             src_dict['Spectrum_Filename'] = utils.xmlpath_to_path(spec['file'])
-                    
+
         if src_type == 'PointSource':
             src_dict['SpatialModel'] = 'PointSource'
         elif spatial_type == 'SpatialMap':
             src_dict['SpatialModel'] = 'SpatialMap'
         else:
             src_dict['SpatialModel'] = spatial_type
-                        
+
         if src_type == 'PointSource' or \
                 spatial_type in ['SpatialMap','RadialGaussian','RadialDisk']:
 
@@ -1069,7 +1069,7 @@ class Source(Model):
             spat_el = utils.create_xml_element(source_element, 'spatialModel',
                                                dict(type=self['SpatialType']))
 
-            
+
         for k, v in self.spatial_pars.items():
             utils.create_xml_element(spat_el, 'parameter', v)
 
@@ -1134,7 +1134,7 @@ class ROIModel(fermipy.config.Configurable):
         self._skydir = kwargs.pop('skydir', SkyCoord(0.0, 0.0, unit=u.deg))        
         self._projection = kwargs.get('projection',None)
         coordsys = kwargs.pop('coordsys', 'CEL')
-        
+
         super(ROIModel, self).__init__(config, **kwargs)
 
         self.logger = Logger.get(self.__class__.__name__,
@@ -1161,7 +1161,7 @@ class ROIModel(fermipy.config.Configurable):
     def __contains__(self, key):
         key = key.replace(' ', '').lower()        
         return key in self._src_dict.keys()
-        
+
     def __getitem__(self, key):
         return self.get_source_by_name(key)
 
@@ -1203,7 +1203,7 @@ class ROIModel(fermipy.config.Configurable):
     @property
     def projection(self):
         return self._projection
-    
+
     @property
     def sources(self):
         return self._srcs + self._diffuse_srcs
@@ -1220,14 +1220,14 @@ class ROIModel(fermipy.config.Configurable):
         self._projection = proj
         for s in self._srcs:
             s.set_roi_projection(proj)
-    
+
     def clear(self):
         """Clear the contents of the ROI."""
         self._srcs = []
         self._diffuse_srcs = []
         self._src_dict = collections.defaultdict(set)
         self._src_radius = []
-    
+
     def load_diffuse_srcs(self):
 
         self._load_diffuse_src('isodiff')
@@ -1259,7 +1259,7 @@ class ROIModel(fermipy.config.Configurable):
                 src_dict = copy.deepcopy(t)
             else:
                 raise Exception('Invalid type in diffuse mode list: %s'%str(type(t)))
-                
+
             src_dict['file'] = \
                 resolve_file_path(src_dict['file'],
                                   search_dirs=['$FERMIPY_WORKDIR',
@@ -1326,28 +1326,28 @@ class ROIModel(fermipy.config.Configurable):
         if isinstance(src,Source):
             src.set_roi_direction(self.skydir)
             src.set_roi_projection(self.projection)
-            
+
         self.logger.debug('Creating source ' + src.name)
         self.load_source(src, build_index=build_index,
                          merge_sources=merge_sources)
-        
+
         return self.get_source_by_name(name)
 
     def copy_source(self, name):
         src = self.get_source_by_name(name)
         return copy.deepcopy(src)
-    
+
     def load_sources(self, sources):
         """Delete all sources in the ROI and load the input source list."""
 
         self.logger.debug('Loading sources')
-        
+
         self.clear()
         for s in sources:
 
             if isinstance(s, dict):
                 s = Model.create_from_dict(s)
-            
+
             self.load_source(s, build_index=False)
         self._build_src_index()
 
@@ -1370,7 +1370,7 @@ class ROIModel(fermipy.config.Configurable):
 
         build_index : bool 
            Re-make the source index after loading this source.
-        
+
         """
         src = copy.deepcopy(src)
         name = src.name.replace(' ', '').lower()
@@ -1378,18 +1378,18 @@ class ROIModel(fermipy.config.Configurable):
         min_sep = kwargs.get('min_separation',None)
 
         if min_sep is not None:
-        
+
             sep = src.skydir.separation(self._src_skydir).deg            
             if len(sep) > 0 and np.min(sep) < min_sep:
                 return        
-        
+
         match_srcs = self.match_source(src)
-        
+
         if len(match_srcs) == 1:
 
             self.logger.debug('Found matching source for %s : %s'
                               %( src.name, match_srcs[0].name ) )
-            
+
             if merge_sources:
                 self.logger.debug('Updating source model for %s' % src.name)
                 match_srcs[0].update_from_source(src)
@@ -1398,12 +1398,12 @@ class ROIModel(fermipy.config.Configurable):
                 self.logger.debug('Skipping source model for %s' % src.name)
 
             self._src_dict[src.name.replace(' ', '').lower()].add(match_srcs[0])
-                
+
             return
         elif len(match_srcs) > 2:
             self.logger.warning('Multiple sources matching %s' % name)
             return
-            
+
         self._src_dict[src.name].add(src)
 
         for name in src.names:
@@ -1422,7 +1422,7 @@ class ROIModel(fermipy.config.Configurable):
         given source.  Sources are matched by name and any association
         columns defined in the assoc_xmatch_columns parameter.
         """
-        
+
         srcs = set()
 
         names = [src.name]
@@ -1434,14 +1434,14 @@ class ROIModel(fermipy.config.Configurable):
             name = name.replace(' ', '').lower()
             if name in self._src_dict and self._src_dict[name]:
                 srcs.update(self._src_dict[name])
-                
+
         return list(srcs)
-        
+
     def load(self, **kwargs):
         """Load both point source and diffuse components."""
 
         self.logger.debug('Starting')
-        
+
         coordsys = kwargs.get('coordsys', 'CEL')
         extdir = kwargs.get('extdir', self.config['extdir'])
 
@@ -1489,11 +1489,11 @@ class ROIModel(fermipy.config.Configurable):
         roi.load_sources(data['sources'].values())
 
         return roi
-        
+
     @staticmethod
     def create(selection, config, **kwargs):
         """Create an ROIModel instance."""
-        
+
         if selection['target'] is not None:
             return ROIModel.create_from_source(selection['target'],
                                                config, **kwargs)
@@ -1509,14 +1509,14 @@ class ROIModel(fermipy.config.Configurable):
 
         Parameters
         ----------
-        
+
         skydir : `~astropy.coordinates.SkyCoord` 
             Sky direction on which the ROI will be centered.
 
         config : dict
             Model configuration dictionary.
         """
-        
+
         coordsys = kwargs.pop('coordsys', 'CEL')
         roi = ROIModel(config, skydir=skydir, coordsys=coordsys, **kwargs)
         return roi
@@ -1586,12 +1586,12 @@ class ROIModel(fermipy.config.Configurable):
         ----------
         name : str 
            Name string.
-        
+
         Returns
         -------
         srcs : `~fermipy.roi_model.Model`
            A source object.
-        
+
         """
         srcs = self.get_sources_by_name(name)
 
@@ -1601,7 +1601,7 @@ class ROIModel(fermipy.config.Configurable):
             raise Exception('No source matching name: ' + name)
         elif len(srcs) > 1:
             raise Exception('Multiple sources matching name: ' + name)
-        
+
     def get_sources_by_name(self, name):
         """Return a list of sources in the ROI matching the given
         name.  The input name string can match any of the strings in
@@ -1656,7 +1656,7 @@ class ROIModel(fermipy.config.Configurable):
 
         if skydir is None:
             skydir = self.skydir
-        
+
         rsrc, srcs = self.get_sources_by_position(skydir,
                                                   distance,
                                                   square=square,
@@ -1760,7 +1760,7 @@ class ROIModel(fermipy.config.Configurable):
         """
 
         self.logger.debug('Loading FITS catalog: %s'%name)
-        
+
         coordsys = kwargs.get('coordsys', 'CEL')
         extdir = kwargs.get('extdir', self.config['extdir'])
 
@@ -1772,7 +1772,7 @@ class ROIModel(fermipy.config.Configurable):
                                       self.config['src_radius_roi'],
                                       square=True, coordsys=coordsys)
         m = (m0 & m1)
-        
+
         offset = self.skydir.separation(cat.skydir).deg
         offset_cel = wcs_utils.sky_to_offset(self.skydir,
                                          cat.radec[:, 0], cat.radec[:, 1],
@@ -1783,7 +1783,7 @@ class ROIModel(fermipy.config.Configurable):
 
         for i, (row, radec) in enumerate(zip(cat.table[m],
                                              cat.radec[m])):
-            
+
             catalog_dict = catalog.row_to_dict(row)
             src_dict = {'catalog': catalog_dict}
             src_dict['Source_Name'] = row['Source_Name']
@@ -1797,10 +1797,10 @@ class ROIModel(fermipy.config.Configurable):
                 search_dirs = []
                 if extdir is not None:
                     search_dirs += [extdir, os.path.join(extdir, 'Templates')]
-                
+
                 search_dirs += [row['extdir'],
                                 os.path.join(row['extdir'], 'Templates')]
-                
+
                 src_dict['Spatial_Filename'] = resolve_file_path(
                     row['Spatial_Filename'],
                     search_dirs=search_dirs)
@@ -1822,7 +1822,7 @@ class ROIModel(fermipy.config.Configurable):
 
         self._build_src_index()
 
-        
+
     def load_xml(self, xmlfile, **kwargs):
         """Load sources from an XML file."""
 
@@ -1913,15 +1913,15 @@ class ROIModel(fermipy.config.Configurable):
 
 
     def create_table(self):
-        
+
         scan_shape = (1,)
         for src in self._srcs:
             scan_shape = max(scan_shape,src['dloglike_scan'].shape)
-            
+
         tab = create_source_table(scan_shape)
 
         row_dict = {} 
-        
+
         for s in self._srcs:
 
             row_dict['Source_Name'] = s['name']
@@ -1950,28 +1950,28 @@ class ROIModel(fermipy.config.Configurable):
             r68_semiminor = s['pos_sigma_semiminor']*s['pos_r68']/s['pos_sigma']
             r95_semimajor = s['pos_sigma_semimajor']*s['pos_r95']/s['pos_sigma']
             r95_semiminor = s['pos_sigma_semiminor']*s['pos_r95']/s['pos_sigma']
-            
+
             row_dict['Conf_68_PosAng'] = s['pos_angle']
             row_dict['Conf_68_SemiMajor'] = r68_semimajor
             row_dict['Conf_68_SemiMinor'] = r68_semiminor
             row_dict['Conf_95_PosAng'] = s['pos_angle']
             row_dict['Conf_95_SemiMajor'] = r95_semimajor
             row_dict['Conf_95_SemiMinor'] = r95_semiminor
-            
+
             row_dict.update(s.get_catalog_dict())
-                            
+
             for t in s.data.keys():
 
                 if t == 'params':
                     continue
                 if t in tab.columns:
                     row_dict[t] = s[t]
-            
+
             row  = [row_dict[k] for k in tab.columns]
             tab.add_row(row)
 
         return tab
-                
+
     def write_fits(self,fitsfile):
         """Write the ROI model to a FITS file."""
 
@@ -1982,7 +1982,7 @@ class ROIModel(fermipy.config.Configurable):
         for h in hdulist:
             h.header['CREATOR'] = 'fermipy ' + fermipy.__version__
         hdulist.writeto(fitsfile, clobber=True)
-        
+
 if __name__ == '__main__':
     roi = ROIModel()
 

--- a/fermipy/scripts/clone_configs.py
+++ b/fermipy/scripts/clone_configs.py
@@ -29,7 +29,7 @@ def clone_configs(basedir,base_configs,opt_configs,scripts):
 cat $0
 {scriptexe} --config={config}
 """
-        
+
         if os.path.isfile(script_in):
             script = os.path.basename(script_in)
             scriptpath = os.path.join(scriptdir,script)
@@ -47,7 +47,7 @@ cat $0
 
         dirname = os.path.abspath(os.path.join(basedir,name))
         utils.mkdir(dirname)
- 
+
         cfgfile = os.path.join(dirname,'config.yaml')
         for script_in,bash_script in zip(scripts,bash_scripts):
 
@@ -60,7 +60,7 @@ cat $0
 
         if not config:
             continue
- 
+
         c = copy.deepcopy(config)
         c = utils.merge_dict(c,vdict,add_new_keys=True)
         yaml.dump(utils.tolist(c),open(cfgfile,'w'),default_flow_style=False)
@@ -87,14 +87,14 @@ def main():
 
     #src_dict = {}
     #src_list = yaml.load(open(args.source_list))
-    
+
     #for src,sdict in src_list.items():
     #    src_dict[src] = sdict
 
     src_dict = yaml.load(open(args.source_list))
-    
+
     clone_configs(args.basedir,args.configs,src_dict,args.script)
 
 if __name__ == "__main__":
     main()
-        
+

--- a/fermipy/scripts/collect_sources.py
+++ b/fermipy/scripts/collect_sources.py
@@ -15,7 +15,7 @@ from fermipy.roi_model import ROIModel
 
 def read_sources_from_numpy_file(npfile):
     """ Open a numpy pickle file and read all the new sources into a dictionary
- 
+
     Parameters
     ----------
     npfile : file name
@@ -30,11 +30,11 @@ def read_sources_from_numpy_file(npfile):
     roi = ROIModel()
     roi.load_sources(srcs.values())    
     return roi.create_table()
-    
+
 
 def read_sources_from_yaml_file(yamfile):
     """ Open a yaml file and read all the new sources into a dictionary
- 
+
     Parameters
     ----------
     yaml : file name
@@ -51,7 +51,7 @@ def read_sources_from_yaml_file(yamfile):
     roi = ROIModel()
     roi.load_sources(srcs.values())    
     return roi.create_table()
-    
+
 
 def merge_source_tables(src_tab,tab,all_sources=False,prefix="",suffix="",
                         roi_idx=None):
@@ -62,10 +62,10 @@ def merge_source_tables(src_tab,tab,all_sources=False,prefix="",suffix="",
     src_tab : `~astropy.table.Table`    
        Master source table that will be appended with the sources in
        ``tab``.
-    
+
     tab : `~astropy.table.Table`
        Table to be merged into ``src_tab``. 
-      
+
     all_sources : bool
        If true, then all the sources get added to the table.  
        if false, then only the sources that start with 'PS' get added
@@ -83,10 +83,10 @@ def merge_source_tables(src_tab,tab,all_sources=False,prefix="",suffix="",
     """
     if roi_idx is not None and 'roi' not in tab.columns:
         tab.add_column(Column(name='roi',data=len(tab)*[roi_idx]))
-    
+
     remove_rows = []    
     for i, row in enumerate(tab):
-        
+
         if not all_sources and row['name'].find("PS") != 0:
             remove_rows += [i]
             continue
@@ -94,7 +94,7 @@ def merge_source_tables(src_tab,tab,all_sources=False,prefix="",suffix="",
         row['name'] = sname
 
     tab.remove_rows(remove_rows)
-        
+
     if src_tab is None:
         src_tab = tab
     else:
@@ -104,10 +104,10 @@ def merge_source_tables(src_tab,tab,all_sources=False,prefix="",suffix="",
 
 
 def main():
-        
+
     usage = "usage: %(prog)s [input]"    
     description = "Collect multiple source files into a single FITS file."
-    
+
     parser = argparse.ArgumentParser(usage=usage,description=description)
     parser.add_argument('--output', type=argparse.FileType('w'), help='Output FITS file.',
                         required=True)
@@ -133,7 +133,7 @@ def main():
             tab = read_sources_from_yaml_file(filepath)
         else:
             raise Exception("Can't read source from file type %s"%(ext))
-            
+
         src_tab = merge_source_tables(src_tab,tab,prefix="roi_%05i_"%idx,
                                       all_sources=args.all_sources,
                                       roi_idx=idx)
@@ -142,6 +142,6 @@ def main():
     print('Collected', len(src_tab), 'sources')
     src_tab.write(args.output,format='fits',overwrite=args.clobber)
 
-    
+
 if __name__ == "__main__":
     main()

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -18,15 +18,15 @@ def file_age_in_seconds(pathname):
 
 def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90): 
     """Construct a list of job dictionaries."""
-    
+
     jobs = []
-    
+
     for dirname in sorted(dirs):        
-        
+
         o = dict(cfgfile = os.path.join(dirname,'config.yaml'),
                  logfile = os.path.join(dirname,os.path.splitext(runscript)[0] + '.log'),
                  runscript = os.path.join(dirname,runscript))
-        
+
         if not os.path.isfile(o['cfgfile']):
             continue
 
@@ -36,10 +36,10 @@ def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90):
         if not os.path.isfile(o['logfile']):
             jobs.append(o)
             continue
-            
+
         age = file_age_in_seconds(o['logfile'])/60.
         job_status = check_log(o['logfile'])
-        
+
         print(dirname, job_status, age)
 
         if job_status is False or overwrite:
@@ -92,11 +92,11 @@ def main():
     args = parser.parse_args()
 
     from itertools import chain
-    
+
     dirs = [d for argdir in args.dirs for d in utils.collect_dirs(argdir)]
     jobs = collect_jobs(dirs, args.runscript,
                         args.overwrite, args.max_job_age)
-    
+
     lsf_opts = {'W' : 1500,
                 'R' : 'bullet,hequ,kiso'}
 
@@ -105,9 +105,9 @@ def main():
 
         if utils.isstr(optval):
             optval = '\"%s\"'%optval
-            
+
         lsf_opt_string += '-%s %s '%(optname,optval)
-    
+
     while(1):
 
         print('-'*80)

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -23,7 +23,7 @@ NORM_LABEL = {'NORM':r'Flux Normalization [a.u.]',
               'E2DFDE':r'%E^2% dN/dE [MeV $cm^{-2} s^{-1} MeV^{-1}$]',
               'SIGVJ':r'$J\langle \sigma v \rangle$ [$GeV^{2} cm^{-2} s^{-1}$]',
               'SIGV':r'$\langle \sigma v \rangle$ [$cm^{3} s^{-1}$]'}
-              
+
 
 def plotNLL_v_Flux(nll,fluxType,nstep=25,xlims=None):
     """ Plot the (negative) log-likelihood as a function of normalization
@@ -55,7 +55,7 @@ def plotNLL_v_Flux(nll,fluxType,nstep=25,xlims=None):
 
     ax.set_xlim((xmin,xmax))
     ax.set_ylim((ymin,ymax))
-    
+
     ax.set_xlabel(NORM_LABEL[fluxType])
     ax.set_ylabel(r'$-\Delta \log\mathcal{L}$')
     ax.plot(xvals,yvals)
@@ -86,7 +86,7 @@ def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
     else:
         zmin = zlims[0]
         zmax = zlims[1]
-  
+
     fig = plt.figure()
     ax = fig.add_subplot(111)
 
@@ -94,7 +94,7 @@ def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
     ax.set_yscale('log')
     ax.set_xlim((xmin,xmax))
     ax.set_ylim((ymin,ymax))
-    
+
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
 
@@ -109,7 +109,7 @@ def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
     im = ax.imshow(ztmp, extent=[xmin,xmax,ymin,ymax],
                    origin='lower', aspect='auto',interpolation='nearest',
                    vmin=zmin, vmax=zmax,cmap=matplotlib.cm.jet_r)
-    
+
     return fig,ax,im,ztmp   
 
 
@@ -146,7 +146,7 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
     xmax = castroData.specData.ebins[-1]
     ymin = ylims[0]
     ymax = ylims[1]
-  
+
     fig = plt.figure()
     ax = fig.add_subplot(111)
 
@@ -154,7 +154,7 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
     ax.set_yscale('log')
     ax.set_xlim((xmin,xmax))
     ax.set_ylim((ymin,ymax))
-    
+
     ax.set_xlabel("Energy [GeV]")
     ax.set_ylabel(NORM_LABEL[castroData.norm_type])
 
@@ -164,7 +164,7 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
     has_point = ts_vals > TS_thresh
     has_limit = ~has_point
     ul_vals = castroData.getLimits(0.05)
-    
+
     err_pos = castroData.getLimits(0.32) - mles
     err_neg = mles - castroData.getLimits(0.32,upper=False) 
 
@@ -192,7 +192,7 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
 
 if __name__ == "__main__":
 
-    
+
     from fermipy import castro
     from fermipy import roi_model
     import sys
@@ -201,7 +201,7 @@ if __name__ == "__main__":
         flux_type = "FLUX"
     else:
         flux_type = sys.argv[1]
-        
+
 
     if flux_type == 'NORM':
         xlims = (0.,1.)
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     else:
         print ("Didn't reconginize flux type %s, choose from NORM | FLUX | EFLUX | NPRED | DFDE | EDFDE"%sys.argv[1])
         sys.exit()
-        
+
     tscube = castro.TSCube.create_from_fits("tscube_test.fits",flux_type)
     resultDict = tscube.find_sources(10.0,1.0,use_cumul=False,
                                      output_peaks=True,
@@ -240,7 +240,7 @@ if __name__ == "__main__":
     fig,ax = plotNLL_v_Flux(nll,flux_type)
 
     fig2,ax2,im2,ztmp2 = plotCastro(castro,ylims=flux_lims,nstep=100)
-        
+
     spec_pl = test_dict["PowerLaw"]["Spectrum"]
     spec_lp = test_dict["LogParabola"]["Spectrum"]
     spec_pc = test_dict["PLExpCutoff"]["Spectrum"]
@@ -260,4 +260,4 @@ if __name__ == "__main__":
     print "TS for LogParabola:   %.1f (Index = %.2f, Beta = %.2f)"%(ts_lp,result_lp[1],result_lp[2])
     print "TS for PLExpCutoff:   %.1f (Index = %.2f, E_c = %.2f)"%(ts_pc,result_pc[1],result_pc[2])
 
-     
+

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -95,11 +95,11 @@ class Map(Map_Base):
         self._pix_size = np.array([np.abs(self.wcs.wcs.cdelt[0]),
                                    np.abs(self.wcs.wcs.cdelt[1])])
 
-        
+
         self._skydir = SkyCoord.from_pixel(self._pix_center[0],
                                            self._pix_center[1],
                                            self.wcs)
-        
+
     @property
     def wcs(self):
         return self._wcs
@@ -123,7 +123,7 @@ class Map(Map_Base):
     def pix_center(self):
         """Return the ROI center in pixel coordinates."""
         return self._pix_center
-    
+
     @staticmethod
     def create_from_hdu(hdu, wcs):
         return Map(hdu.data.T, wcs)
@@ -145,14 +145,14 @@ class Map(Map_Base):
         wcs = wcs_utils.create_wcs(skydir,coordsys,projection,
                                    cdelt,crpix)
         return Map(np.zeros(npix),wcs)
-    
+
     def create_image_hdu(self,name=None):
         return pyfits.ImageHDU(self.counts,header=self.wcs.to_header(),
                                name=name)
-    
+
     def create_primary_hdu(self):
         return pyfits.PrimaryHDU(self.counts,header=self.wcs.to_header())
-    
+
 
     def sum_over_energy(self):
         """ Reduce a 3D counts cube to a 2D counts map
@@ -172,7 +172,7 @@ class Map(Map_Base):
         else:
             return np.where( (xypix[0] < self._wcs._naxis2)*(xypix[1] < self._wcs._naxis1),
                              xypix[1]*self._wcs._naxis1 + xypix[0], -1 )
-    
+
     def ipix_to_xypix(self,ipix,colwise=False):
         """ Return the pixel xy coordinates from the pixel index
 
@@ -182,7 +182,7 @@ class Map(Map_Base):
             return (ipix / self._wcs._naxis2, ipix % self._wcs._naxis2)
         else:
             return (ipix % self._wcs._naxis1, ipix / self._wcs._naxis1)
-    
+
     def ipix_swap_axes(self,ipix,colwise=False):
         """ Return the transposed pixel index from the pixel xy coordinates 
 
@@ -199,7 +199,7 @@ class Map(Map_Base):
         ypix = np.linspace(0,self.counts.shape[1]-1.,self.counts.shape[1])
         xypix = np.meshgrid(xpix,ypix,indexing='ij')
         return SkyCoord.from_pixel(np.ravel(xypix[0]),np.ravel(xypix[1]),self.wcs)
-        
+
     def get_pixel_indices(self,lons,lats):
         """ Return the indices in the flat array corresponding to a set of coordinates
 
@@ -207,10 +207,10 @@ class Map(Map_Base):
         ----------       
         lons  : array-like
            'Longitudes' (RA or GLON)
-        
+
         lats  : array-like
            'Latitidues' (DEC or GLAT)
-        
+
         Returns
         ----------
            idxs : numpy.ndarray((n),'i')
@@ -231,10 +231,10 @@ class Map(Map_Base):
         ----------       
         lons  : array-like
            'Longitudes' (RA or GLON)
-        
+
         lats  : array-like
            'Latitidues' (DEC or GLAT)
-        
+
         Returns
         ----------
            vals : numpy.ndarray((n))
@@ -244,7 +244,7 @@ class Map(Map_Base):
         vals = np.where(pix_idxs>0,self.counts.flat[pix_idxs],np.nan)
         return vals
 
-    
+
 class HpxMap(Map_Base):
     """ Representation of a 2D or 3D counts map using HEALPix. """
 
@@ -350,7 +350,7 @@ class HpxMap(Map_Base):
                 loop_ebins = True
         else:
             raise Exception('Wrong dimension for HpxMap %i' % len(hpx_in.shape))
-        
+
         if loop_ebins:
             for i in range(hpx_data.shape[0]):
                 self._hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data[i],wcs_data[i],normalize)

--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -27,51 +27,51 @@ class SEDFunctor(object):
     @property
     def scale(self):
         return self._scale
-    
+
 class SEDFluxFunctor(SEDFunctor):
     """Functor that computes the flux of a source in a sequence of SED
     energy bins."""
-    
+
     def __init__(self,spectrum,scale,emin,emax):
         super(SEDFluxFunctor,self).__init__(spectrum, scale, emin, emax)
-        
+
     def __call__(self,params):
 
         params = list(params)
         for i, p in enumerate(params):
             params[i] = np.expand_dims(np.array(params[i],ndmin=1),0)
-            
+
         emin = np.expand_dims(self.emin,1)
         emax = np.expand_dims(self.emax,1)
-        
+
         return self._spectrum.eval_flux(emin,emax,
                                         params,self.scale)
 
 class SEDEFluxFunctor(SEDFunctor):
     """Functor that computes the energy flux of a source in a sequence
     of SED energy bins."""
-    
+
     def __init__(self,spectrum,scale,emin,emax):
         super(SEDEFluxFunctor,self).__init__(spectrum, scale, emin, emax)
-        
+
     def __call__(self,params):
 
         params = list(params)
         for i, p in enumerate(params):
             params[i] = np.expand_dims(np.array(params[i],ndmin=1),0)
-            
+
         emin = np.expand_dims(self.emin,1)
         emax = np.expand_dims(self.emax,1)
-        
+
         return self._spectrum.eval_eflux(emin,emax, params,self.scale)
-        
+
 class SpectralFunction(object):
     """Base class for spectral model classes."""
-    
+
     def __init__(self, params, scale = 1.0):
         self._params = params
         self._scale = scale
-    
+
     @property
     def params(self):
         return self._params
@@ -82,14 +82,14 @@ class SpectralFunction(object):
 
     @staticmethod
     def create_functor(spec_type,func_type,emin,emax,scale=1.0):
-        
+
         if func_type.lower() == 'flux':
             return eval(spec_type).create_flux_functor(emin,emax,scale)
         elif func_type.lower() == 'eflux':
             return eval(spec_type).create_eflux_functor(emin,emax,scale)
         else:
             raise Exception("Did not recognize func_type: %s"%func_type)
-        
+
     @classmethod
     def create_flux_functor(cls,emin,emax,escale=1.0):
         return SEDFluxFunctor(cls,escale,emin,emax)
@@ -114,10 +114,10 @@ class SpectralFunction(object):
         emax = np.expand_dims(emax,-1)
 
         params = copy.deepcopy(params)
-        
+
         for i, p in enumerate(params):
             params[i] = np.expand_dims(params[i],-1)
-            
+
 #        params = np.expand_dims(params,-1)
         xedges = np.linspace(0.0,1.0,npt+1)
         logx_edge = np.log(emin) + xedges*(np.log(emax)-np.log(emin)) 
@@ -125,22 +125,22 @@ class SpectralFunction(object):
         xw = np.exp(logx_edge[...,1:])-np.exp(logx_edge[...,:-1]) 
         dfde = fn(np.exp(logx),params,scale)
         return np.sum(dfde*xw,axis=-1)
-        
+
         #logx_edge = np.log(emin) + xedges[:,np.newaxis]*(np.log(emax)-np.log(emin)) 
         #logx = 0.5*(logx_edge[1:,...]+logx_edge[:-1,...])
         #xw = np.exp(logx_edge[1:,...])-np.exp(logx_edge[:-1,...])        
         #x = np.exp(logx)
         #dfde = fn(x,params,scale)
         #return np.sum(dfde*xw,axis=0)
-    
+
     @classmethod
     def eval_flux(cls, emin, emax, params, scale=1.0):
         return cls.integrate(cls.eval_dfde,emin,emax,params,scale)
-        
+
     @classmethod
     def eval_eflux(cls,emin, emax, params, scale=1.0):
         return cls.integrate(cls.eval_edfde,emin,emax,params,scale)
-    
+
     def dfde(self, x):
         """Evaluate differential flux."""
         return self.eval_dfde(x, self.params, self.scale)
@@ -157,7 +157,7 @@ class SpectralFunction(object):
         """Evaluate the energy flux flux."""
         return self.eval_eflux(emin, emax, self.params, self.scale)
 
-    
+
 class PowerLaw(SpectralFunction):
     def __init__(self, params, scale=1.0):
         super(PowerLaw,self).__init__(params, scale)
@@ -165,7 +165,7 @@ class PowerLaw(SpectralFunction):
     @staticmethod
     def eval_dfde(x, params, scale=1.0):
         return params[0] * (x / scale) ** params[1]
-    
+
     @classmethod
     def eval_flux(cls, emin, emax, params, scale=1.0):
 
@@ -180,12 +180,12 @@ class PowerLaw(SpectralFunction):
         iindex1 = np.zeros(index.shape)
         iindex1[~m] = 1./index1[~m]
         iindex0[m] = 1.        
-        
+
         v0 = phi0 * x0 ** (-index) * (np.log(emax) - np.log(emin))*iindex0
         v1 = phi0 * x0 ** (-index) * (emax ** index1 - emin ** index1)*iindex1
-        
+
         return v0+v1
-        
+
 #        y0 = x0 * phi0 * (emin / x0) ** (index + 1) / (index + 1)
 #        y1 = x0 * phi0 * (emax / x0) ** (index + 1) / (index + 1)
 #        v2 = y1 - y0
@@ -197,7 +197,7 @@ class PowerLaw(SpectralFunction):
         params = copy.deepcopy(params)
         params[1] += 1.0        
         return cls.eval_flux(emin,emax,params,scale)*scale
-        
+
     @staticmethod
     def eval_norm(scale, index, emin, emax, flux):
         return flux / PowerLaw.eval_flux(emin,emax, [1.0, index], scale)
@@ -206,16 +206,16 @@ class PowerLaw(SpectralFunction):
 class LogParabola(SpectralFunction):
     def __init__(self, params, scale=1.0):
         super(LogParabola,self).__init__(params, scale)
-    
+
     @staticmethod
     def eval_dfde(x, params, scale=1.0):
         return params[0] * (x / scale) ** (params[1]-params[2]*np.log(x/scale))
 
-    
+
 class PLExpCutoff(SpectralFunction):
     def __init__(self, params, scale=1.0):
         super(PLExpCutoff,self).__init__(params, scale)
-    
+
     @staticmethod
     def eval_dfde(x, params, scale=1.0):
         return params[0] * (x / scale) ** (params[1]) * np.exp(-x/params[2])

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -129,7 +129,7 @@ def make_disk_spatial_map(skydir, sigma, outfile, npix=501, cdelt=0.01):
 
 def delete_source_map(srcmap_file, name, logger=None):
     """Delete a map from a binned analysis source map file if it exists.
-    
+
     Parameters
     ----------
 

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -48,7 +48,7 @@ class prior_functor:
         # Default is to marginalize over two decades,
         # centered on mean, using 1000 bins
         return np.logspace(-1.+log_mean,1.+log_mean,1001)
-    
+
 
 
 class lognorm_prior(prior_functor):
@@ -60,20 +60,20 @@ class lognorm_prior(prior_functor):
     scale = 1.0 : This is the mean of the linear-space lognormal distribution.
                   The mean of the underlying normal distribution occurs at ln(scale)
     loc = 0     : This linearly shifts the distribution in x (DO NOT USE)
-    
+
     The convention is different for numpy.random.lognormal
     mean        : This is the mean of the underlying normal distribution (so mean = log(scale))
     sigma       : This is the standard deviation of the underlying normal distribution (so sigma = s)
-    
+
     For random sampling:
     numpy.random.lognormal(mean, sigma, size)
     mean        : This is the mean of the underlying normal distribution (so mean = exp(scale))
     sigma       : This is the standard deviation of the underlying normal distribution (so sigma = s)
-    
+
     scipy.stats.lognorm.rvs(s, scale, loc, size)
     s           : This is the standard deviation of the underlying normal distribution
     scale       : This is the mean of the generated random sample scale = exp(mean)
-    
+
     Remember, pdf in log space is
     plot( log(x), stats.lognorm(sigma,scale=exp(mean)).pdf(x)*x )
     """
@@ -100,7 +100,7 @@ class lognorm_prior(prior_functor):
 
 class norm_prior(prior_functor):
     """ A wrapper around the lormal function.
-        
+
     Parameters
     ----------
     mu    :  The mean value of the function
@@ -120,7 +120,7 @@ class norm_prior(prior_functor):
     def __call__(self,x):
         """ Normal function from scipy """
         return stats.norm(loc=self._mu,scale=self._sigma).pdf(x)
-        
+
 
 def create_prior_functor(d):
     """ Build a prior from a dictionary
@@ -130,7 +130,7 @@ def create_prior_functor(d):
     d     :  A dictionary, it must contain:
        d['functype'] : 'lognorm' or 'norm' 
        and all of the required parameters for the prior_functor of the desired type
-    
+
     """
     functype = d.pop('functype','lognorm')
     if functype == 'norm':
@@ -139,7 +139,7 @@ def create_prior_functor(d):
         return lognorm_prior(**d)
     else:
         raise KeyError("Unrecognized prior_functor type %s"%functype)
-    
+
 
 class LnLFn_norm_prior:
     """ A class to add a prior on normalization of a LnLFn object
@@ -148,7 +148,7 @@ class LnLFn_norm_prior:
 
     where x is the parameter of interest, y is a nuisance parameter,
     and L_z is a likelihood constraining z = x*y.
-  
+
     This class can compute:
 
     The likelikhood:
@@ -173,15 +173,15 @@ class LnLFn_norm_prior:
     """
     def __init__(self,lnlfn,nuis_pdf,ret_type='profile'):
         """ C'tor
-  
+
         Parameters
         ----------
         lnlx : '~fermipy.castro.LnLFn' 
            The object wrapping L(x)  
-        
+
         nuis_pdf : '~fermipy.stats_utils.prior_functor'
            The object wrapping L(y)
-           
+
         ret_type : str
            determine what is returned by __call__
            allowed values are 'straight','profile','marginal','posterior'        
@@ -192,7 +192,7 @@ class LnLFn_norm_prior:
         self._nuis_log_norm = np.log(self._nuis_norm)
         self.clear_cached_values()
         self.init_return(ret_type) 
-        
+
     @property
     def ret_type(self):
         """ Specifies what is returned by __call__
@@ -206,7 +206,7 @@ class LnLFn_norm_prior:
         That will give interoplated values of the type determined by ret_type
         """ 
         return self._interp
-    
+
     def init_return(self,ret_type):
         """ Specify the return type
 
@@ -230,7 +230,7 @@ class LnLFn_norm_prior:
             raise ValueError("Did not recognize return type %s"%ret_type)
         self._ret_type = ret_type
 
-        
+
     def clear_cached_values(self):
         """ Removes all of the cached values and interpolators
         """
@@ -253,14 +253,14 @@ class LnLFn_norm_prior:
         ----------
         x : array_like
         Array of coordinates in the `x` parameter.
-        
+
         y : array_like       
         Array of coordinates in the `y` nuisance parameter.
         """        
         # This is the negative log-likelihood
         z = self._lnlfn.interp(x*y)        
         return np.exp(-z)*self._nuis_pdf(y)/self._nuis_norm
-    
+
 
     def loglike(self,x,y):
         """ Evaluate the 2-D log-likelihood in the x/y parameter space.
@@ -270,7 +270,7 @@ class LnLFn_norm_prior:
         ----------
         x : array_like
         Array of coordinates in the `x` parameter.
-        
+
         y : array_like       
         Array of coordinates in the `y` nuisance parameter.
         """        
@@ -293,7 +293,7 @@ class LnLFn_norm_prior:
         if self._prof_interp is None:
             # This calculates values and caches the spline 
             return self._profile_loglike(x)[1]            
-    
+
         x = np.array(x,ndmin=1)
         return self._prof_interp(x)
 
@@ -307,7 +307,7 @@ class LnLFn_norm_prior:
         if self._marg_interp is None:
             # This calculates values and caches the spline 
             return self._marginal_loglike(x)
-        
+
         x = np.array(x,ndmin=1)
         return self._marg_interp(x)
 
@@ -329,12 +329,12 @@ class LnLFn_norm_prior:
         """ Internal function to calculate and cache the profile likelihood
         """
         x = np.array(x,ndmin=1)
-        
+
         z = []
         y = []
 
         for xtmp in x:
-            
+
             fn = lambda t: -self.loglike(xtmp,t)
             ytmp = opt.fmin(fn,1.0,disp=False)[0]
             ztmp = self.loglike(xtmp,ytmp)
@@ -377,8 +377,8 @@ class LnLFn_norm_prior:
         yedge = self._nuis_pdf.marginalization_bins()
         yc = 0.5*(yedge[1:]+yedge[:-1])
         yw = yedge[1:]-yedge[:-1]
-        
-        
+
+
         like_array = self.like(x[:,np.newaxis],yc[np.newaxis,:])*yw 
         like_array /= like_array.sum()
 
@@ -386,7 +386,7 @@ class LnLFn_norm_prior:
         self._post_interp = castro.Interpolator(x,self._post)
         return self._post
 
-   
+
     def __call__(self,x):
         """ Evaluate the quantity specified by ret_type parameter
 
@@ -409,5 +409,5 @@ class LnLFn_norm_prior:
 
 
 if __name__ == "__main__":
-    
+
     pass

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -39,6 +39,6 @@ def test_castro_test_spectra_castro(tmpdir):
     assert( np.abs(test_dict['LogParabola']['TS'][0] -  3.72) < 0.01)
     assert( np.abs(test_dict['PLExpCutoff']['TS'][0] -  3.70) < 0.01)
 
-    
+
 
 

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -79,7 +79,7 @@ def test_gtanalysis_residmap(setup):
     gta.load_roi('fit1')
     gta.residmap(model={})
 
-    
+
 def test_gtanalysis_sed(setup):
 
     gta = setup
@@ -93,10 +93,10 @@ def test_gtanalysis_sed(setup):
 
     emin = gta.energies[:-1]
     emax = gta.energies[1:]
-    
+
     flux_true = spectrum.PowerLaw.eval_flux(emin, emax,
                                             [prefactor,-index],scale)
-    
+
     gta.simulate_source({'SpatialModel': 'PointSource',
                          'Index' : index,
                          'Scale' : scale,
@@ -104,7 +104,7 @@ def test_gtanalysis_sed(setup):
 
     gta.free_source('draco')
     gta.fit()
-    
+
     o = gta.sed('draco')
 
     flux_resid = np.abs((flux_true - o['flux'])/o['flux_err'])
@@ -113,9 +113,9 @@ def test_gtanalysis_sed(setup):
     assert(np.abs(-params['Index'][0]-index)/params['Index'][1] < 3.0)
     assert(np.abs(params['Prefactor'][0]-prefactor)/
            params['Prefactor'][1] < 3.0)
-    
+
     gta.simulate_roi(restore=True)
-    
+
 
 def test_gtanalysis_extension_gaussian(setup):
 

--- a/fermipy/tests/test_roi_model.py
+++ b/fermipy/tests/test_roi_model.py
@@ -143,14 +143,14 @@ def test_load_source_from_xml(tmppath):
 
     for x in attribs:
         assert_allclose(sp['Scale'][x],values['ptsrc_scale_%s'%x])
-        
+
     assert_allclose(src.params['Prefactor'][0],
                     values['ptsrc_prefactor_value']*values['ptsrc_prefactor_scale'])
     assert_allclose(src.params['Index'][0],
                     values['ptsrc_index_value']*values['ptsrc_index_scale'])
     assert_allclose(src.params['Scale'][0],
                     values['ptsrc_scale_value']*values['ptsrc_scale_scale'])
-    
+
     src = roi['galdiff']
     assert(src['SpatialType'] == 'MapCubeFunction')
     assert(src['SpatialModel'] == 'MapCubeFunction')
@@ -164,7 +164,7 @@ def test_create_source_from_dict(tmppath):
 
     ra = 252.367
     dec = 52.6356
-    
+
     src = Source.create_from_dict({'name' : 'testsrc',
                                    'SpatialModel' : 'PointSource',
                                    'SpectrumType' : 'PowerLaw',
@@ -177,7 +177,7 @@ def test_create_source_from_dict(tmppath):
     assert(src['SpatialType'] == 'SkyDirFunction')
     assert(src['SourceType'] == 'PointSource')
     assert(src.extended is False)
-    
+
     src = Source.create_from_dict({'name' : 'testsrc',
                                    'SpatialModel' : 'GaussianSource',
                                    'SpectrumType' : 'PowerLaw',
@@ -190,7 +190,7 @@ def test_create_source_from_dict(tmppath):
     assert(src['SpatialType'] == 'SpatialMap')
     assert(src['SourceType'] == 'DiffuseSource')
     assert(src.extended is True)
-    
+
     src = Source.create_from_dict({'name' : 'testsrc',
                                    'SpatialModel' : 'RadialGaussian',
                                    'SpectrumType' : 'PowerLaw',
@@ -202,7 +202,7 @@ def test_create_source_from_dict(tmppath):
     assert_allclose(src['Sigma'],0.5)
     if src['SpatialType'] == 'RadialGaussian':
         assert_allclose(src.spatial_pars['Sigma']['value'],0.5)
-    
+
     assert(src['SpatialModel'] == 'RadialGaussian')
     assert(src['SourceType'] == 'DiffuseSource')
     assert(src.extended is True)
@@ -218,18 +218,18 @@ def test_create_source_from_dict(tmppath):
     assert_allclose(src['Radius'],0.5)
     if src['SpatialType'] == 'RadialDisk':
         assert_allclose(src.spatial_pars['Radius']['value'],0.5)
-    
+
     assert(src['SpatialModel'] == 'RadialDisk')
     assert(src['SourceType'] == 'DiffuseSource')
     assert(src.extended is True)
-    
+
 
 def test_create_source(tmppath):
 
     ra = 252.367
     dec = 52.6356
     sigma = 0.5
-    
+
     src_dict = {'SpatialModel' : 'GaussianSource', 'ra' : ra, 'dec' : dec, 'Sigma' : sigma}    
     src = Source('testsrc',src_dict)
 
@@ -243,7 +243,7 @@ def test_set_spatial_model(tmppath):
 
     ra = 252.367
     dec = 52.6356
-    
+
     src_dict = {'SpatialModel' : 'GaussianSource', 'ra' : ra, 'dec' : dec}    
     src = Source('testsrc',src_dict)
 
@@ -251,4 +251,4 @@ def test_set_spatial_model(tmppath):
     assert(src['SpatialModel'] == 'PointSource')
     assert(src['SpatialType'] == 'SkyDirFunction')
     assert(src['SourceType'] == 'PointSource')
-    
+

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -53,7 +53,7 @@ def extract_images_from_tscube(infile,outfile):
     wcs_cube = wcs_utils.wcs_add_energy_axis(wcs,energies)
 
     outhdulist = [inhdulist[0],inhdulist["EBOUNDS"]]
-    
+
     FIT_COLNAMES = ['FIT_TS','FIT_STATUS','FIT_NORM','FIT_NORM_ERR','FIT_NORM_ERRP','FIT_NORM_ERRN']
     SCAN_COLNAMES = ['TS','BIN_STATUS','NORM','NORM_UL','NORM_ERR','NORM_ERRP','NORM_ERRN','LOGLIKE']
 
@@ -83,7 +83,7 @@ def convert_tscube(infile,outfile):
         if infile != outfile:
             hdulist.writeto(outfile,clobber=True)
         return
-    
+
     # Get stuff out of the input file
     nrows = inhdulist['SCANDATA']._nrows
     nebins = inhdulist['EBOUNDS']._nrows
@@ -99,7 +99,7 @@ def convert_tscube(infile,outfile):
     flux = PowerLaw.eval_flux(emin,emax,[dfde_emin,index],emin)
     eflux = PowerLaw.eval_eflux(emin,emax,[dfde_emin,index],emin)
     dfde = PowerLaw.eval_dfde(np.sqrt(emin*emax),[dfde_emin,index],emin)
- 
+
     ts_map = inhdulist['PRIMARY'].data.reshape((nrows))
     ok_map = inhdulist['TSMAP_OK'].data.reshape((nrows))
     n_map = inhdulist['N_MAP'].data.reshape((nrows))
@@ -123,7 +123,7 @@ def convert_tscube(infile,outfile):
     errcube = np.ndarray((nrows,nebins))
     errcube[m] = 0.5*(errpcube[m]+errncube[m])
     errcube[~m] = errpcube[~m]
-    
+
     norm_scan = inhdulist['SCANDATA'].data.field('NORMSCAN').reshape((nrows,npts,nebins)).swapaxes(1,2)
     nll_scan = inhdulist['SCANDATA'].data.field('NLL_SCAN').reshape((nrows,npts,nebins)).swapaxes(1,2)
 
@@ -141,14 +141,14 @@ def convert_tscube(infile,outfile):
     columns.add_col(pyfits.Column(name=str('REF_DFDE'),
                                   format='D', array=dfde,
                                   unit='ph / (MeV cm2 s)'))
-    
+
     columns.change_name('E_MIN_FL',str('REF_DFDE_E_MIN'))
     columns.change_unit('REF_DFDE_E_MIN','ph / (MeV cm2 s)')
     columns.change_name('E_MAX_FL',str('REF_DFDE_E_MAX'))
     columns.change_unit('REF_DFDE_E_MAX','ph / (MeV cm2 s)')
     columns.change_name('NPRED',str('REF_NPRED'))
-    
-    
+
+
     hdu_e = pyfits.BinTableHDU.from_columns(columns,name='EBOUNDS')
 
     # Make the "FITDATA" hdu
@@ -161,25 +161,25 @@ def convert_tscube(infile,outfile):
     columns.add_col(pyfits.Column(name=str('FIT_NORM_ERRP'), format='E', array=errp_map))
     columns.add_col(pyfits.Column(name=str('FIT_NORM_ERRN'), format='E', array=errn_map))    
     hdu_f = pyfits.BinTableHDU.from_columns(columns,name='FITDATA')
-   
+
     # Make the "SCANDATA" hdu
     columns = pyfits.ColDefs([])
-   
+
     columns.add_col(pyfits.Column(name=str('TS'), format='%iE'%nebins, array=tscube,
                                   dim=str('(%i)'%nebins)))
-   
+
     columns.add_col(pyfits.Column(name=str('BIN_STATUS'), format='%iE'%nebins, array=ok_cube,
                                   dim=str('(%i)'%nebins)))
-       
+
     columns.add_col(pyfits.Column(name=str('NORM'), format='%iE'%nebins, array=ncube,
                                   dim=str('(%i)'%nebins)))
 
     columns.add_col(pyfits.Column(name=str('NORM_UL'), format='%iE'%nebins, array=ul_cube,
                                   dim=str('(%i)'%nebins)))
-    
+
     columns.add_col(pyfits.Column(name=str('NORM_ERR'), format='%iE'%nebins, array=errcube,
                                   dim=str('(%i)'%nebins)))
-    
+
     columns.add_col(pyfits.Column(name=str('NORM_ERRP'), format='%iE'%nebins, array=errpcube,
                                   dim=str('(%i)'%nebins)))
 
@@ -195,10 +195,10 @@ def convert_tscube(infile,outfile):
     columns.add_col(pyfits.Column(name=str('DLOGLIKE_SCAN'), format='%iE'%(nebins*npts), array=nll_scan,
                                   dim=str('(%i,%i)'%(npts,nebins))))
 
-       
+
     hdu_s = pyfits.BinTableHDU.from_columns(columns,name='SCANDATA')
 
- 
+
     hdulist = pyfits.HDUList([inhdulist[0],
                               hdu_s,
                               hdu_f,
@@ -210,7 +210,7 @@ def convert_tscube(infile,outfile):
     hdulist.writeto(outfile,clobber=True)
 
     return hdulist
-    
+
 
 def overlap_slices(large_array_shape, small_array_shape, position):
     """
@@ -597,10 +597,10 @@ class TSMapGenerator(object):
 
         write_fits : bool
            Write a FITS file.
-           
+
         write_npy : bool
            Write a numpy file.
-        
+
         Returns
         -------
 
@@ -620,7 +620,7 @@ class TSMapGenerator(object):
         config['model'].setdefault('SpectrumType', 'PowerLaw')
         config['model'].setdefault('SpatialModel', 'PointSource')
         config['model'].setdefault('Prefactor', 1E-13)
-        
+
         make_plots = kwargs.get('make_plots', True)
         maps = self._make_tsmap_fast(prefix, config, **kwargs)
 
@@ -630,10 +630,10 @@ class TSMapGenerator(object):
                                                logging=self.config['logging'])
 
             plotter.make_tsmap_plots(self, maps)
-            
+
         self.logger.info('Finished TS map')
         return maps
-    
+
     def _make_tsmap_fast(self, prefix, config, **kwargs):
         """
         Make a TS map from a GTAnalysis instance.  This is a
@@ -643,7 +643,7 @@ class TSMapGenerator(object):
         source can be defined with the src_dict argument.  By default
         this method will generate a TS map for a point source with an
         index=2.0 power-law spectrum.
-        
+
         Parameters
         ----------
         model : dict or `~fermipy.roi_model.Source` object        
@@ -651,13 +651,13 @@ class TSMapGenerator(object):
            test source that will be used in the scan.
 
         """
-        
+
         write_fits = kwargs.get('write_fits', True)
         write_npy = kwargs.get('write_npy', True)
         map_skydir = kwargs.get('map_skydir',None)
         map_size = kwargs.get('map_size',1.0)
         exclude = kwargs.get('exclude', None)
-        
+
         src_dict = copy.deepcopy(config.setdefault('model',{}))
         multithread = config.setdefault('multithread',False)
         threshold = config.setdefault('threshold',1E-2)
@@ -673,7 +673,7 @@ class TSMapGenerator(object):
                          else self.log_energies[-1])
         else:
             loge_bounds = [self.log_energies[0],self.log_energies[-1]]
-        
+
         # Put the test source at the pixel closest to the ROI center
         xpix, ypix = (np.round((self.npix - 1.0) / 2.),
                       np.round((self.npix - 1.0) / 2.))
@@ -706,14 +706,14 @@ class TSMapGenerator(object):
             eslice = slice(imin,imax)
             bm = c.model_counts_map(exclude=exclude).counts.astype('float')[eslice,...]
             cm = c.counts_map().counts.astype('float')[eslice,...]
-            
+
             background += [bm]
             counts += [cm]
             c0_map += [cash(cm, bm)]
             eslices += [eslice]
             enumbins += [cm.shape[0]]
 
-        
+
         self.add_source('tsmap_testsource', src_dict, free=True,
                        init_source=False)
         src = self.roi['tsmap_testsource']
@@ -723,31 +723,31 @@ class TSMapGenerator(object):
             mm = c.model_counts_map('tsmap_testsource').counts.astype('float')[eslice,...]            
             model_npred += np.sum(mm)
             model += [mm]
-            
+
         self.delete_source('tsmap_testsource')
-        
+
         for i, mm in enumerate(model):
 
             dpix = 3
             for j in range(mm.shape[0]):
 
                 ix,iy = np.unravel_index(np.argmax(mm[j,...]),mm[j,...].shape)
-                
+
                 mx = mm[j,ix, :] > mm[j,ix,iy] * threshold
                 my = mm[j,:, iy] > mm[j,ix,iy] * threshold
                 dpix = max(dpix, np.round(np.sum(mx) / 2.))
                 dpix = max(dpix, np.round(np.sum(my) / 2.))
-                
+
             if max_kernel_radius is not None and \
                     dpix > int(max_kernel_radius/self.components[i].binsz):
                 dpix = int(max_kernel_radius/self.components[i].binsz)
 
             xslice = slice(max(xpix-dpix,0),min(xpix+dpix+1,self.npix))
             model[i] = model[i][:,xslice,xslice]
-            
+
         ts_values = np.zeros((self.npix, self.npix))
         amp_values = np.zeros((self.npix, self.npix))
-        
+
         wrap = functools.partial(_ts_value, counts=counts, 
                                  background=background, model=model,
                                  C_0_map=c0_map, method='root brentq')
@@ -763,7 +763,7 @@ class TSMapGenerator(object):
             xslice = slice(xmin,xmax)
             yslice = slice(ymin,ymax)
             xyrange = [range(xmin,xmax), range(ymin,ymax)]
-            
+
             map_wcs = skywcs.deepcopy()
             map_wcs.wcs.crpix[0] -= ymin
             map_wcs.wcs.crpix[1] -= xmin
@@ -773,7 +773,7 @@ class TSMapGenerator(object):
 
             xslice = slice(0,self.npix)
             yslice = slice(0,self.npix)
-            
+
         positions = []
         for i,j in itertools.product(xyrange[0],xyrange[1]):
             p = [[k//2,i,j] for k in enumbins]
@@ -795,7 +795,7 @@ class TSMapGenerator(object):
 
         ts_values = ts_values[xslice,yslice]
         amp_values = amp_values[xslice,yslice]
-            
+
         ts_map = Map(ts_values, map_wcs)
         sqrt_ts_map = Map(ts_values**0.5, map_wcs)
         npred_map = Map(amp_values*model_npred, map_wcs)
@@ -814,9 +814,9 @@ class TSMapGenerator(object):
         fits_file = utils.format_filename(self.config['fileio']['workdir'],
                                           'tsmap.fits',
                                           prefix=[prefix,modelname])
-        
+
         if write_fits:
-                        
+
             fits_utils.write_maps(ts_map,
                              {'SQRT_TS_MAP': sqrt_ts_map,
                               'NPRED_MAP': npred_map,
@@ -826,7 +826,7 @@ class TSMapGenerator(object):
 
         if write_npy:
             np.save(os.path.splitext(fits_file)[0] + '.npy', o)
-            
+
         return o
 
     def _tsmap_pylike(self, prefix, **kwargs):
@@ -898,7 +898,7 @@ class TSMapGenerator(object):
 
         outfile = os.path.join(self.config['fileio']['workdir'], 'tsmap.fits')
         utils.write_fits_image(data, w, outfile)
-    
+
 class TSCubeGenerator(object):
 
     def tscube(self,  prefix='', **kwargs):
@@ -925,28 +925,28 @@ class TSCubeGenerator(object):
 
         do_sed : bool
            Compute the energy bin-by-bin fits.
-        
+
         nnorm : int
            Number of points in the likelihood v. normalization scan.
 
         norm_sigma : float
            Number of sigma to use for the scan range.
-        
+
         tol : float        
            Critetia for fit convergence (estimated vertical distance
            to min < tol ).
-        
+
         tol_type : int
            Absoulte (0) or relative (1) criteria for convergence.
-        
+
         max_iter : int
            Maximum number of iterations for the Newton's method fitter
-        
+
         remake_test_source : bool
            If true, recomputes the test source image (otherwise just shifts it)
-        
+
         st_scan_level : int
-           
+
         make_plots : bool
            Write image files.
 
@@ -955,7 +955,7 @@ class TSCubeGenerator(object):
 
         Returns
         -------
-        
+
         maps : dict
            A dictionary containing the `~fermipy.skymap.Map` objects
            for TS and source amplitude.
@@ -966,7 +966,7 @@ class TSCubeGenerator(object):
 
         config = copy.deepcopy(self.config['tscube'])
         config = utils.merge_dict(config,kwargs,add_new_keys=True)
-        
+
         make_plots = kwargs.get('make_plots', True)
         maps = self._make_ts_cube(prefix, config, **kwargs)
 
@@ -974,24 +974,24 @@ class TSCubeGenerator(object):
             plotter = plotting.AnalysisPlotter(self.config['plotting'],
                                                fileio=self.config['fileio'],
                                                logging=self.config['logging'])
-            
+
             plotter.make_tsmap_plots(self, maps, suffix='tscube')
-            
+
         self.logger.info("Finished TS cube")
         return maps
-        
+
     def _make_ts_cube(self, prefix, config, **kwargs):
 
         write_fits = kwargs.get('write_fits', True)
         skywcs = kwargs.get('wcs',self._skywcs)
         npix = kwargs.get('npix',self.npix)
-        
+
         galactic = wcs_utils.is_galactic(skywcs)
         ref_skydir = wcs_utils.wcs_to_skydir(skywcs)
         refdir = pyLike.SkyDir(ref_skydir.ra.deg,
                                ref_skydir.dec.deg)
         pixsize = np.abs(skywcs.wcs.cdelt[0])
-        
+
         skyproj = pyLike.FitScanner.buildSkyProj(str("AIT"),
                                                  refdir, pixsize, npix,
                                                  galactic)
@@ -1004,7 +1004,7 @@ class TSCubeGenerator(object):
         xpix, ypix = (np.round((self.npix - 1.0) / 2.),
                       np.round((self.npix - 1.0) / 2.))
         skydir = wcs_utils.pix_to_skydir(xpix, ypix, skywcs)
-            
+
         src_dict['ra'] = skydir.ra.deg
         src_dict['dec'] = skydir.dec.deg
         src_dict.setdefault('SpatialModel', 'PointSource')
@@ -1012,9 +1012,9 @@ class TSCubeGenerator(object):
         src_dict.setdefault('Index', 2.0)
         src_dict.setdefault('Prefactor', 1E-13)
         src_dict['name'] = 'tscube_testsource'
-        
+
         src = Source.create_from_dict(src_dict)
-        
+
         modelname = utils.create_model_name(src)
 
         optFactory = pyLike.OptimizerFactory_instance()        
@@ -1026,9 +1026,9 @@ class TSCubeGenerator(object):
                                        npix, npix)
 
         pylike_src.spectrum().normPar().setBounds(0,1E6)
-        
+
         fitScanner.setTestSource(pylike_src)
-        
+
         self.logger.info("Running tscube")
         outfile = utils.format_filename(self.config['fileio']['workdir'],
                                         'tscube.fits',
@@ -1064,13 +1064,13 @@ class TSCubeGenerator(object):
                                   config['tol'], config['max_iter'],
                                   config['tol_type'], config['remake_test_source'],
                                   config['st_scan_level'])
-        
+
         self.logger.info("Writing FITS output")
-                                        
+
         fitScanner.writeFitsFile(str(outfile), str("gttscube"))
 
         convert_tscube(str(outfile),str(outfile))
-        
+
         tscube = castro.TSCube.create_from_fits(outfile)
         ts_map = tscube.tsmap        
         norm_map = tscube.normmap
@@ -1082,7 +1082,7 @@ class TSCubeGenerator(object):
         sqrt_ts_map = copy.deepcopy(ts_map)
         sqrt_ts_map._counts = np.abs(sqrt_ts_map._counts)**0.5
 
-        
+
         o = {'name': '%s_%s' % (prefix, modelname),
              'src_dict': copy.deepcopy(src_dict),
              'file': os.path.basename(outfile),
@@ -1093,7 +1093,7 @@ class TSCubeGenerator(object):
              'config' : config,
              'tscube' : tscube
              }
-       
+
 
         self.logger.info("Done")
         return o

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -59,7 +59,7 @@ def load_data(infile, workdir=None):
     else:
         raise Exception('Unrecognized extension.')
 
-    
+
 def resolve_path(path, workdir=None):
     if os.path.isabs(path):
         return path
@@ -67,7 +67,7 @@ def resolve_path(path, workdir=None):
         return os.path.abspath(path)
     else:
         return os.path.join(workdir, path)
-            
+
 
 def collect_dirs(path, max_depth=1, followlinks=True):
     """Recursively find directories under the given path."""
@@ -96,13 +96,13 @@ def collect_dirs(path, max_depth=1, followlinks=True):
             o += collect_dirs(subdir,max_depth=max_depth-1)
 
     return list(set(o))
-        
+
 
 def match_regex_list(patterns, string):
     """Perform a regex match of a string against a list of patterns.
     Returns true if the string matches at least one pattern in the
     list."""
-    
+
     for p in patterns:
 
         if re.findall(p,string):
@@ -120,7 +120,7 @@ def join_strings(strings,sep='_'):
             strings = [strings]        
         return sep.join([s for s in strings if s])
 
-    
+
 def format_filename(outdir, basename, prefix=None, extension=None):
     filename = join_strings(prefix)
     filename = join_strings([filename,basename])
@@ -141,15 +141,15 @@ def strip_suffix(filename,suffix):
         filename = re.sub(r'\.%s$'%s, '', filename)
 
     return filename
-        
+
 RA_NGP = np.radians(192.8594812065348)
 DEC_NGP = np.radians(27.12825118085622)
 L_CP = np.radians(122.9319185680026)
 
 def gal2eq(l, b):
-    
+
     global RA_NGP, DEC_NGP, L_CP
-    
+
     L_0 = L_CP - np.pi / 2.
     RA_0 = RA_NGP + np.pi / 2.
 
@@ -185,7 +185,7 @@ def gal2eq(l, b):
 def eq2gal(ra, dec):
 
     global RA_NGP, DEC_NGP, L_CP
-    
+
     L_0 = L_CP - np.pi / 2.
     RA_0 = RA_NGP + np.pi / 2.
     DEC_0 = np.pi / 2. - DEC_NGP
@@ -334,7 +334,7 @@ def create_model_name(src):
         o += '_powerlaw_%04.2f' % float(src.spectral_pars['Index']['value'])
     else:
         o += '_%s'%(src['SpectrumType'].lower())
-        
+
     return o
 
 
@@ -395,7 +395,7 @@ def find_function_root(fn, x0, xb, delta = 0.0):
 
     if x0 == xb:
         return np.nan
-    
+
     for i in range(10):
         if np.sign(fn(xb) + delta) != np.sign(fn(x0) + delta):
             break
@@ -404,7 +404,7 @@ def find_function_root(fn, x0, xb, delta = 0.0):
             xb *= 0.5
         else:
             xb *= 2.0
-            
+
     # Failed to find a root
     if np.sign(fn(xb) + delta) == np.sign(fn(x0) + delta):
         return np.nan
@@ -413,7 +413,7 @@ def find_function_root(fn, x0, xb, delta = 0.0):
         xtol = 1e-10*xb
     else:
         xtol = 1e-10*(xb+x0)
-            
+
     return brentq(lambda t: fn(t)+delta,x0, xb, xtol=xtol)
 
 
@@ -441,30 +441,30 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, delta_tol=0.05):
     delta_tol : float    
        Mask sequential points in the profile that have a
        log-likelihood differences smaller than this threshold.
-       
+
     """
 
     deltalnl = cl_to_dlnl(ul_confidence)
-    
+
     #spline = UnivariateSpline(xval, loglike, k=2, s=1E-4)
     m = np.abs(loglike[1:] - loglike[:-1]) > delta_tol
     xval = np.concatenate((xval[:1],xval[1:][m]))
     loglike = np.concatenate((loglike[:1],loglike[1:][m]))
-    
+
     spline = InterpolatedUnivariateSpline(xval, loglike, k=2)
     sd = spline.derivative()
-        
+
     imax = np.argmax(loglike)
     ilo = max(imax-2,0)
     ihi = min(imax+2,len(xval)-1)
-        
+
     # Find the peak
     x0 = xval[imax]        
 
     # Refine the peak position
     if np.sign(sd(xval[ilo])) != np.sign(sd(xval[ihi])):
         x0 = find_function_root(sd, xval[ilo], xval[ihi])
-                
+
     lnlmax = float(spline(x0))
 
     fn = lambda t: spline(t)-lnlmax
@@ -472,17 +472,17 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, delta_tol=0.05):
     ll = find_function_root(fn,x0,xval[0],deltalnl)
     err_lo = np.abs(x0 - find_function_root(fn,x0,xval[0],0.5))
     err_hi = np.abs(x0 - find_function_root(fn,x0,xval[-1],0.5))
-    
+
     if np.isfinite(err_lo):
         err = 0.5*(err_lo+err_hi)
     else:
         err = err_hi
-        
+
     o = {'x0' : x0, 'ul' : ul, 'll' : ll,
          'err_lo' : err_lo, 'err_hi' : err_hi, 'err' : err,
          'lnlmax' : lnlmax }
     return o
-    
+
 
 def poly_to_parabola(coeff):
 
@@ -515,19 +515,19 @@ def fit_parabola(z,ix,iy,dpix=2,zmin=None):
 
     ymin = max(0,iy-dpix)
     ymax = min(z.shape[1],iy+dpix+1)
-    
+
     sx = slice(xmin,xmax)
     sy = slice(ymin,ymax)
 
     nx = sx.stop-sx.start
     ny = sy.stop-sy.start
-    
+
     x = np.arange(sx.start,sx.stop)
     y = np.arange(sy.start,sy.stop)
 
     x = x[:,np.newaxis]*np.ones((nx,ny))
     y = y[np.newaxis,:]*np.ones((nx,ny))
-        
+
     coeffx = poly_to_parabola(np.polyfit(np.arange(sx.start,sx.stop),z[sx,iy],2))
     coeffy = poly_to_parabola(np.polyfit(np.arange(sy.start,sy.stop),z[ix,sy],2))
     p0 = [coeffx[2], coeffx[0], coeffy[0], coeffx[1], coeffy[1], 0.0]
@@ -536,7 +536,7 @@ def fit_parabola(z,ix,iy,dpix=2,zmin=None):
         m = z[sx,sy] > zmin
 
     o = { 'fit_success': True, 'p0' : p0 }
-    
+
     try:
         popt, pcov = scipy.optimize.curve_fit(parabola,
                                               (np.ravel(x[m]),np.ravel(y[m])),
@@ -545,11 +545,11 @@ def fit_parabola(z,ix,iy,dpix=2,zmin=None):
         popt = copy.deepcopy(p0)
         o['fit_success'] = False
 #        self.logger.error('Localization failed.', exc_info=True)
-        
+
     fm = parabola((x[m],y[m]),*popt)
     df = fm - z[sx,sy][m].flat
     rchi2 = np.sum(df**2)/len(fm)
-        
+
     o['rchi2'] = rchi2
     o['x0'] = popt[1]
     o['y0'] = popt[2]
@@ -562,10 +562,10 @@ def fit_parabola(z,ix,iy,dpix=2,zmin=None):
 
     a = max(o['sigmax'],o['sigmay'])
     b = min(o['sigmax'],o['sigmay'])
-    
+
     o['eccentricity'] = np.sqrt(1-b**2/a**2)
     o['eccentricity2'] = np.sqrt(a**2/b**2-1)
-    
+
     return o
 
 
@@ -604,7 +604,7 @@ def val_to_bin_bounded(edges, x):
 
 def extend_array(edges,binsz,lo,hi):
     """Extend an array to encompass lo and hi values."""
-    
+
     numlo = int(np.ceil((edges[0]-lo)/binsz))
     numhi = int(np.ceil((hi-edges[-1])/binsz))
 
@@ -612,13 +612,13 @@ def extend_array(edges,binsz,lo,hi):
     if numlo > 0:
         edges_lo = np.linspace(edges[0]-numlo*binsz, edges[0], numlo+1)
         edges = np.concatenate((edges_lo[:-1],edges))
-        
+
     if numhi > 0:
         edges_hi = np.linspace(edges[-1],edges[-1]+numhi*binsz,numhi+1)
         edges = np.concatenate((edges,edges_hi[1:]))
 
     return edges
-        
+
 
 def mkdir(dir):
     if not os.path.exists(dir):
@@ -666,7 +666,7 @@ def unicode_to_str(args):
 def isstr(s):
     """String instance testing method that works under both Python 2.X
     and 3.X.  Returns true if the input is a string."""
-    
+
     try:
         return isinstance(s, basestring)
     except NameError:
@@ -677,7 +677,7 @@ def xmlpath_to_path(path):
 
     if path is None:
         return path
-    
+
     return re.sub(r'\$\(([a-zA-Z\_]+)\)',r'$\1',path)
 
 
@@ -685,10 +685,10 @@ def path_to_xmlpath(path):
 
     if path is None:
         return path
-    
+
     return re.sub(r'\$([a-zA-Z\_]+)', r'$(\1)', path)
 
-    
+
 def create_xml_element(root, name, attrib):
     el = et.SubElement(root, name)
     for k, v in attrib.iteritems():
@@ -696,10 +696,10 @@ def create_xml_element(root, name, attrib):
         if isinstance(v,bool):
             el.set(k,str(int(v)))
         elif isstr(v):
-             el.set(k, v)
+            el.set(k, v)
         elif np.isfinite(v):        
             el.set(k, str(v))
-            
+
     return el
 
 
@@ -737,7 +737,7 @@ def update_keys(input_dict,key_map):
             o[k] = update_keys(v,key_map)
         else:
             o[k] = v
-            
+
     return o
 
 def merge_dict(d0, d1, add_new_keys=False, append_arrays=False):
@@ -748,10 +748,10 @@ def merge_dict(d0, d1, add_new_keys=False, append_arrays=False):
     ----------
     d0 : dict
        The input dictionary.
-    
+
     d1 : dict
        Dictionary to be merged with the input dictionary.
-    
+
     add_new_keys : str
        Do not skip keys that only exist in d1.
 
@@ -884,7 +884,7 @@ def extract_mapcube_region(infile, skydir, outfile, maphdu=0):
 
     infile : str
         Path to mapcube file.
-    
+
     skydir : `~astropy.coordinates.SkyCoord`
 
     """
@@ -1093,7 +1093,7 @@ def make_gaussian_kernel(sigma, npix=501, cdelt=0.01, xpix=0.0, ypix=0.0):
 
 def make_disk_kernel(sigma, npix=501, cdelt=0.01, xpix=0.0, ypix=0.0):
     """Make kernel for a 2D disk.
-    
+
     Parameters
     ----------
 
@@ -1118,7 +1118,7 @@ def make_cdisk_kernel(psf, sigma, npix, cdelt, xpix, ypix, normalize=False):
     ----------
 
     psf : `~fermipy.irfs.PSFModel`
-    
+
     sigma : float
       68% containment radius in degrees.
     """
@@ -1137,7 +1137,7 @@ def make_cdisk_kernel(psf, sigma, npix, cdelt, xpix, ypix, normalize=False):
 
     if normalize:
         k /= (np.sum(k,axis=0)[np.newaxis,...] * np.radians(cdelt) ** 2)
-        
+
     return k
 
 
@@ -1148,7 +1148,7 @@ def make_cgauss_kernel(psf, sigma, npix, cdelt, xpix, ypix, normalize=False):
     ----------
 
     psf : `~fermipy.irfs.PSFModel`
-    
+
     sigma : float
       68% containment radius in degrees.
     """
@@ -1164,7 +1164,7 @@ def make_cgauss_kernel(psf, sigma, npix, cdelt, xpix, ypix, normalize=False):
     k = np.zeros((len(egy), npix, npix))
 
     logpsf = np.log10(psf.val)
-    
+
     for i in range(len(egy)):
         fn = lambda t: 10 ** np.interp(t, dtheta, logpsf[:, i])
         psfc = convolve2d_gauss(fn, dtheta, sigma)
@@ -1187,18 +1187,18 @@ def make_psf_kernel(psf, npix, cdelt, xpix, ypix, normalize=False):
 
     npix : int
         Number of pixels in X and Y dimensions.
-    
+
     cdelt : float
         Pixel size in degrees.
-    
+
     """
-     
+
     dtheta = psf.dtheta
     egy = psf.energies
 
     x = make_pixel_offset(npix, xpix, ypix)
     x *= cdelt
-    
+
     k = np.zeros((len(egy), npix, npix))
     for i in range(len(egy)):
         k[i] = 10 ** np.interp(np.ravel(x), dtheta,
@@ -1206,7 +1206,7 @@ def make_psf_kernel(psf, npix, cdelt, xpix, ypix, normalize=False):
 
     if normalize:
         k /= (np.sum(k,axis=0)[np.newaxis,...] * np.radians(cdelt) ** 2)
-         
+
     return k
 
 

--- a/fermipy/version.py
+++ b/fermipy/version.py
@@ -43,7 +43,7 @@ _commit_info = '$Format:%cd by %aN$'
 _commit_hash = '$Format: %h$'
 
 def capture_output(cmd,dirname):
-    
+
     p = subprocess.Popen(cmd,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
@@ -51,7 +51,7 @@ def capture_output(cmd,dirname):
     p.stderr.close()
 
     output = p.stdout.readlines()
-    
+
     if not output: return None
     else: return  output[0].strip()
 
@@ -66,7 +66,7 @@ def render_pep440(vcs):
         return tags[0]
     else:
         return tags[0] + '+' + '.'.join(tags[1:])
-        
+
 def call_git_describe(abbrev=4):
 
     dirname = os.path.abspath(os.path.dirname(__file__))
@@ -95,7 +95,7 @@ def read_release_keywords(keyword):
     tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
     if not tags: return None
     return sorted(tags)[-1]
-        
+
 def read_release_version():
 
     import re

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -27,7 +27,7 @@ class WCSProj(object):
 
         xindex = 0
         yindex = 1
-        
+
         self._width = np.array([cdelt0*self._npix[xindex],
                                 cdelt1*self._npix[yindex]])
         self._pix_center = np.array([(self._npix[xindex]-1.0)/2.,
@@ -36,7 +36,7 @@ class WCSProj(object):
         self._skydir = SkyCoord.from_pixel(self._pix_center[0],
                                            self._pix_center[1],
                                            self.wcs)
-        
+
     @property
     def wcs(self):
         return self._wcs
@@ -44,7 +44,7 @@ class WCSProj(object):
     @property
     def coordsys(self):
         return self._coordsys
-    
+
     @property
     def skydir(self):
         """Return the sky coordinate of the image center."""
@@ -54,7 +54,7 @@ class WCSProj(object):
     def width(self):
         """Return the dimensions of the image."""
         return self._width
-    
+
     @property
     def npix(self):
         return self._npix
@@ -77,7 +77,7 @@ class WCSProj(object):
                           ndmin=1)
         deltay = np.array((ypix-self._pix_center[1])*self._pix_size[1],
                           ndmin=1)
-        
+
         deltax = np.abs(deltax) - 0.5*self._width[0]
         deltay = np.abs(deltay) - 0.5*self._width[1]
 
@@ -92,7 +92,7 @@ class WCSProj(object):
         delta[(m0&mx)|(m3&my)|m1] = deltax[(m0&mx)|(m3&my)|m1]
         delta[(m0&my)|(m3&mx)|m2] = deltay[(m0&my)|(m3&mx)|m2]
         return delta
-    
+
 def create_wcs(skydir, coordsys='CEL', projection='AIT',
                cdelt=1.0, crpix=1., naxis=2, energies=None):
     """Create a WCS object.
@@ -114,10 +114,10 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
 
     naxis : 2
        Number of dimensions of the projection.  Valid inputs are 2 or 3. 
-        
+
     energies : array-like   
        Array of energies that defines the third dimension if naxis=3.
-        
+
     """
 
     w = pywcs.WCS(naxis=naxis)
@@ -165,7 +165,7 @@ def wcs_add_energy_axis(wcs,energies):
 
     energies : array-like
        Array of energies.
-    
+
     """
     if wcs.naxis != 2:
         raise Exception('wcs_add_energy_axis, input WCS naxis != 2 %i'%wcs.naxis)
@@ -203,13 +203,13 @@ def offset_to_sky(skydir, offset_lon, offset_lat,
 def sky_to_offset(skydir, lon, lat, coordsys='CEL', projection='AIT'):
     """Convert sky coordinates to a projected offset.  This function
     is the inverse of offset_to_sky."""
-    
+
     w = create_wcs(skydir, coordsys, projection)
     skycrd = np.vstack((lon, lat)).T
-    
+
     if len(skycrd) == 0:
         return skycrd
-    
+
     return w.wcs_world2pix(skycrd, 0)
 
 
@@ -239,7 +239,7 @@ def skydir_to_pix(skydir, wcs):
     -------
     xp, yp : `numpy.ndarray`
        The pixel coordinates
-    
+
     """
     if len(skydir.shape) > 0 and len(skydir) == 0:
         return [np.empty(0),np.empty(0)]
@@ -255,15 +255,15 @@ def pix_to_skydir(xpix, ypix, wcs):
     Parameters
     ----------
     xpix : `numpy.ndarray`
-    
+
     ypix : `numpy.ndarray`
 
     wcs : `~astropy.wcs.WCS`
-    
+
     """
     xpix = np.array(xpix)
     ypix = np.array(ypix)
-    
+
     if xpix.ndim > 0 and len(xpix) == 0:
         return SkyCoord(np.empty(0),np.empty(0),unit='deg',
                         frame='icrs')
@@ -280,12 +280,12 @@ def get_coordsys(wcs):
     else:
         raise Exception('Unrecognized WCS coordinate system.')
 
-    
+
 def get_target_skydir(config,ref_skydir=None):
-    
+
     if ref_skydir is None:
         ref_skydir = SkyCoord(0.0,0.0,unit=u.deg)
-    
+
     radec = config.get('radec', None)
 
     if utils.isstr(radec):
@@ -308,18 +308,18 @@ def get_target_skydir(config,ref_skydir=None):
 
     offset_ra = config.get('offset_ra', None)
     offset_dec = config.get('offset_dec', None)
-    
+
     if offset_ra is not None and offset_dec is not None:
         return offset_to_skydir(ref_skydir, offset_ra, offset_dec,
                                 coordsys='CEL')[0]
 
     offset_glon = config.get('offset_glon', None)
     offset_glat = config.get('offset_glat', None)
-    
+
     if offset_glon is not None and offset_glat is not None:
         return offset_to_skydir(ref_skydir, offset_glon, offset_glat,
                                 coordsys='GAL')[0].transform_to('icrs')
-        
+
     return ref_skydir
 
 
@@ -351,7 +351,7 @@ def wcs_to_coords(w, shape):
         z, y, x = wcs_to_axes(w,shape)
     else:
         raise Exception("Wrong number of WCS axes %i"%w.naxis)
-    
+
     x = 0.5*(x[1:] + x[:-1])
     y = 0.5*(y[1:] + y[:-1])
 
@@ -364,7 +364,7 @@ def wcs_to_coords(w, shape):
     x = np.ravel(np.ones(shape)*x[:,np.newaxis,np.newaxis])
     y = np.ravel(np.ones(shape)*y[np.newaxis,:,np.newaxis])       
     z = np.ravel(np.ones(shape)*z[np.newaxis,np.newaxis,:])
-         
+
     return np.vstack((x,y,z))    
 
 


### PR DESCRIPTION
This PR does some code style cleanup, replacing tabs with spaces.
Actually these mixed tabs / spaces were generating errors on Python 3, there it's not just a stylistic thing.

I'll do other cleanup / fixes, but since this diff is so large I didn't want to add in other stuff.
This should be a safe change, i.e. `autopep8` will never introduce bugs.

I used this command:
autopep8 . --recursive --select=E101,E121 --in-place

Following the advice here:
http://stackoverflow.com/a/26643477/498873