### PR TITLE
Fix parabola function call for Python 3

### DIFF
--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -556,8 +556,8 @@ class SourceFinder(object):
         o.update(scan_fit)
 
 #        lnlscan['dloglike_fit'] = \
-#            utils.parabola((np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
-#                            np.linspace(0,nstep-1.0,nstep)[np.newaxis,:]),
+#            utils.parabola(np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
+#                           np.linspace(0,nstep-1.0,nstep)[np.newaxis,:],
 #                           *scan_fit['popt']).reshape((nstep,nstep))
 
         o['lnlscan'] = lnlscan
@@ -745,8 +745,8 @@ class SourceFinder(object):
         sigmay = 2.**0.5*scan_fit['sigmay']*scan_step
 
         lnlscan['dloglike_fit'] = \
-            utils.parabola((np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
-                            np.linspace(0,nstep-1.0,nstep)[np.newaxis,:]),
+            utils.parabola(np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
+                           np.linspace(0,nstep-1.0,nstep)[np.newaxis,:],
                            *scan_fit['popt']).reshape((nstep,nstep))
 
         o['lnlscan'] = lnlscan

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -490,7 +490,7 @@ def poly_to_parabola(coeff):
     return x0, sigma, y0
 
 
-def parabola((x, y), amplitude, x0, y0, sx, sy, theta):
+def parabola(x, y, amplitude, x0, y0, sx, sy, theta):
     cth = np.cos(theta)
     sth = np.sin(theta)
     a = (cth ** 2) / (2 * sx ** 2) + (sth ** 2) / (2 * sy ** 2)
@@ -536,14 +536,14 @@ def fit_parabola(z,ix,iy,dpix=2,zmin=None):
 
     try:
         popt, pcov = scipy.optimize.curve_fit(parabola,
-                                              (np.ravel(x[m]),np.ravel(y[m])),
+                                              np.ravel(x[m]),np.ravel(y[m]),
                                               np.ravel(z[sx,sy][m]), p0)
     except Exception:
         popt = copy.deepcopy(p0)
         o['fit_success'] = False
 #        self.logger.error('Localization failed.', exc_info=True)
 
-    fm = parabola((x[m],y[m]),*popt)
+    fm = parabola(x[m],y[m],*popt)
     df = fm - z[sx,sy][m].flat
     rchi2 = np.sum(df**2)/len(fm)
 


### PR DESCRIPTION
This is an attempt to fix this SyntaxError on Python 3
```
$ python -c 'import fermipy.utils'
No module named 'version'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/deil/code/fermipy/fermipy/utils.py", line 493
    def parabola((x, y), amplitude, x0, y0, sx, sy, theta):
                 ^
SyntaxError: invalid syntax
```

A small step towards making import work on Python 3 (see #42)

@woodmd  - Please have a look. I'm not sure if this code is under test or if this fix is correct.
