### PR TITLE
Remove unused imports

### DIFF
--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -13,30 +13,18 @@ or the mass and cross-section of a putative dark matter particle.
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import copy
-import logging
-import os
-
 import numpy as np
 from scipy.interpolate import UnivariateSpline, splrep, splev
 import scipy.optimize as opt
-import scipy.special as spf
-from scipy.integrate import quad
 import scipy
 
-import astropy.io.fits as pf
-from astropy.coordinates import SkyCoord
-from astropy.table import Table, Column
+from astropy.table import Table
 
-import fermipy.utils as utils
-import fermipy.roi_model as roi_model
 import fermipy.sourcefind as sourcefind
 
 from fermipy.wcs_utils import wcs_add_energy_axis
-from fermipy.fits_utils import read_energy_bounds, read_spectral_data
 from fermipy.skymap import read_map_from_fits, Map
-from fermipy.logger import Logger
-from fermipy.sourcefind import find_peaks, refine_peak
+from fermipy.sourcefind import find_peaks
 from fermipy.spectrum import SpectralFunction
 
 # Some useful functions

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -2,15 +2,12 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import os
-import copy
 import numpy as np
 
 import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
 
 import fermipy
-import fermipy.utils as utils
-import fermipy.wcs_utils as wcs_utils
 from fermipy.hpx_utils import HPX
 
 
@@ -128,4 +125,4 @@ def write_tables_to_fits(filepath,tablelist,clobber=False,
     pyfits.HDUList(outhdulist).writeto(filepath,clobber=clobber)
     for rm in rmlist:
         os.unlink(rm)
-        
+

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import os
-import re
 import copy
 import shutil
 import collections
@@ -11,21 +10,17 @@ import tempfile
 import filecmp
 
 import numpy as np
-import scipy
-import scipy.optimize
 
 # pyLikelihood needs to be imported before astropy to avoid CFITSIO
 # header error
 import pyLikelihood as pyLike
 import astropy.io.fits as pyfits
-from astropy.coordinates import SkyCoord
 
 import fermipy
 import fermipy.defaults as defaults
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.gtutils as gtutils
-import fermipy.fits_utils as fits_utils
 import fermipy.srcmap_utils as srcmap_utils
 import fermipy.skymap as skymap
 import fermipy.plotting as plotting
@@ -34,11 +29,11 @@ import fermipy.sed as sed
 from fermipy.residmap import ResidMapGenerator
 from fermipy.tsmap import TSMapGenerator, TSCubeGenerator
 from fermipy.sourcefind import SourceFinder
-from fermipy.utils import merge_dict, tolist
+from fermipy.utils import merge_dict
 from fermipy.utils import create_hpx_disk_region_string
 from fermipy.skymap import Map, HpxMap
 from fermipy.hpx_utils import HPX
-from fermipy.roi_model import ROIModel, Model
+from fermipy.roi_model import ROIModel
 from fermipy.logger import Logger, log_level
 
 # pylikelihood

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -20,7 +20,6 @@ import astropy.wcs as pywcs
 from astropy.coordinates import SkyCoord
 from astropy.coordinates import Galactic, ICRS
 
-import fermipy.utils as utils
 
 # This is an approximation of the size of HEALPix pixels (in degrees) 
 # for a particular order.   It is used to convert from HEALPix to WCS-based

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -13,22 +13,19 @@ except KeyError:
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
-from matplotlib.patches import Circle, Ellipse, Rectangle
+from matplotlib.patches import Circle, Ellipse
 from matplotlib.colors import LogNorm, Normalize, PowerNorm
 
 import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
 from astropy.coordinates import SkyCoord
-import wcsaxes
 import numpy as np
 
 import fermipy
 import fermipy.config
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
-import fermipy.fits_utils as fits_utils
 import fermipy.defaults as defaults
-import fermipy.roi_model as roi_model
 import fermipy.catalog as catalog
 from fermipy.utils import merge_dict
 from fermipy.skymap import Map, HpxMap

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -5,14 +5,11 @@ import copy
 import os
 import numpy as np
 import scipy.signal
-import fermipy.config
-import fermipy.defaults as defaults
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.fits_utils as fits_utils
 import fermipy.plotting as plotting
 from fermipy.skymap import Map
-from fermipy.logger import Logger
 
 
 def poisson_lnl(nc, mu):

--- a/fermipy/scripts/clone_configs.py
+++ b/fermipy/scripts/clone_configs.py
@@ -1,8 +1,6 @@
 import os
 import copy
 import yaml
-import numpy as np
-import healpy as hp
 import fermipy.utils as utils
 import argparse
 import subprocess

--- a/fermipy/scripts/cluster_sources.py
+++ b/fermipy/scripts/cluster_sources.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 
-import os
 import sys
-import collections
 import argparse
 import yaml
 
 import numpy as np
 
-import astropy.io.fits as pyfits
-from astropy.table import Table, Column
+from astropy.table import Table
 from scipy.sparse import csgraph
 
 

--- a/fermipy/scripts/collect_sources.py
+++ b/fermipy/scripts/collect_sources.py
@@ -3,12 +3,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import collections
 import argparse
 
 import numpy as np
 
-import astropy.io.fits as pyfits
 from astropy.table import Table, Column, vstack
 
 from fermipy.roi_model import ROIModel

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -4,9 +4,7 @@ import sys
 import time, os, stat
 import datetime
 import argparse
-import glob
 import pprint
-import yaml
 
 import fermipy.utils as utils
 from fermipy.batch import check_log, get_lsf_status

--- a/fermipy/sed.py
+++ b/fermipy/sed.py
@@ -14,29 +14,16 @@ import logging
 import os
 
 import numpy as np
-from scipy.interpolate import UnivariateSpline, splrep, splev
-import scipy.optimize as opt
-import scipy.special as spf
-from scipy.integrate import quad
-import scipy
 
 import pyLikelihood as pyLike
 
 import astropy.io.fits as pyfits
-from astropy.coordinates import SkyCoord
 from astropy.table import Table, Column
 
 import fermipy.config
-import fermipy.defaults as defaults
 import fermipy.utils as utils
 import fermipy.gtutils as gtutils
 import fermipy.roi_model as roi_model
-from fermipy.wcs_utils import wcs_add_energy_axis
-from fermipy.fits_utils import read_energy_bounds, read_spectral_data
-from fermipy.skymap import read_map_from_fits, Map
-from fermipy.logger import Logger
-from fermipy.sourcefind import find_peaks, refine_peak
-from fermipy.spectrum import SpectralFunction
 
 from LikelihoodState import LikelihoodState
 

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -6,7 +6,6 @@ import numpy as np
 
 import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
-from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 import fermipy.utils as utils

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -11,11 +11,9 @@ from scipy.ndimage.filters import maximum_filter
 from astropy.coordinates import SkyCoord
 
 import fermipy.config
-import fermipy.defaults as defaults
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 from fermipy.skymap import Map
-from fermipy.logger import Logger
 
 from LikelihoodState import LikelihoodState
 

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import, division, print_function, \
 
 import numpy as np
 
-from astropy.coordinates import SkyCoord
 import astropy.io.fits as pyfits
-import astropy.wcs as pywcs
 
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -5,16 +5,11 @@
 Utilities to fit dark matter spectra to castro data
 """
 
-import os
 import numpy as np
-import collections
 
-from scipy.integrate import quad
-from scipy.interpolate import UnivariateSpline
 import scipy.stats as stats
 import scipy.optimize as opt
 
-from fermipy import spectrum
 from fermipy import castro
 
 

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import pytest
 import os
 
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from numpy.testing import assert_allclose
-import astropy.units as u
 import numpy as np
 from .. import gtanalysis
-from .. import utils
 from .. import spectrum
 import pytest
 import os

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -5,7 +5,7 @@ import os
 import copy
 import itertools
 import functools
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 
 import numpy as np
 import warnings
@@ -16,8 +16,6 @@ import astropy.io.fits as pyfits
 from astropy.table import Table
 import astropy.wcs as pywcs
 
-import fermipy.config
-import fermipy.defaults as defaults
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.fits_utils as fits_utils
@@ -25,9 +23,7 @@ import fermipy.plotting as plotting
 import fermipy.castro as castro
 from fermipy.skymap import Map
 from fermipy.roi_model import Source
-from fermipy.logger import Logger
 
-import fermipy.sed as sed
 from fermipy.spectrum import PowerLaw
 
 MAX_NITER = 100

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -10,8 +10,6 @@ import yaml
 import numpy as np
 import scipy
 import xml.etree.cElementTree as et
-from astropy import units as u
-from astropy.coordinates import SkyCoord
 import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
 from scipy.interpolate import UnivariateSpline, InterpolatedUnivariateSpline

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -2,10 +2,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import copy
 import numpy as np
 
-import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
 from astropy import units as u
 from astropy.coordinates import SkyCoord


### PR DESCRIPTION
This PR removes unused imports.

This is a first tiny step towards making it easier to see which module in Fermipy depends on which other module, with the end goal of being able to extract things like `hpx_utils` and `skymap`.