### PR TITLE
Improve setup.py and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,14 @@ matrix:
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
                CONDA2='conda install -c openastronomy healpy wcsaxes'
 
-        # Python 3, no Fermi ST, only the required dependencies
-        - os: linux
-          env: PYTHON_VERSION=3.5
-               ST_INSTALL=''
-               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS=''
-               CONDA2=''
+#        # Python 3, no Fermi ST, only the required dependencies
+#        # TODO: This isn't working yet, need to handle imports for opt deps more carefully
+#        - os: linux
+#          env: PYTHON_VERSION=3.5
+#               ST_INSTALL=''
+#               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+#               CONDA_DEPS=''
+#               CONDA2=''
 
 
 # Setup anaconda and install packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,15 @@ install:
 #  - python setup.py install
 #  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib astropy 
 #  - pip install healpy
- 
+
+  # This is needed to make matplotlib plot testing work
+  - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+        export DISPLAY=:99.0;
+        sh -e /etc/init.d/xvfb start;
+        export QT_API=pyqt;
+    fi
+
+
 # Run test
 script:
   - py.test -vv -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
-               CONDA_DEPS2='healpy wcsaxes'
+               CONDA2='conda install -c openastronomy healpy wcsaxes'
 
         # Python 3, no Fermi ST, all other dependencies
         - os: linux
@@ -22,7 +22,7 @@ matrix:
                ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
-               CONDA_DEPS2=''
+               CONDA2='conda install -c openastronomy healpy wcsaxes'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
@@ -30,7 +30,7 @@ matrix:
                ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
-               CONDA_DEPS2=''
+               CONDA2='conda install -c openastronomy healpy wcsaxes'
 
         # Python 3, no Fermi ST, only the required dependencies
         - os: linux
@@ -38,7 +38,7 @@ matrix:
                ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS=''
-               CONDA_DEPS2=''
+               CONDA2=''
 
 
 # Setup anaconda and install packages
@@ -51,7 +51,7 @@ install:
   - conda info -a
   - conda create -q -n fermi-env python=$PYTHON_VERSION numpy astropy pytest $CONDA_DEPS
   - source activate fermi-env
-  - conda install -c openastronomy $CONDA_DEPS2
+  - $CONDA2
 #  - pip install healpy
   - python setup.py install
   - $ST_INSTALL # Download and install the ST binaries

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,38 @@ notifications:
 matrix:
     include:
 
+        # The main build:
+        # Python 2, Fermi ST, all dependencies
         - os: linux
           env: PYTHON_VERSION=2.7
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
+               ST_INSTALL='bash stinstall.sh force'
+               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS2='healpy wcsaxes'
+
+        # Python 3, no Fermi ST, all other dependencies
         - os: linux
           env: PYTHON_VERSION=3.5
+               ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS2=''
+
+        # Python 2, no Fermi ST, all other dependencies
+        - os: linux
+          env: PYTHON_VERSION=2.7
+               ST_INSTALL=''
+               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS2=''
+
+        # Python 3, no Fermi ST, only the required dependencies
+        - os: linux
+          env: PYTHON_VERSION=3.5
+               ST_INSTALL=''
+               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+               CONDA_DEPS=''
+               CONDA_DEPS2=''
 
 
 # Setup anaconda and install packages
@@ -23,12 +49,12 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n fermi-env python=$PYTHON_VERSION numpy scipy matplotlib astropy pytest pyyaml
+  - conda create -q -n fermi-env python=$PYTHON_VERSION numpy astropy pytest $CONDA_DEPS
   - source activate fermi-env
-  - conda install -c openastronomy healpy wcsaxes
+  - conda install -c openastronomy $CONDA_DEPS2
 #  - pip install healpy
   - python setup.py install
-  - bash stinstall.sh force # Download and install the ST binaries
+  - $ST_INSTALL # Download and install the ST binaries
   - source travissetup.sh
   - source condasetup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,29 @@
 language: python
-
-python:
-  - 2.7
-
 sudo: false
 
 notifications:
   email: false
- 
+
+matrix:
+    include:
+
+        - os: linux
+          env: PYTHON_VERSION=2.7
+               CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
+        - os: linux
+          env: PYTHON_VERSION=3.5
+               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+
+
 # Setup anaconda and install packages
 install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n fermi-env python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib astropy pytest pyyaml
+  - conda create -q -n fermi-env python=$PYTHON_VERSION numpy scipy matplotlib astropy pytest pyyaml
   - source activate fermi-env
   - conda install -c openastronomy healpy wcsaxes
 #  - pip install healpy

--- a/fermipy/batch.py
+++ b/fermipy/batch.py
@@ -3,6 +3,12 @@ from __future__ import absolute_import, division, print_function
 import os
 import subprocess
 
+__all__ = [
+    'check_log',
+    'get_lsf_status',
+    'dispatch_jobs',
+]
+
 
 def check_log(logfile, exited='Exited with exit code',
               successful='Successfully completed', exists=True):

--- a/fermipy/batch.py
+++ b/fermipy/batch.py
@@ -1,5 +1,8 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import subprocess
+
 
 def check_log(logfile, exited='Exited with exit code',
               successful='Successfully completed', exists=True):
@@ -17,16 +20,16 @@ def check_log(logfile, exited='Exited with exit code',
     elif successful in open(logfile).read():
         return 'Successful'
     else:
-        return 'None' 
+        return 'None'
+
 
 def get_lsf_status():
-
-    status_count = {'RUN' : 0,
-                    'PEND' : 0,
-                    'SUSP' : 0,
+    status_count = {'RUN': 0,
+                    'PEND': 0,
+                    'SUSP': 0,
                     'USUSP': 0,
-                    'NJOB' : 0,
-                    'UNKNWN' : 0}
+                    'NJOB': 0,
+                    'UNKNWN': 0}
 
     p = subprocess.Popen(['bjobs'],
                          stdout=subprocess.PIPE,
@@ -48,40 +51,38 @@ def get_lsf_status():
     return status_count
 
 
-def dispatch_jobs(exe,args,opts,batch_opts):
+def dispatch_jobs(exe, args, opts, batch_opts):
+    batch_opts.setdefault('W', 300)
+    batch_opts.setdefault('R', 'rhel60')
 
-    batch_opts.setdefault('W',300)
-    batch_opts.setdefault('R','rhel60')
-
-    #skip_keywords = ['queue','resources','batch','W']
+    # skip_keywords = ['queue','resources','batch','W']
 
     cmd_opts = ''
     for k, v in opts.__dict__.items():
-        if isinstance(v,list):
+        if isinstance(v, list):
             continue
 
-        if isinstance(v,bool) and v:
-            cmd_opts += ' --%s '%(k)
-        elif isinstance(v,bool):
+        if isinstance(v, bool) and v:
+            cmd_opts += ' --%s ' % (k)
+        elif isinstance(v, bool):
             continue
-        elif not v is None:
-            cmd_opts += ' --%s=\"%s\" '%(k,v)
+        elif v is not None:
+            cmd_opts += ' --%s=\"%s\" ' % (k, v)
 
-#    for x in args:
-#            cmd = '%s %s '%(exe,x)
-#            batch_cmd = 'bsub -W %s -R %s '%(W,resources)
-#            batch_cmd += ' %s %s '%(cmd,cmd_opts)        
-#            print(batch_cmd)
-#            os.system(batch_cmd)
+        #    for x in args:
+        #            cmd = '%s %s '%(exe,x)
+        #            batch_cmd = 'bsub -W %s -R %s '%(W,resources)
+        #            batch_cmd += ' %s %s '%(cmd,cmd_opts)
+        #            print(batch_cmd)
+        #            os.system(batch_cmd)
 
-
-    cmd = '%s %s '%(exe,' '.join(args))
+    cmd = '%s %s ' % (exe, ' '.join(args))
 
     batch_optstr = ''
-    for k,v in batch_opts.items():
-        batch_optstr += ' -%s %s '%(k,v)
+    for k, v in batch_opts.items():
+        batch_optstr += ' -%s %s ' % (k, v)
 
-    batch_cmd = 'bsub %s '%(batch_optstr)
-    batch_cmd += ' %s %s '%(cmd,cmd_opts)        
+    batch_cmd = 'bsub %s ' % (batch_optstr)
+    batch_cmd += ' %s %s ' % (cmd, cmd_opts)
     print(batch_cmd)
-    #os.system(batch_cmd)
+    # os.system(batch_cmd)

--- a/fermipy/batch.py
+++ b/fermipy/batch.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import subprocess
 

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for dealing with 'castro data', i.e., 2D table of
 likelihood values.
 
@@ -10,13 +11,10 @@ other variables, such as the Flux normalization and the spectral
 index, or the mass and cross-section of a putative dark matter
 particle.
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from scipy.interpolate import UnivariateSpline, splrep, splev
-import scipy
 
 from astropy.table import Table
 import astropy.units as u

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -11,7 +11,7 @@ other variables, such as the Flux normalization and the spectral
 index, or the mass and cross-section of a putative dark matter
 particle.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import numpy as np
 from astropy.table import Table
 import astropy.units as u

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -12,26 +12,22 @@ index, or the mass and cross-section of a putative dark matter
 particle.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
-from scipy.interpolate import UnivariateSpline, splrep, splev
-
 from astropy.table import Table
 import astropy.units as u
-
 from fermipy.wcs_utils import wcs_add_energy_axis
 from fermipy.skymap import read_map_from_fits, Map
 from fermipy.sourcefind_utils import fit_error_ellipse
 from fermipy.sourcefind_utils import find_peaks
 from fermipy.spectrum import SpectralFunction
 
-# Some useful functions
-
 FluxTypes = ['NORM', 'FLUX', 'EFLUX', 'NPRED', 'DFDE', 'EDFDE']
 
-PAR_NAMES = {"PowerLaw": ["Prefactor", "Index"],
-             "LogParabola": ["norm", "alpha", "beta"],
-             "PLExpCutoff": ["Prefactor", "Index1", "Cutoff"]}
+PAR_NAMES = {
+    "PowerLaw": ["Prefactor", "Index"],
+    "LogParabola": ["norm", "alpha", "beta"],
+    "PLExpCutoff": ["Prefactor", "Index1", "Cutoff"],
+}
 
 
 class Interpolator(object):
@@ -44,6 +40,7 @@ class Interpolator(object):
     def __init__(self, x, y):
         """ C'tor, take input array of x and y value         
         """
+        from scipy.interpolate import UnivariateSpline, splrep
 
         x = np.squeeze(np.array(x, ndmin=1))
         y = np.squeeze(np.array(y, ndmin=1))
@@ -94,6 +91,8 @@ class Interpolator(object):
         x   : the inputs        
         der : the order of derivative         
         """
+        from scipy.interpolate import splev
+
         return splev(x, self._sp, der=der)
 
     def __call__(self, x):
@@ -177,24 +176,26 @@ class LnLFn(object):
         return self._norm_type
 
     def _compute_mle(self):
-        """compute the maximum likelihood estimate.  By using the
-        scipy.optimize.brentq method to find the roots of the
-        derivative.
+        """Compute the maximum likelihood estimate.
 
+        Calls `scipy.optimize.brentq` to find the roots of the derivative.
         """
+        from scipy.optimize import brentq
         if self._interp.y[0] == np.min(self._interp.y):
             self._mle = self._interp.x[0]
         else:
             ix0 = max(np.argmin(self._interp.y) - 4, 0)
             ix1 = min(np.argmin(self._interp.y) + 4, len(self._interp.x) - 1)
 
-            while np.sign(self._interp.derivative(self._interp.x[ix0])) == np.sign(self._interp.derivative(self._interp.x[ix1])):
+            while np.sign(self._interp.derivative(self._interp.x[ix0])) == np.sign(
+                    self._interp.derivative(self._interp.x[ix1])):
                 ix0 += 1
 
-            self._mle = scipy.optimize.brentq(self._interp.derivative,
-                                              self._interp.x[
-                                                  ix0], self._interp.x[ix1],
-                                              xtol=1e-10 * np.median(self._interp.x))
+            self._mle = brentq(
+                self._interp.derivative,
+                self._interp.x[ix0], self._interp.x[ix1],
+                xtol=1e-10 * np.median(self._interp.x)
+            )
 
     def mle(self):
         """ return the maximum likelihood estimate 
@@ -226,8 +227,8 @@ class LnLFn(object):
         lnl_max = self.fn_mle()
 
         # This ultra-safe code to find an absolute maximum
-        #fmax = self.fn_mle()
-        #m = (fmax-self.interp.y > 0.1+dlnl) & (self.interp.x>self._mle)
+        # fmax = self.fn_mle()
+        # m = (fmax-self.interp.y > 0.1+dlnl) & (self.interp.x>self._mle)
 
         # if sum(m) == 0:
         #    xmax = self.interp.x[-1]*10
@@ -236,7 +237,7 @@ class LnLFn(object):
 
         # Matt has found that this is use an interpolator than an actual root-finder to
         # find the root probably b/c of python overhead
-        #rf = lambda x: self._interp(x)+dlnl-lnl_max
+        # rf = lambda x: self._interp(x)+dlnl-lnl_max
         if upper:
             x = np.linspace(self._mle, self._interp.xmax, 100)
             # return
@@ -540,9 +541,10 @@ class CastroData_Base(object):
 
         returns the best-fit normalization value
         """
+        from scipy.optimize import brentq
         fDeriv = lambda x: self.derivative(specVals * x)
         try:
-            result = scipy.optimize.brentq(fDeriv, xlims[0], xlims[1])
+            result = brentq(fDeriv, xlims[0], xlims[1])
         except:
             if self.__call__(specVals * xlims[0]) < self.__call__(specVals * xlims[1]):
                 return xlims[0]
@@ -551,21 +553,23 @@ class CastroData_Base(object):
         return result
 
     def fitNorm_v2(self, specVals):
-        """Fit the normalization given a set of spectral values that define a
-        spectral shape
+        """Fit the normalization given a set of spectral values that define a spectral shape.
 
-        This version uses scipy.optimize.fmin
+        This version uses `scipy.optimize.fmin`.
 
         Parameters
         ----------
         specVals :  an array of (nebin values that define a spectral shape
         xlims    :  fit limits     
 
-        returns the best-fit normalization value
-
+        Returns
+        -------
+        norm : float
+            Best-fit normalization value
         """
+        from scipy.optimize import fmin
         fToMin = lambda x: self.__call__(specVals * x)
-        result = scipy.optimize.fmin(fToMin, 0., disp=False, xtol=1e-6)
+        result = fmin(fToMin, 0., disp=False, xtol=1e-6)
         return result
 
     def fit_spectrum(self, specFunc, initPars):
@@ -587,31 +591,31 @@ class CastroData_Base(object):
         TS_spec  : float
            The TS of the best-fit spectrum
         """
+        from scipy.optimize import fmin
 
         def fToMin(x):
             return self.__call__(specFunc(x))
 
-        result = scipy.optimize.fmin(fToMin, initPars, disp=False, xtol=1e-6)
-        print(result)
+        result = fmin(fToMin, initPars, disp=False, xtol=1e-6)
         spec_out = specFunc(result)
         TS_spec = self.TS_spectrum(spec_out)
         return result, spec_out, TS_spec
 
     def TS_spectrum(self, spec_vals):
-        """ Calculate and the TS for a given set of spectral values
+        """Calculate and the TS for a given set of spectral values.
         """
         return 2. * (self._nll_null - self.__call__(spec_vals))
 
     @staticmethod
     def stack_nll(shape, components, weights=None):
-        """ Combine the log-likelihoods from a number of components.
+        """Combine the log-likelihoods from a number of components.
 
         Parameters
         ----------
         shape    :  tuple
            The shape of the return array
 
-        components : [~fermipy.castro.CastroData_Base]
+        components : `~fermipy.castro.CastroData_Base`
            The components to be stacked
 
         weights : array-like
@@ -696,53 +700,51 @@ class CastroData(CastroData_Base):
         """ Return a '~fermipy.castro.SpecData' with the spectral data """
         return self._specData
 
-
     @staticmethod
     def create_from_flux_points(txtfile):
         """Create a Castro data object from a text file containing a
         sequence of differential flux points."""
 
-        tab = Table.read(txtfile,format='ascii.ecsv')
-        dfde_unit = u.ph / (u.MeV * u.cm**2 * u.s)
+        tab = Table.read(txtfile, format='ascii.ecsv')
+        dfde_unit = u.ph / (u.MeV * u.cm ** 2 * u.s)
         loge = np.log10(np.array(tab['E_REF'].to(u.MeV)))
         norm = np.array(tab['NORM'].to(dfde_unit))
         norm_errp = np.array(tab['NORM_ERRP'].to(dfde_unit))
         norm_errn = np.array(tab['NORM_ERRN'].to(dfde_unit))
-        norm_err = 0.5*(norm_errp + norm_errn)
-        dloge = loge[1:]-loge[:-1]
-        dloge = np.insert(dloge,0,dloge[0])        
-        emin = 10**(loge-dloge*0.5)
-        emax = 10**(loge+dloge*0.5)
-        ectr = 10**loge
-        deltae = emax-emin
-        flux = norm*deltae
-        eflux = norm*deltae*ectr
-        
+        norm_err = 0.5 * (norm_errp + norm_errn)
+        dloge = loge[1:] - loge[:-1]
+        dloge = np.insert(dloge, 0, dloge[0])
+        emin = 10 ** (loge - dloge * 0.5)
+        emax = 10 ** (loge + dloge * 0.5)
+        ectr = 10 ** loge
+        deltae = emax - emin
+        flux = norm * deltae
+        eflux = norm * deltae * ectr
+
         spec_data = SpecData(emin, emax, norm, flux, eflux,
                              np.zeros(len(norm)))
 
-        xmin = norm - 3.0*norm_errn
+        xmin = norm - 3.0 * norm_errn
 
         stephi = np.linspace(0, 1, 11)
         steplo = -np.linspace(0, 1, 11)[1:][::-1]
 
-        loscale = 3*norm_err
-        hiscale = 3*norm_err
+        loscale = 3 * norm_err
+        hiscale = 3 * norm_err
         loscale[loscale > norm] = norm[loscale > norm]
-        
-        norm_vals_hi = norm[:,np.newaxis] + stephi[np.newaxis,:]*hiscale[:,np.newaxis]
-        norm_vals_lo = norm[:,np.newaxis] + steplo[np.newaxis,:]*loscale[:,np.newaxis]
 
-        delta = norm/norm_err
-        
-        norm_vals = np.hstack((norm_vals_lo,norm_vals_hi))        
-        nll_vals = 0.5*(norm_vals - norm[:,np.newaxis])**2/norm_err[:,np.newaxis]**2
+        norm_vals_hi = norm[:, np.newaxis] + stephi[np.newaxis, :] * hiscale[:, np.newaxis]
+        norm_vals_lo = norm[:, np.newaxis] + steplo[np.newaxis, :] * loscale[:, np.newaxis]
 
-        norm_vals *= flux[:,np.newaxis]/norm[:,np.newaxis]
-        
+        delta = norm / norm_err
+
+        norm_vals = np.hstack((norm_vals_lo, norm_vals_hi))
+        nll_vals = 0.5 * (norm_vals - norm[:, np.newaxis]) ** 2 / norm_err[:, np.newaxis] ** 2
+
+        norm_vals *= flux[:, np.newaxis] / norm[:, np.newaxis]
+
         return CastroData(norm_vals, nll_vals, spec_data, 'FLUX')
 
-    
     @staticmethod
     def create_from_tables(norm_type='EFLUX',
                            tab_s="SCANDATA",
@@ -1342,10 +1344,10 @@ if __name__ == "__main__":
     else:
         flux_type = sys.argv[1]
 
-    #castro_sed = CastroData.create_from_sedfile("sed.fits")
+    # castro_sed = CastroData.create_from_sedfile("sed.fits")
     castro_sed = CastroData.create_from_fits("castro.fits", irow=0)
     test_dict_sed = castro_sed.test_spectra()
-    print (test_dict_sed)
+    print(test_dict_sed)
 
     """
     tscube = TSCube.create_from_fits("tscube_test.fits",flux_type)

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from astropy import units as u

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -1,14 +1,11 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
-
 from astropy import units as u
 from astropy.table import Table, Column
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-
 import fermipy
 from fermipy import spectrum
 

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
-import yaml
 import fermipy
 from fermipy import utils
 
@@ -27,7 +26,8 @@ def create_default_config(defaults):
             if value is None and (item_type == list or item_type == dict):
                 value = item_type()
 
-            if key in o: raise Exception('Duplicate key.')
+            if key in o:
+                raise Exception('Duplicate key.')
 
             o[key] = value
         else:
@@ -61,19 +61,18 @@ def cast_config(config, defaults):
 def validate_config(config, defaults, section=None):
     for key, item in config.items():
 
-        if (key in defaults and isinstance(defaults[key],dict)
-            and not isinstance(item,dict)):
-
+        if (key in defaults and isinstance(defaults[key], dict)
+            and not isinstance(item, dict)):
             type0 = type(defaults[key])
             type1 = type(item)
 
             raise Exception('Wrong type for configuration key: '
-                            '%s\ntype: %s required type: %s'%(key,type1,type0))
+                            '%s\ntype: %s required type: %s' % (key, type1, type0))
 
         if key not in defaults:
 
             if section is None:
-                raise Exception('Invalid key in configuration: %s'%key)
+                raise Exception('Invalid key in configuration: %s' % key)
             else:
                 raise Exception('Invalid key in \'%s\' section of configuration: %s' %
                                 (section, key))
@@ -87,29 +86,30 @@ class Configurable(object):
     configuration state. """
 
     def __init__(self, config, **kwargs):
+        import yaml
 
         self._config = self.get_config()
         self._configdir = None
 
         if utils.isstr(config) and os.path.isfile(config):
             self._configdir = os.path.abspath(os.path.dirname(config))
-            config_dict = yaml.load(open(config))            
+            config_dict = yaml.load(open(config))
         elif isinstance(config, dict) or config is None:
             config_dict = config
         elif utils.isstr(config) and not os.path.isfile(config):
-            raise Exception('Invalid path to configuration file: %s'%config)
+            raise Exception('Invalid path to configuration file: %s' % config)
         else:
             raise Exception('Invalid config argument.')
 
         self.configure(config_dict, **kwargs)
 
         if self.configdir and 'fileio' in self.config and \
-                self.config['fileio']['outdir'] is None:
+                        self.config['fileio']['outdir'] is None:
             self.config['fileio']['outdir'] = self.configdir
 
     def configure(self, config, **kwargs):
 
-        validate = kwargs.pop('validate',False)        
+        validate = kwargs.pop('validate', False)
         config = utils.merge_dict(config, kwargs, add_new_keys=True)
         if validate:
             validate_config(config, self.defaults)
@@ -135,13 +135,14 @@ class Configurable(object):
         utils.write_yaml(self.config, outfile, default_flow_style=False)
 
     def print_config(self, logger, loglevel=None):
-
-        cfgstr = yaml.dump(self.config,default_flow_style=False)
+        import yaml
+        cfgstr = yaml.dump(self.config, default_flow_style=False)
 
         if loglevel is None:
             logger.debug('Configuration:\n' + cfgstr)
         else:
             logger.log(loglevel, 'Configuration:\n' + cfgstr)
+
 
 class ConfigManager(object):
     @staticmethod
@@ -170,7 +171,7 @@ class ConfigManager(object):
 
     @staticmethod
     def load(path):
-
+        import yaml
         if not os.path.isfile(path):
             path = os.path.join(fermipy.PACKAGE_ROOT, 'config', path)
 

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import fermipy
 from fermipy import utils

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import yaml
 import fermipy

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 from collections import OrderedDict
 import numpy as np

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 from collections import OrderedDict
 import numpy as np

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 import astropy.io.fits as pyfits

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -1,12 +1,9 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
-
 import astropy.io.fits as pyfits
 import astropy.wcs as pywcs
-
 import fermipy
 from fermipy.hpx_utils import HPX
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
+# Note: we don't use __future__.unicode_literals here on purpose
 import os
 import copy
 import shutil

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
-# Note: we don't use __future__.unicode_literals here on purpose
 import os
 import copy
 import shutil

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import shutil
@@ -8,14 +7,10 @@ import collections
 import logging
 import tempfile
 import filecmp
-
 import numpy as np
-
-# pyLikelihood needs to be imported before astropy to avoid CFITSIO
-# header error
+# pyLikelihood needs to be imported before astropy to avoid CFITSIO header error
 import pyLikelihood as pyLike
 from astropy.io import fits
-
 import fermipy
 import fermipy.defaults as defaults
 import fermipy.utils as utils
@@ -37,7 +32,6 @@ from fermipy.hpx_utils import HPX
 from fermipy.roi_model import ROIModel
 from fermipy.plotting import AnalysisPlotter
 from fermipy.logger import Logger, log_level
-
 # pylikelihood
 import GtApp
 import FluxDensity

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -1,9 +1,6 @@
-# pylikelihood
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
-
 import numpy as np
 import pyLikelihood as pyLike
 from SrcModel import SourceModel

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import numpy as np
 import pyLikelihood as pyLike

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -2,7 +2,7 @@
 """
 Utilities for dealing with HEALPix projections and mappings
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import re
 import healpy as hp
 import numpy as np

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -1,14 +1,11 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities for dealing with HEALPix projections and mappings
 """
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import re
-
 import healpy as hp
 import numpy as np
-
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -580,30 +580,3 @@ class HpxToWcsMapping(object):
         if normalize:
             wcs_data_flat *= self._mult_val
         wcs_data.flat = wcs_data_flat
-
-
-if __name__ == "__main__":
-
-    from fermipy.fits_utils import write_fits_image
-    from fermipy.skymap import HpxMap
-
-    n = np.ones((10, 192), 'd')
-    hpx = HPX(4, False, "GAL")
-    hpx.write_fits(n, "test_hpx.fits", clobber=True)
-
-    ebins = np.logspace(2, 5, 8)
-
-    hpx_2 = HPX(1024, False, "GAL", region="DISK(110.,75.,2.)", ebins=ebins)
-    #hpx_2 = HPX(1024,False,"GAL",region="HPX_PIXEL(RING,16,500)",ebins=ebins)
-    npixels = hpx_2.npix
-    print("Npixels", npixels)
-
-    n2 = np.ndarray((8, npixels), 'd')
-    for i in range(8):
-        n2[i].flat = np.arange(npixels)
-
-    hpx_map = HpxMap(n2, hpx_2)
-    wcs, wcs_data = hpx_map.make_wcs_from_hpx(normalize=True)
-
-    wcs_out = hpx_2.make_wcs(3)
-    write_fits_image(wcs_data, wcs_out, "test_hpx_2_wcs.fits")

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -1,4 +1,5 @@
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import glob
 import re
 import numpy as np

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import glob
 import re
 import numpy as np

--- a/fermipy/logger.py
+++ b/fermipy/logger.py
@@ -1,4 +1,5 @@
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import sys
 import logging

--- a/fermipy/logger.py
+++ b/fermipy/logger.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import sys
 import logging

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -1,14 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import os
-import matplotlib
-
-try:
-    os.environ['DISPLAY']
-except KeyError:
-    matplotlib.use('Agg')
-
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
@@ -102,8 +95,6 @@ def make_counts_spectrum_plot(o, roi, energies, imfile):
     plt.close(fig)
 
 
-
-
 def load_ds9_cmap():
     # http://tdc-www.harvard.edu/software/saoimage/saoimage.color.html
     ds9_b = {
@@ -128,18 +119,19 @@ def load_ds9_cmap():
     plt.cm.ds9_b = plt.cm.get_cmap('ds9_b')
     return plt.cm.ds9_b
 
+
 def load_bluered_cmap():
-    bluered = {'red':   ((0.0, 0.0, 0.0),
-                        (0.5, 0.0, 0.0),
-                        (1.0, 1.0, 1.0)),
+    bluered = {'red': ((0.0, 0.0, 0.0),
+                       (0.5, 0.0, 0.0),
+                       (1.0, 1.0, 1.0)),
 
                'green': ((0.0, 0.0, 0.0),
-                        (1.0, 0.0, 0.0)),
+                         (1.0, 0.0, 0.0)),
 
-               'blue':  ((0.0, 0.0, 1.0),
+               'blue': ((0.0, 0.0, 1.0),
                         (0.5, 0.0, 0.0),
                         (1.0, 0.0, 0.0))
-    }
+               }
 
     plt.register_cmap(name='bluered', data=bluered)
     plt.cm.bluered = plt.cm.get_cmap('bluered')
@@ -175,32 +167,29 @@ def annotate(**kwargs):
 
 
 class ImagePlotter(object):
-
     def __init__(self, data, proj):
 
-        if isinstance(proj,WCS):
+        if isinstance(proj, WCS):
             self._projtype = 'WCS'
             if data.ndim == 3:
                 data = np.sum(copy.deepcopy(data), axis=2)
                 proj = WCS(proj.to_header(), naxis=[1, 2])
             else:
-                data = copy.deepcopy(data)        
+                data = copy.deepcopy(data)
             self._proj = proj
-            self._wcs = proj            
-        elif isinstance(proj,hpx_utils.HPX):
+            self._wcs = proj
+        elif isinstance(proj, hpx_utils.HPX):
             self._projtype = 'HPX'
             self._proj = proj
-            self._wcs,data = proj.make_wcs_from_hpx()
+            self._wcs, data = proj.make_wcs_from_hpx()
         else:
-            raise Exception("Can't co-add map of unknown type %s"%type(proj))
+            raise Exception("Can't co-add map of unknown type %s" % type(proj))
 
         self._data = data
-
 
     @property
     def projtype(self):
         return self._projtype
-
 
     def plot(self, subplot=111, cmap='jet', **kwargs):
 
@@ -227,10 +216,10 @@ class ImagePlotter(object):
 
         fig = plt.gcf()
 
-        ax = fig.add_subplot(subplot,projection=self._wcs)
+        ax = fig.add_subplot(subplot, projection=self._wcs)
 
         load_ds9_cmap()
-        colormap = matplotlib.cm.get_cmap(cmap)
+        colormap = plt.get_cmap(cmap)
         colormap.set_under(colormap(0))
 
         data = copy.copy(self._data)
@@ -242,8 +231,8 @@ class ImagePlotter(object):
 
         if kwargs_contour['levels']:
             cs = ax.contour(data.T, **kwargs_contour)
-            cs.levels = ['%.0f'%val for val in cs.levels]
-            plt.clabel(cs,inline=1,fontsize=8)
+            cs.levels = ['%.0f' % val for val in cs.levels]
+            plt.clabel(cs, inline=1, fontsize=8)
 
         coordsys = wcs_utils.get_coordsys(self._proj)
 
@@ -261,7 +250,7 @@ class ImagePlotter(object):
         if ylabel is not None:
             ax.set_ylabel(ylabel)
 
-        #        plt.colorbar(im,orientation='horizontal',shrink=0.7,pad=0.15,
+        # plt.colorbar(im,orientation='horizontal',shrink=0.7,pad=0.15,
         #                     fraction=0.05)
         ax.coords.grid(color='white')  # , alpha=0.5)
         #       ax.locator_params(axis="x", nbins=12)
@@ -279,32 +268,32 @@ class ROIPlotter(fermipy.config.Configurable):
     }
 
     def __init__(self, data_map, **kwargs):
-        self._roi = kwargs.pop('roi',None)
-        super(ROIPlotter,self).__init__(None,**kwargs)        
-        #fermipy.config.Configurable.__init__(self, None, **kwargs)
+        self._roi = kwargs.pop('roi', None)
+        super(ROIPlotter, self).__init__(None, **kwargs)
+        # fermipy.config.Configurable.__init__(self, None, **kwargs)
 
         self._data_map = data_map
         self._catalogs = []
         for c in self.config['catalogs']:
-            if utils.isstr(c):            
+            if utils.isstr(c):
                 self._catalogs += [catalog.Catalog.create(c)]
             else:
                 self._catalogs += [c]
 
-        if isinstance(data_map,Map):
+        if isinstance(data_map, Map):
             self._projtype = 'WCS'
             self._data = data_map.counts.T
             self._proj = data_map.wcs
             self._wcs = self._proj
-        elif isinstance(data_map,HpxMap):
+        elif isinstance(data_map, HpxMap):
             self._projtype = 'HPX'
             self._proj = data_map.hpx
-            self._wcs,dataT = data_map.make_wcs_from_hpx(sum_ebins=False,
-                                                    proj='CAR',
-                                                    oversample=2)
+            self._wcs, dataT = data_map.make_wcs_from_hpx(sum_ebins=False,
+                                                          proj='CAR',
+                                                          oversample=2)
             self._data = dataT.T
         else:
-            raise Exception("Can't make ROIPlotter of unknown projection type %s"%type(data_map))
+            raise Exception("Can't make ROIPlotter of unknown projection type %s" % type(data_map))
 
         self._loge_bounds = self.config['loge_bounds']
 
@@ -328,7 +317,7 @@ class ROIPlotter(fermipy.config.Configurable):
 
     @property
     def projtype(self):
-        return self._projtype   
+        return self._projtype
 
     @property
     def proj(self):
@@ -353,9 +342,9 @@ class ROIPlotter(fermipy.config.Configurable):
             data = copy.deepcopy(hdulist[0].data)
             themap = Map(data, wcs)
         elif projtype == "HPX":
-            themap = HpxMap.create_from_hdulist(hdulist,ebounds="EBOUNDS")            
+            themap = HpxMap.create_from_hdulist(hdulist, ebounds="EBOUNDS")
         else:
-            raise Exception("Unknown projection type %s"%projtype)        
+            raise Exception("Unknown projection type %s" % projtype)
 
         return ROIPlotter(themap, roi=roi, **kwargs)
 
@@ -413,25 +402,25 @@ class ROIPlotter(fermipy.config.Configurable):
         else:
             plt.gca().set_xlabel('LAT Offset [deg]')
 
-    def plot_sources(self,skydir,labels,
-                     plot_kwargs,text_kwargs, **kwargs):
+    def plot_sources(self, skydir, labels,
+                     plot_kwargs, text_kwargs, **kwargs):
 
         ax = plt.gca()
 
-        nolabels = kwargs.get('nolabels',False)
+        nolabels = kwargs.get('nolabels', False)
         label_mask = kwargs.get('label_mask',
-                                np.ones(len(labels),dtype=bool))
+                                np.ones(len(labels), dtype=bool))
         if nolabels:
             label_mask.fill(False)
 
         pixcrd = wcs_utils.skydir_to_pix(skydir, self._implot._wcs)
 
-        for i, (x,y,label,show_label) in enumerate(zip(pixcrd[0],pixcrd[1],labels,label_mask)):
+        for i, (x, y, label, show_label) in enumerate(zip(pixcrd[0], pixcrd[1], labels, label_mask)):
 
             if show_label:
-                t = ax.annotate(label,xy=(x,y),
+                t = ax.annotate(label, xy=(x, y),
                                 xytext=(5.0, 5.0), textcoords='offset points',
-                                **text_kwargs)            
+                                **text_kwargs)
                 plt.setp(t, path_effects=[PathEffects.withStroke(linewidth=2.0, foreground="black")])
 
             t = ax.plot(x, y, **plot_kwargs)
@@ -441,10 +430,10 @@ class ROIPlotter(fermipy.config.Configurable):
 
         src_color = 'w'
 
-        label_ts_threshold = kwargs.get('label_ts_threshold',0.0)
+        label_ts_threshold = kwargs.get('label_ts_threshold', 0.0)
         plot_kwargs = dict(linestyle='None', marker='+',
-                           markerfacecolor='None',mew=0.66,ms=8,
-#                           markersize=8,
+                           markerfacecolor='None', mew=0.66, ms=8,
+                           #                           markersize=8,
                            markeredgecolor=src_color, clip_on=True)
 
         text_kwargs = dict(color=src_color, size=8, clip_on=True,
@@ -453,15 +442,15 @@ class ROIPlotter(fermipy.config.Configurable):
         ts = np.array([s['ts'] for s in roi.point_sources])
 
         if label_ts_threshold is None:
-            m = np.zeros(len(ts),dtype=bool)            
+            m = np.zeros(len(ts), dtype=bool)
         elif label_ts_threshold <= 0:
-            m = np.ones(len(ts),dtype=bool)            
+            m = np.ones(len(ts), dtype=bool)
         else:
             m = ts > label_ts_threshold
 
         skydir = roi._src_skydir
-        labels = [s.name for s in roi.point_sources]        
-        self.plot_sources(skydir,labels,plot_kwargs,text_kwargs,
+        labels = [s.name for s in roi.point_sources]
+        self.plot_sources(skydir, labels, plot_kwargs, text_kwargs,
                           label_mask=m, **kwargs)
 
     def plot_catalog(self, catalog):
@@ -485,17 +474,16 @@ class ROIPlotter(fermipy.config.Configurable):
         separation = skydir.separation(self.cmap.skydir).deg
         m = separation < max(self.cmap.width)
 
-        self.plot_sources(skydir[m],labels[m],plot_kwargs,text_kwargs,
+        self.plot_sources(skydir[m], labels[m], plot_kwargs, text_kwargs,
                           nolabels=True)
-
 
     def plot(self, **kwargs):
 
-        zoom = kwargs.get('zoom',None)
+        zoom = kwargs.get('zoom', None)
         graticule_radii = kwargs.get('graticule_radii',
                                      self.config['graticule_radii'])
         label_ts_threshold = kwargs.get('label_ts_threshold',
-                                       self.config['label_ts_threshold'])
+                                        self.config['label_ts_threshold'])
 
         im_kwargs = dict(cmap=self.config['cmap'],
                          interpolation='nearest',
@@ -517,7 +505,7 @@ class ROIPlotter(fermipy.config.Configurable):
 
         if self._roi is not None:
             self.plot_roi(self._roi,
-                          label_ts_threshold=label_ts_threshold)        
+                          label_ts_threshold=label_ts_threshold)
 
         self._extent = im.get_extent()
         ax.set_xlim(self._extent[0], self._extent[1])
@@ -530,44 +518,44 @@ class ROIPlotter(fermipy.config.Configurable):
         if cb_label:
             cb.set_label(cb_label)
 
-        for r in graticule_radii:            
-            self.draw_circle(self.cmap.skydir,r)
+        for r in graticule_radii:
+            self.draw_circle(self.cmap.skydir, r)
 
+    def draw_circle(self, skydir, radius):
 
-    def draw_circle(self,skydir,radius):
-
-        #coordsys = wcs_utils.get_coordsys(self.proj)
-        #if coordsys == 'GAL':            
+        # coordsys = wcs_utils.get_coordsys(self.proj)
+        # if coordsys == 'GAL':
         #    c = Circle((skydir.galactic.l.deg,skydir.galactic.b.deg),
         #               radius,facecolor='none',edgecolor='w',linestyle='--',
         #               transform=self._ax.get_transform('galactic'))
-        #elif coordsys == 'CEL':            
+        # elif coordsys == 'CEL':
         #    c = Circle((skydir.fk5.l.deg,skydir.fk5.b.deg),
         #               radius,facecolor='none',edgecolor='w',linestyle='--',
         #               transform=self._ax.get_transform('fk5'))
 
-        c = Circle(self.cmap.pix_center,radius/max(self.cmap.pix_size),
-                   facecolor='none',edgecolor='w',linestyle='--',linewidth=0.5)
+        c = Circle(self.cmap.pix_center, radius / max(self.cmap.pix_size),
+                   facecolor='none', edgecolor='w', linestyle='--', linewidth=0.5)
 
         self._ax.add_patch(c)
 
-    def zoom(self,zoom):
+    def zoom(self, zoom):
 
         if zoom is None:
             return
 
         extent = self._extent
 
-        xw = extent[1]-extent[0]
-        x0 = 0.5*(extent[0]+extent[1])
-        yw = extent[1]-extent[0]
-        y0 = 0.5*(extent[0]+extent[1])
+        xw = extent[1] - extent[0]
+        x0 = 0.5 * (extent[0] + extent[1])
+        yw = extent[1] - extent[0]
+        y0 = 0.5 * (extent[0] + extent[1])
 
-        xlim = [x0 - 0.5*xw/zoom,x0 + 0.5*xw/zoom]
-        ylim = [y0 - 0.5*yw/zoom,y0 + 0.5*yw/zoom]
+        xlim = [x0 - 0.5 * xw / zoom, x0 + 0.5 * xw / zoom]
+        ylim = [y0 - 0.5 * yw / zoom, y0 + 0.5 * yw / zoom]
 
-        self._ax.set_xlim(xlim[0],xlim[1])
-        self._ax.set_ylim(ylim[0],ylim[1])
+        self._ax.set_xlim(xlim[0], xlim[1])
+        self._ax.set_ylim(ylim[0], ylim[1])
+
 
 class SEDPlotter(object):
     def __init__(self, src):
@@ -580,10 +568,10 @@ class SEDPlotter(object):
 
         fmin = np.log10(np.min(sed['e2dfde_ul95'])) - 0.5
         fmax = np.log10(np.max(sed['e2dfde_ul95'])) + 0.5
-        fdelta = fmax-fmin
+        fdelta = fmax - fmin
         if fdelta < 2.0:
-            fmin -= 0.5*(2.0-fdelta)
-            fmax += 0.5*(2.0-fdelta)
+            fmin -= 0.5 * (2.0 - fdelta)
+            fmax += 0.5 * (2.0 - fdelta)
 
         return fmin, fmax
 
@@ -596,16 +584,16 @@ class SEDPlotter(object):
 
         lhProf = sed['lnlprofile']
 
-        fmin,fmax = SEDPlotter.get_ylims(sed)
+        fmin, fmax = SEDPlotter.get_ylims(sed)
 
         fluxM = np.arange(fmin, fmax, 0.01)
         fbins = len(fluxM)
-        llhMatrix = np.zeros((len(sed['ectr']), fbins))        
+        llhMatrix = np.zeros((len(sed['ectr']), fbins))
 
         # loop over energy bins
         for i in range(len(lhProf)):
             m = lhProf[i]['dfde'] > 0
-            e2dfde_scan = sed['norm_scan'][i][m]*sed['ref_e2dfde'][i]            
+            e2dfde_scan = sed['norm_scan'][i][m] * sed['ref_e2dfde'][i]
             flux = np.log10(e2dfde_scan)
             logl = lhProf[i]['dloglike'][m]
             logli = np.interp(fluxM, flux, logl)
@@ -635,7 +623,7 @@ class SEDPlotter(object):
         kwargs.setdefault('linestyle', 'None')
         kwargs.setdefault('color', 'k')
 
-        fmin,fmax = SEDPlotter.get_ylims(sed)
+        fmin, fmax = SEDPlotter.get_ylims(sed)
 
         m = sed['ts'] < ts_thresh
 
@@ -657,13 +645,12 @@ class SEDPlotter(object):
         xerr1 = np.vstack((delo[~m], dehi[~m]))
 
         plt.errorbar(x[~m], y[~m], xerr=xerr1, yerr=(yerr_lo[~m], yerr_hi[~m]), **kwargs)
-        plt.errorbar(x[m], yul[m], xerr=xerr0, yerr=yul[m]*0.2, uplims=True, **kwargs)
+        plt.errorbar(x[m], yul[m], xerr=xerr0, yerr=yul[m] * 0.2, uplims=True, **kwargs)
 
         plt.gca().set_yscale('log')
         plt.gca().set_xscale('log')
         plt.gca().set_xlim(sed['emin'][0], sed['emax'][-1])
-        plt.gca().set_ylim(10**fmin,10**fmax)
-
+        plt.gca().set_ylim(10 ** fmin, 10 ** fmax)
 
     @staticmethod
     def plot_sed_resid(src, model_flux, **kwargs):
@@ -745,7 +732,7 @@ class SEDPlotter(object):
         if np.any(sed['ts'] > 9.):
 
             if 'model_flux' in sed:
-                SEDPlotter.plot_model(sed['model_flux'], noband=showlnl)        
+                SEDPlotter.plot_model(sed['model_flux'], noband=showlnl)
             elif 'model_flux' in src:
                 SEDPlotter.plot_model(src, noband=showlnl)
 
@@ -849,18 +836,18 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         format = kwargs.get('format', gta.config['plotting']['format'])
 
-        if 'sigma' not in maps: 
+        if 'sigma' not in maps:
             return
 
         # Reload maps from FITS file
 
-        sigma_levels = [-5,-3,3,5,7] + list(np.logspace(1,3,17))
+        sigma_levels = [-5, -3, 3, 5, 7] + list(np.logspace(1, 3, 17))
 
-        kwargs.setdefault('graticule_radii',self.config['graticule_radii'])
+        kwargs.setdefault('graticule_radii', self.config['graticule_radii'])
         kwargs.setdefault('label_ts_threshold',
                           self.config['label_ts_threshold'])
-        kwargs.setdefault('cmap',self.config['cmap'])
-        kwargs.setdefault('catalogs',self._catalogs)
+        kwargs.setdefault('cmap', self.config['cmap'])
+        kwargs.setdefault('catalogs', self._catalogs)
 
         load_bluered_cmap()
 
@@ -868,7 +855,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
         fig = plt.figure()
         p = ROIPlotter(maps['sigma'], roi=gta.roi, **kwargs)
         p.plot(vmin=-5, vmax=5, levels=sigma_levels,
-               cb_label='Significance [$\sigma$]',interpolation='bicubic', cmap='bluered')
+               cb_label='Significance [$\sigma$]', interpolation='bicubic', cmap='bluered')
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
                                           'residmap_sigma',
                                           prefix=[prefix],
@@ -877,7 +864,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         fig = plt.figure()
         p = ROIPlotter(maps['data'], roi=gta.roi, **kwargs)
-        p.plot(cb_label='Counts',interpolation='bicubic')
+        p.plot(cb_label='Counts', interpolation='bicubic')
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
                                           'residmap_data',
                                           prefix=[prefix],
@@ -886,7 +873,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         fig = plt.figure()
         p = ROIPlotter(maps['model'], roi=gta.roi, **kwargs)
-        p.plot(cb_label='Counts',interpolation='bicubic')
+        p.plot(cb_label='Counts', interpolation='bicubic')
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
                                           'residmap_model',
                                           prefix=[prefix],
@@ -895,7 +882,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         fig = plt.figure()
         p = ROIPlotter(maps['excess'], roi=gta.roi, **kwargs)
-        p.plot(cb_label='Counts',interpolation='bicubic')
+        p.plot(cb_label='Counts', interpolation='bicubic')
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
                                           'residmap_excess',
                                           prefix=[prefix],
@@ -906,37 +893,37 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         format = kwargs.get('format', gta.config['plotting']['format'])
         suffix = kwargs.get('suffix', 'tsmap')
-        zoom = kwargs.get('zoom',None)
+        zoom = kwargs.get('zoom', None)
 
-        if 'ts' not in maps: 
+        if 'ts' not in maps:
             return
 
-        sigma_levels = [3,5,7] + list(np.logspace(1,3,17))
+        sigma_levels = [3, 5, 7] + list(np.logspace(1, 3, 17))
 
-        kwargs.setdefault('graticule_radii',self.config['graticule_radii'])
+        kwargs.setdefault('graticule_radii', self.config['graticule_radii'])
         kwargs.setdefault('label_ts_threshold',
                           self.config['label_ts_threshold'])
-        kwargs.setdefault('cmap',self.config['cmap'])
-        kwargs.setdefault('catalogs',self.config['catalogs'])
+        kwargs.setdefault('cmap', self.config['cmap'])
+        kwargs.setdefault('catalogs', self.config['catalogs'])
 
         prefix = maps['name']
         fig = plt.figure()
         p = ROIPlotter(maps['sqrt_ts'], roi=gta.roi, **kwargs)
         p.plot(vmin=0, vmax=5, levels=sigma_levels,
-               cb_label='Sqrt(TS) [$\sigma$]',interpolation='bicubic',
+               cb_label='Sqrt(TS) [$\sigma$]', interpolation='bicubic',
                zoom=zoom)
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
-                                          '%s_sqrt_ts'%suffix,
+                                          '%s_sqrt_ts' % suffix,
                                           prefix=[prefix],
                                           extension=format))
         plt.close(fig)
 
         fig = plt.figure()
         p = ROIPlotter(maps['npred'], roi=gta.roi, **kwargs)
-        p.plot(vmin=0, cb_label='NPred [Counts]',interpolation='bicubic',
+        p.plot(vmin=0, cb_label='NPred [Counts]', interpolation='bicubic',
                zoom=zoom)
         plt.savefig(utils.format_filename(gta.config['fileio']['workdir'],
-                                          '%s_npred'%suffix,
+                                          '%s_npred' % suffix,
                                           prefix=[prefix],
                                           extension=format))
         plt.close(fig)
@@ -956,12 +943,12 @@ class AnalysisPlotter(fermipy.config.Configurable):
         format = kwargs.get('format', gta.config['plotting']['format'])
 
         roi_kwargs = {}
-        roi_kwargs.setdefault('loge_bounds',loge_bounds)
-        roi_kwargs.setdefault('graticule_radii',self.config['graticule_radii'])
+        roi_kwargs.setdefault('loge_bounds', loge_bounds)
+        roi_kwargs.setdefault('graticule_radii', self.config['graticule_radii'])
         roi_kwargs.setdefault('label_ts_threshold',
                               self.config['label_ts_threshold'])
-        roi_kwargs.setdefault('cmap',self.config['cmap'])
-        roi_kwargs.setdefault('catalogs',self._catalogs)
+        roi_kwargs.setdefault('cmap', self.config['cmap'])
+        roi_kwargs.setdefault('catalogs', self._catalogs)
 
         if loge_bounds is None:
             loge_bounds = (gta.log_energies[0], gta.log_energies[-1])
@@ -974,11 +961,10 @@ class AnalysisPlotter(fermipy.config.Configurable):
         p.plot(cb_label='Counts', zscale='pow', gamma=1. / 3.)
         plt.savefig(os.path.join(gta.config['fileio']['workdir'],
                                  '%s_model_map%s.%s' % (
-                    prefix, esuffix, format)))
+                                     prefix, esuffix, format)))
         plt.close(fig)
 
-
-        #colors = ['k', 'b', 'g', 'r']
+        # colors = ['k', 'b', 'g', 'r']
         data_style = {'marker': 's', 'linestyle': 'None'}
 
         fig = plt.figure()
@@ -988,8 +974,8 @@ class AnalysisPlotter(fermipy.config.Configurable):
             model_data = mcube_map.counts.T
             diffuse_data = mcube_diffuse.counts.T
         elif p.projtype == "HPX":
-            dummy,model_dataT = p.cmap.convert_to_cached_wcs(mcube_map.counts,sum_ebins=False)
-            dummy,diffuse_dataT = p.cmap.convert_to_cached_wcs(mcube_diffuse.counts,sum_ebins=False)
+            dummy, model_dataT = p.cmap.convert_to_cached_wcs(mcube_map.counts, sum_ebins=False)
+            dummy, diffuse_dataT = p.cmap.convert_to_cached_wcs(mcube_diffuse.counts, sum_ebins=False)
             model_data = model_dataT.T
             diffuse_data = diffuse_dataT.T
 
@@ -1001,7 +987,6 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         fig = plt.figure()
         p.plot_projection(0, label='Data', color='k', **data_style)
-
 
         p.plot_projection(0, data=model_data, label='Model',
                           noerror=True)
@@ -1048,9 +1033,8 @@ class AnalysisPlotter(fermipy.config.Configurable):
         if loge_bounds is None:
             loge_bounds = (gta.log_energies[0], gta.log_energies[-1])
         esuffix = '_%.3f_%.3f' % (loge_bounds[0], loge_bounds[1])
-        
-        for i, c in enumerate(gta.components):
 
+        for i, c in enumerate(gta.components):
             fig = plt.figure()
             p = ROIPlotter(mcube_maps[i + 1], roi=gta.roi, **roi_kwargs)
 
@@ -1059,7 +1043,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
             p.plot(cb_label='Counts', zscale='pow', gamma=1. / 3.)
             plt.savefig(os.path.join(gta.config['fileio']['workdir'],
                                      '%s_model_map%s_%02i.%s' % (
-                                     prefix, esuffix, i, format)))
+                                         prefix, esuffix, i, format)))
             plt.close(fig)
 
             plt.figure(figx.number)
@@ -1095,18 +1079,17 @@ class AnalysisPlotter(fermipy.config.Configurable):
         plt.close(figx)
         plt.close(figy)
 
-
     def make_extension_plots(self, prefix, loge_bounds=None, **kwargs):
 
         format = kwargs.get('format', self.config['plotting']['format'])
 
         for s in self.roi.sources:
 
-            if 'extension' not in s: 
+            if 'extension' not in s:
                 continue
-            if s['extension'] is None: 
+            if s['extension'] is None:
                 continue
-            if not s['extension']['config']['save_model_map']: 
+            if not s['extension']['config']['save_model_map']:
                 continue
 
             self._plot_extension(prefix, s, loge_bounds=loge_bounds, format=format)
@@ -1117,9 +1100,9 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         for s in gta.roi.sources:
 
-            if 'sed' not in s: 
+            if 'sed' not in s:
                 continue
-            if s['sed'] is None: 
+            if s['sed'] is None:
                 continue
 
             name = s.name.lower().replace(' ', '_')
@@ -1141,9 +1124,9 @@ class AnalysisPlotter(fermipy.config.Configurable):
                                          prefix, name, format)))
             plt.close(fig)
 
-    def make_sed_plot(self,gta,name,**kwargs):
+    def make_sed_plot(self, gta, name, **kwargs):
 
-        prefix = kwargs.get('prefix','')
+        prefix = kwargs.get('prefix', '')
         src = gta.roi[name]
 
         name = src.name.lower().replace(' ', '_')
@@ -1169,102 +1152,100 @@ class AnalysisPlotter(fermipy.config.Configurable):
         plt.savefig(outfile)
         plt.close(fig)
 
-    def make_localization_plot(self,gta,name,tsmap,**kwargs):
+    def make_localization_plot(self, gta, name, tsmap, **kwargs):
 
         tsmap_renorm = copy.deepcopy(tsmap['ts'])
         tsmap_renorm._counts -= np.max(tsmap_renorm._counts)
 
-        prefix = kwargs.get('prefix','')
-        skydir = kwargs.get('skydir',None)
+        prefix = kwargs.get('prefix', '')
+        skydir = kwargs.get('skydir', None)
         src = gta.roi[name]
         o = src['localize']
 
         name = src.name.lower().replace(' ', '_')
         format = kwargs.get('format', gta.config['plotting']['format'])
 
-        p = ROIPlotter(tsmap_renorm,roi=gta.roi)
+        p = ROIPlotter(tsmap_renorm, roi=gta.roi)
         fig = plt.figure()
 
-        p.plot(levels=[-200,-100,-50,-20,-9.21,-5.99,-2.3,-1.0],
-               cmap='BuGn',vmin=-50.0,
-               interpolation='bicubic',cb_label='2$\\times\Delta\ln$L')
+        p.plot(levels=[-200, -100, -50, -20, -9.21, -5.99, -2.3, -1.0],
+               cmap='BuGn', vmin=-50.0,
+               interpolation='bicubic', cb_label='2$\\times\Delta\ln$L')
 
         cdelt0 = np.abs(tsmap['ts'].wcs.wcs.cdelt[0])
         cdelt1 = np.abs(tsmap['ts'].wcs.wcs.cdelt[1])
 
         tsmap_fit = o['tsmap_fit']
 
-        peak_skydir = SkyCoord(tsmap_fit['glon'],tsmap_fit['glat'],
-                               frame='galactic',unit='deg')
+        peak_skydir = SkyCoord(tsmap_fit['glon'], tsmap_fit['glat'],
+                               frame='galactic', unit='deg')
         peak_pix = peak_skydir.to_pixel(tsmap_renorm.wcs)
         peak_r68 = tsmap_fit['r68']
         peak_r99 = tsmap_fit['r99']
 
-        scan_skydir = SkyCoord(o['glon'],o['glat'],frame='galactic',unit='deg')
+        scan_skydir = SkyCoord(o['glon'], o['glat'], frame='galactic', unit='deg')
         scan_pix = scan_skydir.to_pixel(tsmap_renorm.wcs)
 
         if skydir is not None:
             pix = skydir.to_pixel(tsmap_renorm.wcs)
-            plt.gca().plot(pix[0],pix[1],linestyle='None',
-                           marker='+',color='r')
+            plt.gca().plot(pix[0], pix[1], linestyle='None',
+                           marker='+', color='r')
 
         if np.isfinite(float(peak_pix[0])):
-
             sigma = tsmap_fit['sigma']
             sigmax = tsmap_fit['sigma_semimajor']
             sigmay = tsmap_fit['sigma_semiminor']
             theta = tsmap_fit['theta']
 
-            e0 = Ellipse(xy=(float(peak_pix[0]),float(peak_pix[1])),
-                         width=2.0*sigmax/cdelt0*peak_r68/sigma,
-                         height=2.0*sigmay/cdelt1*peak_r68/sigma,
+            e0 = Ellipse(xy=(float(peak_pix[0]), float(peak_pix[1])),
+                         width=2.0 * sigmax / cdelt0 * peak_r68 / sigma,
+                         height=2.0 * sigmay / cdelt1 * peak_r68 / sigma,
                          angle=-np.degrees(theta),
-                         facecolor='None',edgecolor='k')
+                         facecolor='None', edgecolor='k')
 
-            e1 = Ellipse(xy=(float(peak_pix[0]),float(peak_pix[1])),
-                         width=2.0*sigmax/cdelt0*peak_r99/sigma,
-                         height=2.0*sigmay/cdelt1*peak_r99/sigma,
+            e1 = Ellipse(xy=(float(peak_pix[0]), float(peak_pix[1])),
+                         width=2.0 * sigmax / cdelt0 * peak_r99 / sigma,
+                         height=2.0 * sigmay / cdelt1 * peak_r99 / sigma,
                          angle=-np.degrees(theta),
-                         facecolor='None',edgecolor='k')
+                         facecolor='None', edgecolor='k')
 
             plt.gca().add_artist(e0)
             plt.gca().add_artist(e1)
-            plt.gca().plot(float(peak_pix[0]),float(peak_pix[1]),
-                           marker='x',color='k')
+            plt.gca().plot(float(peak_pix[0]), float(peak_pix[1]),
+                           marker='x', color='k')
 
         if np.isfinite(float(scan_pix[0])):
-
             sigmax = o['sigma_semimajor']
             sigmay = o['sigma_semiminor']
 
-            e0 = Ellipse(xy=(float(scan_pix[0]),float(scan_pix[1])),
-                         width=2.0*sigmax/cdelt0*o['r68']/o['sigma'],
-                         height=2.0*sigmay/cdelt1*o['r68']/o['sigma'],
+            e0 = Ellipse(xy=(float(scan_pix[0]), float(scan_pix[1])),
+                         width=2.0 * sigmax / cdelt0 * o['r68'] / o['sigma'],
+                         height=2.0 * sigmay / cdelt1 * o['r68'] / o['sigma'],
                          angle=-np.degrees(o['theta']),
-                         facecolor='None',edgecolor='r')
+                         facecolor='None', edgecolor='r')
 
-            e1 = Ellipse(xy=(float(scan_pix[0]),float(scan_pix[1])),
-                         width=2.0*sigmax/cdelt0*o['r99']/o['sigma'],
-                         height=2.0*sigmay/cdelt1*o['r99']/o['sigma'],
+            e1 = Ellipse(xy=(float(scan_pix[0]), float(scan_pix[1])),
+                         width=2.0 * sigmax / cdelt0 * o['r99'] / o['sigma'],
+                         height=2.0 * sigmay / cdelt1 * o['r99'] / o['sigma'],
                          angle=-np.degrees(o['theta']),
-                         facecolor='None',edgecolor='r')
+                         facecolor='None', edgecolor='r')
 
             plt.gca().add_artist(e0)
             plt.gca().add_artist(e1)
 
-            plt.gca().plot(float(scan_pix[0]),float(scan_pix[1]),
-                           marker='x',color='r')
+            plt.gca().plot(float(scan_pix[0]), float(scan_pix[1]),
+                           marker='x', color='r')
 
-#        if gta.config['binning']['coordsys'] == 'GAL':        
-#            plt.gca().scatter(o['peak_glon'], o['peak_glat'],
-#                              transform=plt.gca().get_transform('galactic'),color='k')
-#            plt.gca().scatter(o['glon'], o['glat'],
-#                              transform=plt.gca().get_transform('galactic'),color='r')
-#        else:
-#            plt.gca().scatter(o['peak_ra'], o['peak_dec'],
-#                              transform=plt.gca().get_transform('fk5'),color='k')
-#            plt.gca().scatter(o['ra'], o['dec'],
-#                              transform=plt.gca().get_transform('fk5'),color='r')
+        #        if gta.config['binning']['coordsys'] == 'GAL':
+        #            plt.gca().scatter(o['peak_glon'], o['peak_glat'],
+        #                              transform=plt.gca().get_transform('galactic'),color='k')
+        #            plt.gca().scatter(o['glon'], o['glat'],
+        #                              transform=plt.gca().get_transform('galactic'),color='r')
+        #        else:
+        #            plt.gca().scatter(o['peak_ra'], o['peak_dec'],
+        #                              transform=plt.gca().get_transform('fk5'),color='k')
+        #            plt.gca().scatter(o['ra'], o['dec'],
+        #                              transform=plt.gca().get_transform('fk5'),color='r')
 
         outfile = utils.format_filename(gta.config['fileio']['workdir'],
                                         'localize', prefix=[prefix, name],
@@ -1277,7 +1258,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
         """Utility function for generating diagnostic plots for the
         extension analysis."""
 
-        #format = kwargs.get('format', self.config['plotting']['format'])
+        # format = kwargs.get('format', self.config['plotting']['format'])
 
         if loge_bounds is None:
             loge_bounds = (self.energies[0], self.energies[-1])
@@ -1336,5 +1317,3 @@ class AnalysisPlotter(fermipy.config.Configurable):
                                      '%s_%s_extension_yproj%s%s.png' % (
                                          prefix, name, esuffix, suffix)))
             plt.close(fig)
-
-

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import os
 import matplotlib

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import os
 import numpy as np

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import os
 import numpy as np

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import copy
 import re

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import re

--- a/fermipy/scripts/clone_configs.py
+++ b/fermipy/scripts/clone_configs.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import copy
 import yaml

--- a/fermipy/scripts/clone_configs.py
+++ b/fermipy/scripts/clone_configs.py
@@ -1,3 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import yaml
@@ -5,21 +7,23 @@ from fermipy import utils
 import argparse
 import subprocess
 
+
 def cmd_exists(cmd):
-    return subprocess.call("type " + cmd, shell=True, 
+    return subprocess.call("type " + cmd, shell=True,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE) == 0
 
-def clone_configs(basedir,base_configs,opt_configs,scripts):
+
+def clone_configs(basedir, base_configs, opt_configs, scripts):
     """
     """
     config = {}
     for c in base_configs:
-        config = utils.merge_dict(config,yaml.load(open(c)),
-                                  add_new_keys=True)   
+        config = utils.merge_dict(config, yaml.load(open(c)),
+                                  add_new_keys=True)
 
-    scriptdir = os.path.abspath(os.path.join(basedir,'scripts'))
-    utils.mkdir(scriptdir)    
+    scriptdir = os.path.abspath(os.path.join(basedir, 'scripts'))
+    utils.mkdir(scriptdir)
     bash_scripts = []
     for script_in in scripts:
         bash_script = """
@@ -29,28 +33,27 @@ cat $0
 
         if os.path.isfile(script_in):
             script = os.path.basename(script_in)
-            scriptpath = os.path.join(scriptdir,script)
+            scriptpath = os.path.join(scriptdir, script)
             scriptexe = 'python ' + scriptpath
-            os.system('cp %s %s'%(script_in,scriptdir))
+            os.system('cp %s %s' % (script_in, scriptdir))
         elif cmd_exists(script_in):
             scriptexe = script_in
             script = script_in
         else:
-            raise Exception('Could not find script: %s'%script_in)
+            raise Exception('Could not find script: %s' % script_in)
 
-        bash_scripts.append((script,scriptexe,bash_script))
+        bash_scripts.append((script, scriptexe, bash_script))
 
     for name, vdict in opt_configs.items():
 
-        dirname = os.path.abspath(os.path.join(basedir,name))
+        dirname = os.path.abspath(os.path.join(basedir, name))
         utils.mkdir(dirname)
 
-        cfgfile = os.path.join(dirname,'config.yaml')
-        for script_in,bash_script in zip(scripts,bash_scripts):
-
+        cfgfile = os.path.join(dirname, 'config.yaml')
+        for script_in, bash_script in zip(scripts, bash_scripts):
             runscript = os.path.splitext(bash_script[0])[0] + '.sh'
-            runscript = os.path.join(dirname,runscript)            
-            with open(os.path.join(runscript),'wt') as f:
+            runscript = os.path.join(dirname, runscript)
+            with open(os.path.join(runscript), 'wt') as f:
                 f.write(bash_script[2].format(source=name,
                                               scriptexe=bash_script[1],
                                               config=cfgfile))
@@ -59,38 +62,37 @@ cat $0
             continue
 
         c = copy.deepcopy(config)
-        c = utils.merge_dict(c,vdict,add_new_keys=True)
-        yaml.dump(utils.tolist(c),open(cfgfile,'w'),default_flow_style=False)
+        c = utils.merge_dict(c, vdict, add_new_keys=True)
+        yaml.dump(utils.tolist(c), open(cfgfile, 'w'), default_flow_style=False)
 
 
 def main():
-
     usage = "usage: %(prog)s [config files]"
     description = "Clone configuration files and make directory structure"
-    parser = argparse.ArgumentParser(usage=usage,description=description)
+    parser = argparse.ArgumentParser(usage=usage, description=description)
 
-    parser.add_argument('--basedir', default = None, required=True)
-    parser.add_argument('--source_list', default = None, required=True,
+    parser.add_argument('--basedir', default=None, required=True)
+    parser.add_argument('--source_list', default=None, required=True,
                         help='YAML file containing a list of sources to be '
-                        'analyzed.')
+                             'analyzed.')
     parser.add_argument('--script', action='append', required=True,
                         help='The python script.')
-    parser.add_argument('configs', nargs='*', default = None,
+    parser.add_argument('configs', nargs='*', default=None,
                         help='One or more configuration files that will be merged '
-                        'to construct the analysis configuration.')
+                             'to construct the analysis configuration.')
 
     args = parser.parse_args()
 
-    #src_dict = {}
-    #src_list = yaml.load(open(args.source_list))
+    # src_dict = {}
+    # src_list = yaml.load(open(args.source_list))
 
-    #for src,sdict in src_list.items():
+    # for src,sdict in src_list.items():
     #    src_dict[src] = sdict
 
     src_dict = yaml.load(open(args.source_list))
 
-    clone_configs(args.basedir,args.configs,src_dict,args.script)
+    clone_configs(args.basedir, args.configs, src_dict, args.script)
+
 
 if __name__ == "__main__":
     main()
-

--- a/fermipy/scripts/cluster_sources.py
+++ b/fermipy/scripts/cluster_sources.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import sys
 import argparse
 import yaml

--- a/fermipy/scripts/collect_sources.py
+++ b/fermipy/scripts/collect_sources.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import argparse
 import yaml

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import time
@@ -6,25 +7,24 @@ import stat
 import datetime
 import argparse
 import pprint
-
 from fermipy import utils
 from fermipy.batch import check_log, get_lsf_status
+
 
 def file_age_in_seconds(pathname):
     return time.time() - os.stat(pathname)[stat.ST_MTIME]
 
-    #return string in open(logfile).read()
 
-def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90): 
+def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90):
     """Construct a list of job dictionaries."""
 
     jobs = []
 
-    for dirname in sorted(dirs):        
+    for dirname in sorted(dirs):
 
-        o = dict(cfgfile = os.path.join(dirname,'config.yaml'),
-                 logfile = os.path.join(dirname,os.path.splitext(runscript)[0] + '.log'),
-                 runscript = os.path.join(dirname,runscript))
+        o = dict(cfgfile=os.path.join(dirname, 'config.yaml'),
+                 logfile=os.path.join(dirname, os.path.splitext(runscript)[0] + '.log'),
+                 runscript=os.path.join(dirname, runscript))
 
         if not os.path.isfile(o['cfgfile']):
             continue
@@ -36,7 +36,7 @@ def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90):
             jobs.append(o)
             continue
 
-        age = file_age_in_seconds(o['logfile'])/60.
+        age = file_age_in_seconds(o['logfile']) / 60.
         job_status = check_log(o['logfile'])
 
         print(dirname, job_status, age)
@@ -47,49 +47,48 @@ def collect_jobs(dirs, runscript, overwrite=False, max_job_age=90):
             print("Job Exited. Resending command.")
             jobs.append(o)
         elif job_status == 'None' and age > max_job_age:
-            print("Job did not exit, but no activity on log file for > %.2f min. Resending command."%max_job_age)
+            print("Job did not exit, but no activity on log file for > %.2f min. Resending command." % max_job_age)
             jobs.append(o)
-#        elif job_status is True:
-#            print("Job Completed. Resending command.")
-#            jobs.append(o)
-
+        #        elif job_status is True:
+        #            print("Job Completed. Resending command.")
+        #            jobs.append(o)
 
     return jobs
 
-def main():
 
+def main():
     usage = "usage: %(prog)s [config file]"
     description = "Dispatch analysis jobs to LSF."
-    parser = argparse.ArgumentParser(usage=usage,description=description)
+    parser = argparse.ArgumentParser(usage=usage, description=description)
 
-    parser.add_argument('--config', default = 'sample_config.yaml')
-    parser.add_argument('--time', default = 1500, type=int,
+    parser.add_argument('--config', default='sample_config.yaml')
+    parser.add_argument('--time', default=1500, type=int,
                         help='Set the wallclock time allocation for the '
-                        'job in minutes.')
-    parser.add_argument('--max_jobs', default = 500, type=int,
+                             'job in minutes.')
+    parser.add_argument('--max_jobs', default=500, type=int,
                         help='Limit on the number of running or queued jobs.  '
-                        'New jobs will only be dispatched if the number of '
-                        'existing jobs is smaller than this parameter.')
-    parser.add_argument('--jobs_per_cycle', default = 20, type=int,
+                             'New jobs will only be dispatched if the number of '
+                             'existing jobs is smaller than this parameter.')
+    parser.add_argument('--jobs_per_cycle', default=20, type=int,
                         help='Maximum number of jobs to submit in each cycle.')
-    parser.add_argument('--time_per_cycle', default = 15, type=float,
+    parser.add_argument('--time_per_cycle', default=15, type=float,
                         help='Time per submission cycle in seconds.')
-    parser.add_argument('--max_job_age', default = 90, type=float,
+    parser.add_argument('--max_job_age', default=90, type=float,
                         help='Max job age in minutes.  Incomplete jobs without '
-                        'a return code and a logfile modification '
-                        'time older than this parameter will be restarted.')
-    parser.add_argument('--dry_run', default = False, action='store_true')
-    parser.add_argument('--overwrite', default = False, action='store_true',
+                             'a return code and a logfile modification '
+                             'time older than this parameter will be restarted.')
+    parser.add_argument('--dry_run', default=False, action='store_true')
+    parser.add_argument('--overwrite', default=False, action='store_true',
                         help='Force all jobs to be re-run even if the job has '
-                        'completed successfully.')
-    parser.add_argument('--runscript', default = None, required=True,
+                             'completed successfully.')
+    parser.add_argument('--runscript', default=None, required=True,
                         help='Set the name of the job execution script.  A '
-                        'script with this name must be located in each '
-                        'analysis subdirectory.')
+                             'script with this name must be located in each '
+                             'analysis subdirectory.')
 
-    parser.add_argument('dirs', nargs='+', default = None,
+    parser.add_argument('dirs', nargs='+', default=None,
                         help='List of directories in which the analysis will '
-                        'be run.')
+                             'be run.')
 
     args = parser.parse_args()
 
@@ -97,20 +96,20 @@ def main():
     jobs = collect_jobs(dirs, args.runscript,
                         args.overwrite, args.max_job_age)
 
-    lsf_opts = {'W' : args.time,
-                'R' : 'bullet,hequ,kiso'}
+    lsf_opts = {'W': args.time,
+                'R': 'bullet,hequ,kiso'}
 
     lsf_opt_string = ''
     for optname, optval in lsf_opts.items():
 
         if utils.isstr(optval):
-            optval = '\"%s\"'%optval
+            optval = '\"%s\"' % optval
 
-        lsf_opt_string += '-%s %s '%(optname,optval)
+        lsf_opt_string += '-%s %s ' % (optname, optval)
 
-    while(1):
+    while (1):
 
-        print('-'*80)
+        print('-' * 80)
         print(datetime.datetime.now())
         print(len(jobs), 'jobs in queue')
 
@@ -122,8 +121,7 @@ def main():
         njob_to_submit = min(args.max_jobs - status['NJOB'],
                              args.jobs_per_cycle)
 
-
-        pprint.pprint(status)    
+        pprint.pprint(status)
         print('njob_to_submit ', njob_to_submit)
 
         if njob_to_submit > 0:
@@ -131,9 +129,9 @@ def main():
             print('Submitting ', njob_to_submit, 'jobs')
 
             for job in jobs[:njob_to_submit]:
-                cmd = 'bsub %s -oo %s bash %s'%(lsf_opt_string,
-                                                job['logfile'],
-                                                job['runscript'])
+                cmd = 'bsub %s -oo %s bash %s' % (lsf_opt_string,
+                                                  job['logfile'],
+                                                  job['runscript'])
                 print(cmd)
                 if not args.dry_run:
                     print('submitting')
@@ -141,10 +139,9 @@ def main():
 
             del jobs[:njob_to_submit]
 
-        print('Sleeping %f seconds'%args.time_per_cycle)
+        print('Sleeping %f seconds' % args.time_per_cycle)
         sys.stdout.flush()
         time.sleep(args.time_per_cycle)
-
 
 
 if __name__ == "__main__":

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import sys
 import time
 import os

--- a/fermipy/sed.py
+++ b/fermipy/sed.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities for dealing with SEDs
 
@@ -5,10 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import logging
 import os

--- a/fermipy/sed.py
+++ b/fermipy/sed.py
@@ -6,7 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import logging
 import os

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities for plotting SEDs and Castro plots
 
@@ -5,7 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -6,7 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import numpy as np
 
 NORM_LABEL = {

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -8,21 +8,21 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib
 
-NORM_LABEL = {'NORM':r'Flux Normalization [a.u.]',
-              'FLUX':r'$F_{\rm min}^{\rm max} [ph $cm^{-2} s^{-1}$]',
-              'EFLUX':r'$E F_{\rm min}^{\rm max}$ [MeV $cm^{-2} s^{-1}]$',
-              'NPRED':r'$n_{\rm pred}$ [ph]',
-              'DFDE':r'dN/dE [ph $cm^{-2} s^{-1} MeV^{-1}$]',
-              'EDFDE':r'E dN/dE [MeV $cm^{-2} s^{-1} MeV^{-1}$]',
-              'E2DFDE':r'%E^2% dN/dE [MeV $cm^{-2} s^{-1} MeV^{-1}$]',
-              'SIGVJ':r'$J\langle \sigma v \rangle$ [$GeV^{2} cm^{-2} s^{-1}$]',
-              'SIGV':r'$\langle \sigma v \rangle$ [$cm^{3} s^{-1}$]'}
+NORM_LABEL = {
+    'NORM': r'Flux Normalization [a.u.]',
+    'FLUX': r'$F_{\rm min}^{\rm max} [ph $cm^{-2} s^{-1}$]',
+    'EFLUX': r'$E F_{\rm min}^{\rm max}$ [MeV $cm^{-2} s^{-1}]$',
+    'NPRED': r'$n_{\rm pred}$ [ph]',
+    'DFDE': r'dN/dE [ph $cm^{-2} s^{-1} MeV^{-1}$]',
+    'EDFDE': r'E dN/dE [MeV $cm^{-2} s^{-1} MeV^{-1}$]',
+    'E2DFDE': r'%E^2% dN/dE [MeV $cm^{-2} s^{-1} MeV^{-1}$]',
+    'SIGVJ': r'$J\langle \sigma v \rangle$ [$GeV^{2} cm^{-2} s^{-1}$]',
+    'SIGV': r'$\langle \sigma v \rangle$ [$cm^{3} s^{-1}$]',
+}
 
 
-def plotNLL_v_Flux(nll,fluxType,nstep=25,xlims=None):
+def plotNLL_v_Flux(nll, fluxType, nstep=25, xlims=None):
     """ Plot the (negative) log-likelihood as a function of normalization
 
     nll   : a LnLFN object
@@ -31,6 +31,8 @@ def plotNLL_v_Flux(nll,fluxType,nstep=25,xlims=None):
 
     returns fig,ax, which are matplotlib figure and axes objects
     """
+    import matplotlib.pyplot as plt
+
     if xlims is None:
         xmin = nll.interp.xmin
         xmax = nll.interp.xmax
@@ -41,25 +43,25 @@ def plotNLL_v_Flux(nll,fluxType,nstep=25,xlims=None):
     y1 = nll.interp(xmin)
     y2 = nll.interp(xmax)
 
-    ymin = min(y1,y2,0.0)
-    ymax = max(y1,y2,0.5)    
+    ymin = min(y1, y2, 0.0)
+    ymax = max(y1, y2, 0.5)
 
-    xvals = np.linspace(xmin,xmax,nstep)
+    xvals = np.linspace(xmin, xmax, nstep)
     yvals = nll.interp(xvals)
 
     fig = plt.figure()
     ax = fig.add_subplot(111)
 
-    ax.set_xlim((xmin,xmax))
-    ax.set_ylim((ymin,ymax))
+    ax.set_xlim((xmin, xmax))
+    ax.set_ylim((ymin, ymax))
 
     ax.set_xlabel(NORM_LABEL[fluxType])
     ax.set_ylabel(r'$-\Delta \log\mathcal{L}$')
-    ax.plot(xvals,yvals)
-    return fig,ax
+    ax.plot(xvals, yvals)
+    return fig, ax
 
 
-def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
+def plotCastro_base(castroData, xlims, ylims, xlabel, ylabel, nstep=25, zlims=None):
     """ Make a color plot (castro plot) of the log-likelihood as a function of 
     energy and flux normalization
 
@@ -73,6 +75,8 @@ def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
 
     returns fig,ax,im,ztmp which are matplotlib figure, axes and image objects
     """
+    import matplotlib.pyplot as plt
+
     xmin = xlims[0]
     xmax = xlims[1]
     ymin = ylims[0]
@@ -89,28 +93,29 @@ def plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep=25,zlims=None):
 
     ax.set_xscale('log')
     ax.set_yscale('log')
-    ax.set_xlim((xmin,xmax))
-    ax.set_ylim((ymin,ymax))
+    ax.set_xlim((xmin, xmax))
+    ax.set_ylim((ymin, ymax))
 
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
 
-    normVals = np.logspace(np.log10(ymin),np.log10(ymax),nstep)
+    normVals = np.logspace(np.log10(ymin), np.log10(ymax), nstep)
     ztmp = []
     for i in range(castroData.nx):
         ztmp.append(castroData[i].interp(normVals))
 
     ztmp = np.asarray(ztmp).T
     ztmp *= -1.
-    ztmp = np.where(ztmp<zmin,np.nan,ztmp)
-    im = ax.imshow(ztmp, extent=[xmin,xmax,ymin,ymax],
-                   origin='lower', aspect='auto',interpolation='nearest',
-                   vmin=zmin, vmax=zmax,cmap=matplotlib.cm.jet_r)
+    ztmp = np.where(ztmp < zmin, np.nan, ztmp)
+    cmap = plt.get_cmap('jet_r')
+    im = ax.imshow(ztmp, extent=[xmin, xmax, ymin, ymax],
+                   origin='lower', aspect='auto', interpolation='nearest',
+                   vmin=zmin, vmax=zmax, cmap=cmap)
 
-    return fig,ax,im,ztmp   
+    return fig, ax, im, ztmp
 
 
-def plotCastro(castroData,ylims,nstep=25,zlims=None):
+def plotCastro(castroData, ylims, nstep=25, zlims=None):
     """ Make a color plot (castro plot) of the delta log-likelihood as a function of 
     energy and flux normalization
 
@@ -121,14 +126,13 @@ def plotCastro(castroData,ylims,nstep=25,zlims=None):
 
     returns fig,ax,im,ztmp which are matplotlib figure, axes and image objects
     """
-    xlims = (castroData.specData.log_ebins[0],castroData.specData.log_ebins[-1])
+    xlims = (castroData.specData.log_ebins[0], castroData.specData.log_ebins[-1])
     xlabel = "Energy [GeV]"
     ylabel = NORM_LABEL[castroData.norm_type]
-    return plotCastro_base(castroData,xlims,ylims,xlabel,ylabel,nstep,zlims)
+    return plotCastro_base(castroData, xlims, ylims, xlabel, ylabel, nstep, zlims)
 
 
-
-def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
+def plotSED(castroData, ylims, TS_thresh=4.0, errSigma=1.0, specVals=[]):
     """ Make a color plot (castro plot) of the (negative) log-likelihood as a function of 
     energy and flux normalization
 
@@ -139,6 +143,8 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
     specVals   : List of spectra to add to plot
     returns fig,ax which are matplotlib figure and axes objects
     """
+    import matplotlib.pyplot as plt
+
     xmin = castroData.specData.ebins[0]
     xmax = castroData.specData.ebins[-1]
     ymin = ylims[0]
@@ -149,8 +155,8 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
 
     ax.set_xscale('log')
     ax.set_yscale('log')
-    ax.set_xlim((xmin,xmax))
-    ax.set_ylim((ymin,ymax))
+    ax.set_xlim((xmin, xmax))
+    ax.set_ylim((ymin, ymax))
 
     ax.set_xlabel("Energy [GeV]")
     ax.set_ylabel(NORM_LABEL[castroData.norm_type])
@@ -163,31 +169,31 @@ def plotSED(castroData,ylims,TS_thresh=4.0,errSigma=1.0,specVals=[]):
     ul_vals = castroData.getLimits(0.05)
 
     err_pos = castroData.getLimits(0.32) - mles
-    err_neg = mles - castroData.getLimits(0.32,upper=False) 
+    err_neg = mles - castroData.getLimits(0.32, upper=False)
 
-    yerr_points = (err_neg[has_point],err_pos[has_point])
-    xerrs = ( castroData.specData.evals - castroData.specData.ebins[0:-1],
-              castroData.specData.ebins[1:] - castroData.specData.evals )
+    yerr_points = (err_neg[has_point], err_pos[has_point])
+    xerrs = (castroData.specData.evals - castroData.specData.ebins[0:-1],
+             castroData.specData.ebins[1:] - castroData.specData.evals)
 
-    yerr_limits = (0.5*ul_vals[has_limit],np.zeros((has_limit.sum())))
+    yerr_limits = (0.5 * ul_vals[has_limit], np.zeros((has_limit.sum())))
 
-    ax.errorbar(castroData.specData.evals[has_point],mles[has_point],
-                yerr=yerr_points,fmt='o')
+    ax.errorbar(castroData.specData.evals[has_point], mles[has_point],
+                yerr=yerr_points, fmt='o')
 
-    ax.errorbar(castroData.specData.evals[has_limit],ul_vals[has_limit], 
+    ax.errorbar(castroData.specData.evals[has_limit], ul_vals[has_limit],
                 yerr=yerr_limits, lw=1, color='red', ls='none', zorder=1, uplims=True)
 
-    ax.errorbar(castroData.specData.evals[has_limit], ul_vals[has_limit], xerr=(xerrs[0][has_limit],xerrs[1][has_limit]),
+    ax.errorbar(castroData.specData.evals[has_limit], ul_vals[has_limit],
+                xerr=(xerrs[0][has_limit], xerrs[1][has_limit]),
                 lw=1.35, ls='none', color='red', zorder=2, capsize=0)
 
     for spec in specVals:
-        ax.loglog(castroData.specData.evals,spec)
+        ax.loglog(castroData.specData.evals, spec)
 
-    return fig,ax
+    return fig, ax
 
 
 if __name__ == "__main__":
-
 
     from fermipy import castro
     import sys
@@ -197,31 +203,30 @@ if __name__ == "__main__":
     else:
         flux_type = sys.argv[1]
 
-
     if flux_type == 'NORM':
-        xlims = (0.,1.)
-        flux_lims = (1e-5,1e-1)
+        xlims = (0., 1.)
+        flux_lims = (1e-5, 1e-1)
     elif flux_type == "FLUX":
-        xlims = (0.,1.)
-        flux_lims = (1e-13,1e-9)
+        xlims = (0., 1.)
+        flux_lims = (1e-13, 1e-9)
     elif flux_type == "EFLUX":
-        xlims = (0.,1.)
-        flux_lims = (1e-8,1e-4)
+        xlims = (0., 1.)
+        flux_lims = (1e-8, 1e-4)
     elif flux_type == "NPRED":
-        xlims = (0.,1.)
-        flux_lims = (1e-1,1e3)
+        xlims = (0., 1.)
+        flux_lims = (1e-1, 1e3)
     elif flux_type == "DFDE":
-        xlims = (0.,1.)
-        flux_lims = (1e-18,1e-11)
+        xlims = (0., 1.)
+        flux_lims = (1e-18, 1e-11)
     elif flux_type == "EDFDE":
-        xlims = (0.,1.)
-        flux_lims = (1e-13,1e-9)
+        xlims = (0., 1.)
+        flux_lims = (1e-13, 1e-9)
     else:
-        print ("Didn't reconginize flux type %s, choose from NORM | FLUX | EFLUX | NPRED | DFDE | EDFDE"%sys.argv[1])
+        print("Didn't reconginize flux type %s, choose from NORM | FLUX | EFLUX | NPRED | DFDE | EDFDE" % sys.argv[1])
         sys.exit()
 
-    tscube = castro.TSCube.create_from_fits("tscube_test.fits",flux_type)
-    resultDict = tscube.find_sources(10.0,1.0,use_cumul=False,
+    tscube = castro.TSCube.create_from_fits("tscube_test.fits", flux_type)
+    resultDict = tscube.find_sources(10.0, 1.0, use_cumul=False,
                                      output_peaks=True,
                                      output_specInfo=True,
                                      output_srcs=True)
@@ -229,18 +234,18 @@ if __name__ == "__main__":
     peaks = resultDict["Peaks"]
 
     max_ts = tscube.tsmap.counts.max()
-    (castro,test_dict) = tscube.test_spectra_of_peak(peaks[0])
+    (castro, test_dict) = tscube.test_spectra_of_peak(peaks[0])
 
     nll = castro[2]
-    fig,ax = plotNLL_v_Flux(nll,flux_type)
+    fig, ax = plotNLL_v_Flux(nll, flux_type)
 
-    fig2,ax2,im2,ztmp2 = plotCastro(castro,ylims=flux_lims,nstep=100)
+    fig2, ax2, im2, ztmp2 = plotCastro(castro, ylims=flux_lims, nstep=100)
 
     spec_pl = test_dict["PowerLaw"]["Spectrum"]
     spec_lp = test_dict["LogParabola"]["Spectrum"]
     spec_pc = test_dict["PLExpCutoff"]["Spectrum"]
 
-    fig3,ax3 = plotSED(castro,ylims=flux_lims,TS_thresh=2.0,specVals=[spec_pl])        
+    fig3, ax3 = plotSED(castro, ylims=flux_lims, TS_thresh=2.0, specVals=[spec_pl])
 
     result_pl = test_dict["PowerLaw"]["Result"]
     result_lp = test_dict["LogParabola"]["Result"]
@@ -249,8 +254,8 @@ if __name__ == "__main__":
     ts_lp = test_dict["LogParabola"]["TS"]
     ts_pc = test_dict["PLExpCutoff"]["TS"]
 
-    print("TS for PL index = 2:  %.1f"%max_ts)
-    print("Cumulative TS:        %.1f"%castro.ts_vals().sum())
-    print("TS for PL index free: %.1f (Index = %.2f)"%(ts_pl,result_pl[1]))
-    print("TS for LogParabola:   %.1f (Index = %.2f, Beta = %.2f)"%(ts_lp,result_lp[1],result_lp[2]))
-    print("TS for PLExpCutoff:   %.1f (Index = %.2f, E_c = %.2f)"%(ts_pc,result_pc[1],result_pc[2]))
+    print("TS for PL index = 2:  %.1f" % max_ts)
+    print("Cumulative TS:        %.1f" % castro.ts_vals().sum())
+    print("TS for PL index free: %.1f (Index = %.2f)" % (ts_pl, result_pl[1]))
+    print("TS for LogParabola:   %.1f (Index = %.2f, Beta = %.2f)" % (ts_lp, result_lp[1], result_lp[2]))
+    print("TS for PLExpCutoff:   %.1f (Index = %.2f, E_c = %.2f)" % (ts_pc, result_pc[1], result_pc[2]))

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
-
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
-
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.hpx_utils as hpx_utils

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import numpy as np
 from astropy.io import fits

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import logging
 import numpy as np

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -141,7 +141,7 @@ class SourceFinder(object):
 
             self.logger.info('Found source\n' +
                              'name: %s\n' % name +
-                             'ts: %f' % p['amp']**2)
+                             'ts: %f' % p['amp'] ** 2)
 
             names.append(name)
             src_dicts.append(src_dict)
@@ -179,7 +179,7 @@ class SourceFinder(object):
             (names, src_dicts) = \
                 self._build_src_dicts_from_peaks(peaks, m, src_dict_template)
         elif tsmap_fitter == 'tscube':
-            sd = m['tscube'].find_sources(threshold**2, min_separation,
+            sd = m['tscube'].find_sources(threshold ** 2, min_separation,
                                           use_cumul=False,
                                           output_src_dicts=True,
                                           output_peaks=True)
@@ -315,9 +315,9 @@ class SourceFinder(object):
         self.logger.debug('Completed localization with TS Map.\n'
                           '(ra,dec) = (%10.4f,%10.4f)\n'
                           '(glon,glat) = (%10.4f,%10.4f)',
-                          tsmap_fit['ra'],tsmap_fit['dec'],
-                          tsmap_fit['glon'],tsmap_fit['glat'])
-        
+                          tsmap_fit['ra'], tsmap_fit['dec'],
+                          tsmap_fit['glon'], tsmap_fit['glat'])
+
         # Fit baseline (point-source) model
         self.free_norm(name)
         fit_output = self._fit(loglevel=logging.DEBUG, **config['optimizer'])
@@ -338,7 +338,7 @@ class SourceFinder(object):
         self.logger.debug('Refining localization search to '
                           'region of width: %.4f deg',
                           tsmap_fit['r95'])
-        
+
         scan_map = Map.create(SkyCoord(tsmap_fit['ra'],
                                        tsmap_fit['dec'], unit='deg'),
                               scan_step, (nstep, nstep),
@@ -352,7 +352,6 @@ class SourceFinder(object):
                        dloglike_fit=np.zeros((nstep, nstep)))
 
         for i, t in enumerate(scan_skydir):
-
             model_name = '%s_localize' % (name.replace(' ', '').lower())
             src.set_name(model_name)
             src.set_position(t)
@@ -377,10 +376,10 @@ class SourceFinder(object):
         scan_fit, new_skydir = fit_error_ellipse(scan_tsmap, dpix=3)
         o.update(scan_fit)
 
-#        lnlscan['dloglike_fit'] = \
-#            utils.parabola(np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
-#                           np.linspace(0,nstep-1.0,nstep)[np.newaxis,:],
-#                           *scan_fit['popt']).reshape((nstep,nstep))
+        #        lnlscan['dloglike_fit'] = \
+        #            utils.parabola(np.linspace(0,nstep-1.0,nstep)[:,np.newaxis],
+        #                           np.linspace(0,nstep-1.0,nstep)[np.newaxis,:],
+        #                           *scan_fit['popt']).reshape((nstep,nstep))
 
         o['lnlscan'] = lnlscan
 
@@ -406,7 +405,7 @@ class SourceFinder(object):
                               '(glon,glat) = (%10.4f,%10.4f)\n'
                               'offset = %8.4f deltax = %8.4f '
                               'deltay = %8.4f',
-                              o['ra'],o['dec'],o['glon'],o['glat'],
+                              o['ra'], o['dec'], o['glon'], o['glat'],
                               o['offset'], o['deltax'],
                               o['deltay'])
         else:
@@ -417,8 +416,8 @@ class SourceFinder(object):
                              'offset = %8.4f r68 = %8.4f',
                              o['ra'], o['dec'],
                              o['glon'], o['glat'],
-                             o['offset'],o['r68'])
-            
+                             o['offset'], o['r68'])
+
         self.roi[name]['localize'] = copy.deepcopy(o)
 
         try:
@@ -429,9 +428,8 @@ class SourceFinder(object):
             self.logger.error('Plot failed.', exc_info=True)
 
         if update and o['fit_success']:
-
             self.logger.info('Updating source %s '
-                             'to localized position.',name)
+                             'to localized position.', name)
             src = self.delete_source(name)
             src.set_position(new_skydir)
             src.set_name(newname, names=src.names)
@@ -442,7 +440,6 @@ class SourceFinder(object):
             self.roi[name]['localize'] = copy.deepcopy(o)
 
         if o['fit_success']:
-
             src = self.roi.get_source_by_name(newname)
             src['pos_sigma'] = o['sigma']
             src['pos_sigma_semimajor'] = o['sigma_semimajor']
@@ -458,6 +455,8 @@ class SourceFinder(object):
     def _localize_tscube(self, name, **kwargs):
         """Localize a source from a TS map generated with
         `~fermipy.gtanalysis.GTAnalysis.tscube`. """
+        import matplotlib.pyplot as plt
+        from fermipy.plotting import ROIPlotter
 
         prefix = kwargs.get('prefix', '')
 
@@ -469,7 +468,7 @@ class SourceFinder(object):
         self.zero_source(name)
         tscube = self.tscube(utils.join_strings([prefix,
                                                  name.lower().
-                                                 replace(' ', '_')]),
+                                                replace(' ', '_')]),
                              wcs=wp.wcs, npix=wp.npix,
                              remake_test_source=False)
         self.unzero_source(name)
@@ -477,8 +476,6 @@ class SourceFinder(object):
         tsmap_renorm = copy.deepcopy(tscube['ts'])
         tsmap_renorm._counts -= np.max(tsmap_renorm._counts)
 
-        import matplotlib.pyplot as plt
-        from fermipy.plotting import ROIPlotter
         plt.figure()
 
         p = ROIPlotter(tsmap_renorm, roi=self.roi)
@@ -499,7 +496,7 @@ class SourceFinder(object):
         skydir = src.skydir
         skywcs = self._skywcs
         tsmap = self.tsmap(utils.join_strings([prefix, name.lower().
-                                               replace(' ', '_')]),
+                                              replace(' ', '_')]),
                            model=src.data,
                            map_skydir=skydir,
                            map_size=2.0 * dtheta_max,

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -1,20 +1,15 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import logging
-
 import numpy as np
-
 from astropy.coordinates import SkyCoord
-
 import fermipy.config
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 from fermipy.sourcefind_utils import fit_error_ellipse
 from fermipy.sourcefind_utils import find_peaks
 from fermipy.skymap import Map
-
 from LikelihoodState import LikelihoodState
 
 

--- a/fermipy/sourcefind_utils.py
+++ b/fermipy/sourcefind_utils.py
@@ -1,12 +1,8 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from scipy.ndimage.filters import maximum_filter
-import scipy
-
 from astropy.coordinates import SkyCoord
-
 from fermipy import utils
 
 

--- a/fermipy/sourcefind_utils.py
+++ b/fermipy/sourcefind_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import numpy as np
 from scipy.ndimage.filters import maximum_filter
 from astropy.coordinates import SkyCoord

--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
 

--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import copy
 import numpy as np
 

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import numpy as np
 import astropy.io.fits as pyfits
 import fermipy.utils as utils

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -1,10 +1,7 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-
 import astropy.io.fits as pyfits
-
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python
-#
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Utilities to fit dark matter spectra to castro data
 """
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-
 import scipy.stats as stats
 import scipy.optimize as opt
-
 from fermipy import castro
 
 

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -2,7 +2,7 @@
 """
 Utilities to fit dark matter spectra to castro data
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import numpy as np
 import scipy.stats as stats
 import scipy.optimize as opt

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -10,36 +10,34 @@ from fermipy import castro
 
 
 class prior_functor:
-    """ A functor class that wraps simple functions we use to make priors 
-    on paramters.    
+    """A functor class that wraps simple functions we use to make priors on parameters.
     """
+
     def __init__(self):
-        pass       
+        pass
 
     def normalization(self):
-        """ The normalization 
-        i.e., the intergral of the function over the normalization_range 
+        """Normalization, i.e. the integral of the function over the normalization_range.
         """
         return 1.
 
     def normalization_range(self):
-        """ The normalization range.
+        """Normalization range.
         """
-        return (0,np.inf)
+        return 0, np.inf
 
     def mean(self):
-        """ The mean value of the function.
+        """Mean value of the function.
         """
         return 1.
 
     def marginalization_bins(self):
-        """ The binning to use to do the marginalization integrals
-        """ 
+        """Binning to use to do the marginalization integrals
+        """
         log_mean = np.log10(self.mean())
         # Default is to marginalize over two decades,
         # centered on mean, using 1000 bins
-        return np.logspace(-1.+log_mean,1.+log_mean,1001)
-
+        return np.logspace(-1. + log_mean, 1. + log_mean, 1001)
 
 
 class lognorm_prior(prior_functor):
@@ -67,73 +65,76 @@ class lognorm_prior(prior_functor):
 
     Remember, pdf in log space is
     plot( log(x), stats.lognorm(sigma,scale=exp(mean)).pdf(x)*x )
-    """
-    def __init__(self,mu,sigma):
-        """ C'tor
 
-        Parameters
-        ----------
-        mu    :  The mean value of the function
-        sigma :  The variance of the underlying gaussian distribution
-        """
+    Parameters
+    ----------
+    mu : float
+        Mean value of the function
+    sigma : float
+        Variance of the underlying gaussian distribution
+    """
+
+    def __init__(self, mu, sigma):
         self._mu = mu
         self._sigma = sigma
 
     def mean(self):
-        """ .The mean value of the function.
+        """Mean value of the function.
         """
         return self._mu
 
-    def __call__(self,x):
-        """ Log-normal function from scipy """
-        return stats.lognorm(self._sigma,scale=self._mu).pdf(x)
+    def __call__(self, x):
+        """Log-normal function from scipy."""
+        return stats.lognorm(self._sigma, scale=self._mu).pdf(x)
 
 
 class norm_prior(prior_functor):
-    """ A wrapper around the lormal function.
+    """A wrapper around the lormal function.
 
     Parameters
     ----------
-    mu    :  The mean value of the function
-    sigma :  The variance of the function
+    mu : float
+        Mean value of the function
+    sigma : float
+        Variance of the underlying gaussian distribution
     """
-    def __init__(self,mu,sigma):
-        """
-        """
+
+    def __init__(self, mu, sigma):
         self._mu = mu
         self._sigma = sigma
 
     def mean(self):
-        """ .The mean value of the function.
+        """Mean value of the function.
         """
-        return self._mu    
+        return self._mu
 
-    def __call__(self,x):
-        """ Normal function from scipy """
-        return stats.norm(loc=self._mu,scale=self._sigma).pdf(x)
+    def __call__(self, x):
+        """Normal function from scipy """
+        return stats.norm(loc=self._mu, scale=self._sigma).pdf(x)
 
 
 def create_prior_functor(d):
-    """ Build a prior from a dictionary
+    """Build a prior from a dictionary.
 
     Parameters
     ----------
-    d     :  A dictionary, it must contain:
-       d['functype'] : 'lognorm' or 'norm' 
-       and all of the required parameters for the prior_functor of the desired type
-
+    d : dict
+        A dictionary, it must contain:
+        d['functype'] : 'lognorm' or 'norm'
+        and all of the required parameters for the prior_functor of the desired type
     """
-    functype = d.pop('functype','lognorm')
+    functype = d.pop('functype', 'lognorm')
+
     if functype == 'norm':
         return norm_prior(**d)
     elif functype == 'lognorm':
         return lognorm_prior(**d)
     else:
-        raise KeyError("Unrecognized prior_functor type %s"%functype)
+        raise KeyError("Unrecognized prior_functor type %s" % functype)
 
 
 class LnLFn_norm_prior:
-    """ A class to add a prior on normalization of a LnLFn object
+    """A class to add a prior on normalization of a LnLFn object
 
     L(x,y|z') = L_z(x*y|z')*L_y(y)
 
@@ -161,45 +162,45 @@ class LnLFn_norm_prior:
     result in computing and caching a spline to interpolate values on subsequent calls.
 
     The values returned by __call__ is determined by the ret_type parameter.
+
+
+    Parameters
+    ----------
+    lnlx : '~fermipy.castro.LnLFn'
+       The object wrapping L(x)
+
+    nuis_pdf : '~fermipy.stats_utils.prior_functor'
+       The object wrapping L(y)
+
+    ret_type : str
+       determine what is returned by __call__
+       allowed values are 'straight','profile','marginal','posterior'
     """
-    def __init__(self,lnlfn,nuis_pdf,ret_type='profile'):
-        """ C'tor
 
-        Parameters
-        ----------
-        lnlx : '~fermipy.castro.LnLFn' 
-           The object wrapping L(x)  
-
-        nuis_pdf : '~fermipy.stats_utils.prior_functor'
-           The object wrapping L(y)
-
-        ret_type : str
-           determine what is returned by __call__
-           allowed values are 'straight','profile','marginal','posterior'        
-        """
+    def __init__(self, lnlfn, nuis_pdf, ret_type='profile'):
         self._lnlfn = lnlfn
         self._nuis_pdf = nuis_pdf
         self._nuis_norm = nuis_pdf.normalization()
         self._nuis_log_norm = np.log(self._nuis_norm)
         self.clear_cached_values()
-        self.init_return(ret_type) 
+        self.init_return(ret_type)
 
     @property
     def ret_type(self):
-        """ Specifies what is returned by __call__
-        """ 
+        """Specifies what is returned by __call__
+        """
         return self._ret_type
 
     @property
     def interp(self):
-        """ returns a '~fermipy.castro.Interpolator'
+        """A '~fermipy.castro.Interpolator'
 
         That will give interoplated values of the type determined by ret_type
-        """ 
+        """
         return self._interp
 
-    def init_return(self,ret_type):
-        """ Specify the return type
+    def init_return(self, ret_type):
+        """Specify the return type.
 
         Note that this will also construct the '~fermipy.castro.Interpolator' object
         for the request return type.
@@ -216,14 +217,14 @@ class LnLFn_norm_prior:
             self._interp = self._marg_interp
         elif ret_type == "posterior":
             self._posterior(self._lnlfn.interp.x)
-            self._interp = self._post_interp            
+            self._interp = self._post_interp
         else:
-            raise ValueError("Did not recognize return type %s"%ret_type)
+            raise ValueError("Did not recognize return type %s" % ret_type)
+
         self._ret_type = ret_type
 
-
     def clear_cached_values(self):
-        """ Removes all of the cached values and interpolators
+        """Removes all of the cached values and interpolators
         """
         self._prof_interp = None
         self._prof_y = None
@@ -235,170 +236,159 @@ class LnLFn_norm_prior:
         self._interp = None
         self._ret_type = None
 
+    def like(self, x, y):
+        """Evaluate the 2-D likelihood in the x/y parameter space.
 
-    def like(self,x,y):
-        """ Evaluate the 2-D likelihood in the x/y parameter space.
         The dimension of the two input arrays should be the same.
 
         Parameters
         ----------
         x : array_like
-        Array of coordinates in the `x` parameter.
+            Array of coordinates in the `x` parameter.
 
         y : array_like       
-        Array of coordinates in the `y` nuisance parameter.
-        """        
+            Array of coordinates in the `y` nuisance parameter.
+        """
         # This is the negative log-likelihood
-        z = self._lnlfn.interp(x*y)        
-        return np.exp(-z)*self._nuis_pdf(y)/self._nuis_norm
+        z = self._lnlfn.interp(x * y)
+        return np.exp(-z) * self._nuis_pdf(y) / self._nuis_norm
 
+    def loglike(self, x, y):
+        """Evaluate the 2-D log-likelihood in the x/y parameter space.
 
-    def loglike(self,x,y):
-        """ Evaluate the 2-D log-likelihood in the x/y parameter space.
         The dimension of the two input arrays should be the same.
 
         Parameters
         ----------
         x : array_like
-        Array of coordinates in the `x` parameter.
+            Array of coordinates in the `x` parameter.
 
         y : array_like       
-        Array of coordinates in the `y` nuisance parameter.
-        """        
-        vals = -self._lnlfn.interp(x*y) + np.log(self._nuis_pdf(y)) - self._nuis_log_norm
+            Array of coordinates in the `y` nuisance parameter.
+        """
+        vals = -self._lnlfn.interp(x * y) + np.log(self._nuis_pdf(y)) - self._nuis_log_norm
         return vals
 
-
-    def straight_loglike(self,x):
-        """ Return the simple log-likelihood, i.e., L(x)
+    def straight_loglike(self, x):
+        """Return the simple log-likelihood, i.e., L(x)
         """
         return self._lnlfn.interp(x)
 
-    def profile_loglike(self,x):
-        """ Return the profile log-likelihood, 
-            i.e., L_prof(x,y=y_min|z')  : where y_min is the value of y that minimizes L for a given x.
+    def profile_loglike(self, x):
+        """Profile log-likelihood.
 
-            This will used the cached '~fermipy.castro.Interpolator' object if possible, 
-            and construct it if needed.
+        Returns ``L_prof(x,y=y_min|z')``  : where y_min is the value of y that minimizes L for a given x.
+
+        This will used the cached '~fermipy.castro.Interpolator' object if possible,
+        and construct it if needed.
         """
         if self._prof_interp is None:
             # This calculates values and caches the spline 
-            return self._profile_loglike(x)[1]            
+            return self._profile_loglike(x)[1]
 
-        x = np.array(x,ndmin=1)
+        x = np.array(x, ndmin=1)
         return self._prof_interp(x)
 
-    def marginal_loglike(self,x):
-        """ Return the marginal log-likelihood, 
-            i.e., L_marg(x) = \int L(x,y|z') L(y) dy
+    def marginal_loglike(self, x):
+        """Marginal log-likelihood.
 
-            This will used the cached '~fermipy.castro.Interpolator' object if possible,
-            and construct it if needed.
+        Returns ``L_marg(x) = \int L(x,y|z') L(y) dy``
+
+        This will used the cached '~fermipy.castro.Interpolator' object if possible,
+        and construct it if needed.
         """
         if self._marg_interp is None:
             # This calculates values and caches the spline 
             return self._marginal_loglike(x)
 
-        x = np.array(x,ndmin=1)
+        x = np.array(x, ndmin=1)
         return self._marg_interp(x)
 
+    def posterior(self, x):
+        """Posterior function.
 
-    def posterior(self,x):
-        """ Return the posterior function
-            i.e., P(x) = \int L(x,y|z') L(y) dy / \int L(x,y|z') L(y) dx dy
+         Returns ``P(x) = \int L(x,y|z') L(y) dy / \int L(x,y|z') L(y) dx dy``
 
-            This will used the cached '~fermipy.castro.Interpolator' object if possible,
-            and construct it if needed.
+        This will used the cached '~fermipy.castro.Interpolator' object if possible,
+        and construct it if needed.
         """
         if self._post is None:
             return self._posterior(x)
-        x = np.array(x,ndmin=1)
+        x = np.array(x, ndmin=1)
         return self._post_interp(x)
 
-
-    def _profile_loglike(self,x):
-        """ Internal function to calculate and cache the profile likelihood
+    def _profile_loglike(self, x):
+        """Internal function to calculate and cache the profile likelihood
         """
-        x = np.array(x,ndmin=1)
+        x = np.array(x, ndmin=1)
 
         z = []
         y = []
 
         for xtmp in x:
-
-            fn = lambda t: -self.loglike(xtmp,t)
-            ytmp = opt.fmin(fn,1.0,disp=False)[0]
-            ztmp = self.loglike(xtmp,ytmp)
+            fn = lambda t: -self.loglike(xtmp, t)
+            ytmp = opt.fmin(fn, 1.0, disp=False)[0]
+            ztmp = self.loglike(xtmp, ytmp)
             z.append(ztmp)
             y.append(ytmp)
 
         self._prof_y = np.array(y)
         self._prof_z = np.array(z)
         self._prof_z = self._prof_z.max() - self._prof_z
-        self._prof_interp = castro.Interpolator(x,self._prof_z)
-        return self._prof_y,self._prof_z
+        self._prof_interp = castro.Interpolator(x, self._prof_z)
+        return self._prof_y, self._prof_z
 
-
-    def _marginal_loglike(self,x):
-        """ Internal function to calculate and cache the marginal likelihood
+    def _marginal_loglike(self, x):
+        """Internal function to calculate and cache the marginal likelihood
         """
         yedge = self._nuis_pdf.marginalization_bins()
-        yw = yedge[1:]-yedge[:-1]
-        yc = 0.5*(yedge[1:]+yedge[:-1])
+        yw = yedge[1:] - yedge[:-1]
+        yc = 0.5 * (yedge[1:] + yedge[:-1])
 
-        s = self.like(x[:,np.newaxis],yc[np.newaxis,:])
+        s = self.like(x[:, np.newaxis], yc[np.newaxis, :])
 
         # This does the marginalization integral
-        z = 1.*np.sum(s*yw,axis=1)
+        z = 1. * np.sum(s * yw, axis=1)
         self._marg_z = np.zeros(z.shape)
-        msk = z>0
-        self._marg_z[msk] = -1*np.log(z[msk])
+        msk = z > 0
+        self._marg_z[msk] = -1 * np.log(z[msk])
 
         # Extrapolate to unphysical values
         # FIXME, why is this needed
-        dlogzdx = (np.log(z[msk][-1]) - np.log(z[msk][-2]))/(x[msk][-1]-x[msk][-2])
-        self._marg_z[~msk] = self._marg_z[msk][-1] + (self._marg_z[~msk] - self._marg_z[msk][-1])*dlogzdx
-        self._marg_interp = castro.Interpolator(x,self._marg_z)
+        dlogzdx = (np.log(z[msk][-1]) - np.log(z[msk][-2])) / (x[msk][-1] - x[msk][-2])
+        self._marg_z[~msk] = self._marg_z[msk][-1] + (self._marg_z[~msk] - self._marg_z[msk][-1]) * dlogzdx
+        self._marg_interp = castro.Interpolator(x, self._marg_z)
         return self._marg_z
 
-
-    def _posterior(self,x):
-        """ Internal function to calculate and cache the posterior
+    def _posterior(self, x):
+        """Internal function to calculate and cache the posterior
         """
         yedge = self._nuis_pdf.marginalization_bins()
-        yc = 0.5*(yedge[1:]+yedge[:-1])
-        yw = yedge[1:]-yedge[:-1]
+        yc = 0.5 * (yedge[1:] + yedge[:-1])
+        yw = yedge[1:] - yedge[:-1]
 
-
-        like_array = self.like(x[:,np.newaxis],yc[np.newaxis,:])*yw 
+        like_array = self.like(x[:, np.newaxis], yc[np.newaxis, :]) * yw
         like_array /= like_array.sum()
 
         self._post = like_array.sum(1)
-        self._post_interp = castro.Interpolator(x,self._post)
+        self._post_interp = castro.Interpolator(x, self._post)
         return self._post
 
+    def __call__(self, x):
+        """Evaluate the quantity specified by ret_type parameter
 
-    def __call__(self,x):
-        """ Evaluate the quantity specified by ret_type parameter
-
-           x : array-like
+        Parameters
+        ----------
+        x : array-like
+            x value
         """
         return np.squeeze(self._interp(x))
 
-
     def mle(self):
-        """ Maximum likelihood estimator """
-
+        """Maximum likelihood estimator.
+        """
         xmax = self._lnlfn.interp.xmax
-        x0 = max(self._lnlfn.mle(),xmax*1e-5)
-        ret = opt.fmin(lambda x: np.where(xmax>x>0, -self(x), np.inf), x0, disp=False)                       
+        x0 = max(self._lnlfn.mle(), xmax * 1e-5)
+        ret = opt.fmin(lambda x: np.where(xmax > x > 0, -self(x), np.inf), x0, disp=False)
         mle = float(ret[0])
-        return ret
-
-
-
-
-
-if __name__ == "__main__":
-
-    pass
+        return mle

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -1,43 +1,34 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
-
-from numpy.testing import assert_allclose
 import numpy as np
-
+from numpy.testing import assert_allclose
 from fermipy import castro
 
 
 def test_castro_test_spectra_sed(tmpdir):
-
     sedfile = str(tmpdir.join('sed.fits'))
     url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extras/master/data/sed.fits'
-    os.system('curl -o %s -OL %s'%(sedfile,url))
+    os.system('curl -o %s -OL %s' % (sedfile, url))
     c = castro.CastroData.create_from_sedfile(sedfile)
     test_dict = c.test_spectra()
 
-    assert( np.abs(test_dict['PowerLaw']['TS'][0] -  26.88) < 0.01)
-    assert( np.abs(test_dict['LogParabola']['TS'][0] -  27.30) < 0.01)
-    assert( np.abs(test_dict['PLExpCutoff']['TS'][0] -  28.17) < 0.01)
+    assert_allclose(test_dict['PowerLaw']['TS'][0], 26.88, atol=0.01)
+    assert_allclose(test_dict['LogParabola']['TS'][0], 27.30, atol=0.01)
+    assert_allclose(test_dict['PLExpCutoff']['TS'][0], 28.17, atol=0.01)
 
-    assert_allclose(test_dict['PowerLaw']['Result'],np.array([  1.10610705e-16,  -3.86502196e+00]))
-    assert_allclose(test_dict['LogParabola']['Result'],np.array([  4.22089847e-17,  -3.71123256e+00,  -5.72287142e-02]))
-    assert_allclose(test_dict['PLExpCutoff']['Result'],np.array([  5.53464102e-13,  -2.88974835e+00,   1.19098881e+00]))
+    assert_allclose(test_dict['PowerLaw']['Result'], np.array([1.10610705e-16, -3.86502196e+00]))
+    assert_allclose(test_dict['LogParabola']['Result'], np.array([4.22089847e-17, -3.71123256e+00, -5.72287142e-02]))
+    assert_allclose(test_dict['PLExpCutoff']['Result'], np.array([5.53464102e-13, -2.88974835e+00, 1.19098881e+00]))
 
 
 def test_castro_test_spectra_castro(tmpdir):
-
     castrofile = str(tmpdir.join('castro.fits'))
     url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extras/master/data/castro.fits'
-    os.system('curl -o %s -OL %s'%(castrofile,url))
-    c = castro.CastroData.create_from_fits(castrofile,irow=0)
+    os.system('curl -o %s -OL %s' % (castrofile, url))
+    c = castro.CastroData.create_from_fits(castrofile, irow=0)
     test_dict = c.test_spectra()
 
-    assert( np.abs(test_dict['PowerLaw']['TS'][0] -  2.74) < 0.01)
-    assert( np.abs(test_dict['LogParabola']['TS'][0] -  3.72) < 0.01)
-    assert( np.abs(test_dict['PLExpCutoff']['TS'][0] -  3.70) < 0.01)
-
-
-
-
+    assert_allclose(test_dict['PowerLaw']['TS'][0], 2.74, atol=0.01)
+    assert_allclose(test_dict['LogParabola']['TS'][0], 3.72, atol=0.01)
+    assert_allclose(test_dict['PLExpCutoff']['TS'][0], 3.70, atol=0.01)

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -5,8 +5,12 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from fermipy.tests.utils import requires_dependency
-from fermipy import gtanalysis
 from fermipy import spectrum
+
+try:
+    from fermipy import gtanalysis
+except ImportError:
+    pass
 
 # Skip tests in this file if Fermi ST aren't available
 pytestmark = requires_dependency('Fermi ST')

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
+# Note: we don't use __future__.unicode_literals here on purpose
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
-# Note: we don't use __future__.unicode_literals here on purpose
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -1,11 +1,15 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
+from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from .. import gtanalysis
-from .. import spectrum
+from fermipy.tests.utils import requires_dependency
+from fermipy import gtanalysis
+from fermipy import spectrum
+
+# Skip tests in this file if Fermi ST aren't available
+pytestmark = requires_dependency('Fermi ST')
 
 
 @pytest.fixture(scope='module')
@@ -14,13 +18,13 @@ def setup(request, tmpdir_factory):
 
     print('\ndownload')
     url = 'https://www.dropbox.com/s/8a9ebwolxmif1n6/fermipy_test0_small.tar.gz'
-#    'https://www.dropbox.com/s/b5zln7ku780xvzq/fermipy_test0.tar.gz'
+    #    'https://www.dropbox.com/s/b5zln7ku780xvzq/fermipy_test0.tar.gz'
 
-#    dirname = os.path.abspath(os.path.dirname(__file__))
+    #    dirname = os.path.abspath(os.path.dirname(__file__))
     outfile = path.join('fermipy_test0_small.tar.gz')
     dirname = path.join()
-    #os.system('wget -nc %s -O %s' % (url, outfile))
-    os.system('curl -o %s -OL %s'%(outfile,url))
+    # os.system('wget -nc %s -O %s' % (url, outfile))
+    os.system('curl -o %s -OL %s' % (outfile, url))
     os.system('cd %s;tar xzf %s' % (dirname, outfile))
 
     os.system('touch %s' % path.join('test.txt'))
@@ -28,45 +32,34 @@ def setup(request, tmpdir_factory):
 
     cfgfile = path.join('fermipy_test0_small', 'config.yaml')
 
-    print(cfgfile)
-
     gta = gtanalysis.GTAnalysis(str(cfgfile))
     gta.setup()
 
     return gta
 
 
-#@pytest.mark.skipif("True")
 def test_gtanalysis_setup(setup):
-
     gta = setup
     gta.print_roi()
 
 
-#@pytest.mark.skipif("True")
 def test_gtanalysis_write_roi(setup):
-
     gta = setup
     gta.write_roi('test')
 
 
 def test_gtanalysis_load_roi(setup):
-
     gta = setup
     gta.load_roi('fit0')
 
 
 def test_gtanalysis_optimize(setup):
-
     gta = setup
     gta.load_roi('fit0')
     gta.optimize()
 
 
 def test_gtanalysis_fit(setup):
-
-    import pprint
-
     gta = setup
     gta.load_roi('fit0')
     gta.free_sources(distance=3.0, pars='norm')
@@ -75,28 +68,22 @@ def test_gtanalysis_fit(setup):
     gta.load_xml('fit_test')
     fit_output1 = gta.fit(optimizer='NEWMINUIT')
 
-    pprint.pprint(fit_output0)
-    pprint.pprint(fit_output1)
-
-    assert(np.abs(fit_output0['loglike']-fit_output1['loglike']) < 0.01)
+    assert (np.abs(fit_output0['loglike'] - fit_output1['loglike']) < 0.01)
 
 
 def test_gtanalysis_tsmap(setup):
-
     gta = setup
     gta.load_roi('fit1')
     gta.tsmap(model={})
 
 
 def test_gtanalysis_residmap(setup):
-
     gta = setup
     gta.load_roi('fit1')
     gta.residmap(model={})
 
 
 def test_gtanalysis_sed(setup):
-
     gta = setup
     gta.load_roi('fit1')
     np.random.seed(1)
@@ -110,11 +97,11 @@ def test_gtanalysis_sed(setup):
     emax = gta.energies[1:]
 
     flux_true = spectrum.PowerLaw.eval_flux(emin, emax,
-                                            [prefactor,-index],scale)
+                                            [prefactor, -index], scale)
 
     gta.simulate_source({'SpatialModel': 'PointSource',
-                         'Index' : index,
-                         'Scale' : scale,
+                         'Index': index,
+                         'Scale': scale,
                          'Prefactor': prefactor})
 
     gta.free_source('draco')
@@ -122,18 +109,20 @@ def test_gtanalysis_sed(setup):
 
     o = gta.sed('draco')
 
-    flux_resid = np.abs((flux_true - o['flux'])/o['flux_err'])
+    flux_resid = (flux_true - o['flux']) / o['flux_err']
+    assert_allclose(flux_resid, 0, atol=3.0)
+
     params = gta.roi['draco'].params
-    assert(np.all(flux_resid<3.0))
-    assert(np.abs(-params['Index'][0]-index)/params['Index'][1] < 3.0)
-    assert(np.abs(params['Prefactor'][0]-prefactor)/
-           params['Prefactor'][1] < 3.0)
+    index_resid = (-params['Index'][0] - index) / params['Index'][1]
+    assert_allclose(index_resid, 0, atol=3.0)
+
+    prefactor_resid = (params['Prefactor'][0] - prefactor) / params['Prefactor'][1]
+    assert_allclose(prefactor_resid, 0, atol=3.0)
 
     gta.simulate_roi(restore=True)
 
 
 def test_gtanalysis_extension_gaussian(setup):
-
     gta = setup
     gta.simulate_roi(restore=True)
     gta.load_roi('fit1')
@@ -148,13 +137,12 @@ def test_gtanalysis_extension_gaussian(setup):
                       width=[0.4, 0.45, 0.5, 0.55, 0.6],
                       spatial_model='GaussianSource')
 
-    assert(np.abs(o['ext']-spatial_width) < 0.1)
+    assert_allclose(o['ext'], spatial_width, atol=0.1)
 
     gta.simulate_roi(restore=True)
 
 
 def test_gtanalysis_localization(setup):
-
     gta = setup
     gta.simulate_roi(restore=True)
     gta.load_roi('fit1')
@@ -172,15 +160,11 @@ def test_gtanalysis_localization(setup):
     gta.add_source('testloc', src_dict, free=True)
     gta.fit()
 
-    o = gta.localize('testloc', nstep=5, dtheta_max=0.5,
-                     update=True)
+    result = gta.localize('testloc', nstep=5, dtheta_max=0.5, update=True)
 
-    import pprint
-    pprint.pprint(o)
-
-    assert(o['fit_success'] is True)
-    assert(np.abs(o['glon']-86.0) < 0.02)
-    assert(np.abs(o['glat']-36.0) < 0.02)
+    assert result['fit_success'] is True
+    assert_allclose(result['glon'], 86.0, atol=0.02)
+    assert_allclose(result['glat'], 36.0, atol=0.02)
     gta.delete_source('testloc')
 
     gta.simulate_roi(restore=True)

--- a/fermipy/tests/test_roi_model.py
+++ b/fermipy/tests/test_roi_model.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import xml.etree.cElementTree as ElementTree
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest

--- a/fermipy/tests/test_roi_model.py
+++ b/fermipy/tests/test_roi_model.py
@@ -4,8 +4,12 @@ import xml.etree.cElementTree as ElementTree
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from fermipy.tests.utils import requires_dependency
-from fermipy import roi_model
-from fermipy.roi_model import Source
+
+try:
+    from fermipy import roi_model
+    from fermipy.roi_model import Source
+except ImportError:
+    pass
 
 # Skip tests in this file if Fermi ST aren't available
 pytestmark = requires_dependency('Fermi ST')

--- a/fermipy/tests/test_roi_model.py
+++ b/fermipy/tests/test_roi_model.py
@@ -1,10 +1,14 @@
-from astropy.tests.helper import pytest
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import xml.etree.cElementTree as ElementTree
-
 from numpy.testing import assert_allclose
-
+from astropy.tests.helper import pytest
+from fermipy.tests.utils import requires_dependency
 from fermipy import roi_model
 from fermipy.roi_model import Source
+
+# Skip tests in this file if Fermi ST aren't available
+pytestmark = requires_dependency('Fermi ST')
 
 
 @pytest.fixture(scope='module')
@@ -14,28 +18,25 @@ def tmppath(request, tmpdir_factory):
 
 
 def test_load_3fgl_catalog_fits():
-
     rm = roi_model.ROIModel(catalogs=['3FGL'])
-    assert(len(rm.sources) == 3034)
+    assert len(rm.sources) == 3034
 
     rm = roi_model.ROIModel(catalogs=['gll_psc_v16.fit'])
-    assert(len(rm.sources) == 3034)
+    assert len(rm.sources) == 3034
+
 
 def test_load_3fgl_catalog_xml():
-
     rm = roi_model.ROIModel(catalogs=['gll_psc_v16.xml'],
                             extdir='Extended_archive_v15')
-    assert(len(rm.sources) == 3034)
+    assert len(rm.sources) == 3034
 
 
 def test_load_2fhl_catalog_fits():
-
     rm = roi_model.ROIModel(catalogs=['2FHL'])
-    assert(len(rm.sources) == 360)
+    assert len(rm.sources) == 360
 
 
 def test_load_roi_from_dict(tmppath):
-
     sources = [{'name': 'ptsrc0', 'SpectrumType': 'PowerLaw',
                 'ra': 121.0, 'dec': 32.56,
                 'Index': 2.3, 'Prefactor': 1.3E-15, 'Scale': 1452.0},
@@ -44,7 +45,7 @@ def test_load_roi_from_dict(tmppath):
                 'Index': {'value': 2.3, 'scale': 2.4, 'min': 0.3, 'max': 5.7},
                 'Prefactor': {'value': 1.2, 'scale': 3E-12, 'min': 0.0, 'max': 5.0},
                 'Scale': {'value': 134.1, 'scale': 1.2, 'min': 0.0, 'max': 2000.0},
-               } ]
+                }]
 
     roi = roi_model.ROIModel(sources=sources)
     src = roi['ptsrc0']
@@ -54,9 +55,9 @@ def test_load_roi_from_dict(tmppath):
 
     sp = src['spectral_pars']
 
-    assert_allclose(sp['Index']['value'],sources[0]['Index'])
-    assert_allclose(sp['Scale']['value'],1.452)
-    assert_allclose(sp['Prefactor']['value'],1.3)
+    assert_allclose(sp['Index']['value'], sources[0]['Index'])
+    assert_allclose(sp['Scale']['value'], 1.452)
+    assert_allclose(sp['Prefactor']['value'], 1.3)
 
     for p in ['Index', 'Prefactor', 'Scale']:
         if p == 'Index':
@@ -67,12 +68,11 @@ def test_load_roi_from_dict(tmppath):
     src = roi['ptsrc1']
     sp = src['spectral_pars']
     for p in ['Index', 'Prefactor', 'Scale']:
-        assert_allclose(sources[1][p]['value']*sources[1][p]['scale'],
+        assert_allclose(sources[1][p]['value'] * sources[1][p]['scale'],
                         src.params[p][0])
 
 
 def test_load_source_from_xml(tmppath):
-
     values = {'ptsrc_dec': 52.6356, 'ptsrc_ra': 252.367,
               'ptsrc_index_value': 2.21879, 'ptsrc_index_scale': 1.2,
               'ptsrc_index_min': 1.3, 'ptsrc_index_max': 3.5,
@@ -123,131 +123,127 @@ def test_load_source_from_xml(tmppath):
 
     src = roi['3FGL J1649.4+5238']
 
-    assert_allclose(src['dec'],values['ptsrc_dec'])
-    assert_allclose(src['ra'],values['ptsrc_ra'])
-    assert(src['SpectrumType'] == 'PowerLaw')
-    assert(src['SpatialType'] == 'SkyDirFunction')
-    assert(src['SpatialModel'] == 'PointSource')
-    assert(src['SourceType'] == 'PointSource')
+    assert_allclose(src['dec'], values['ptsrc_dec'])
+    assert_allclose(src['ra'], values['ptsrc_ra'])
+    assert (src['SpectrumType'] == 'PowerLaw')
+    assert (src['SpatialType'] == 'SkyDirFunction')
+    assert (src['SpatialModel'] == 'PointSource')
+    assert (src['SourceType'] == 'PointSource')
 
     sp = src['spectral_pars']
 
     attribs = ['value', 'scale', 'min', 'max']
 
     for x in attribs:
-        assert_allclose(sp['Index'][x],values['ptsrc_index_%s'%x])
+        assert_allclose(sp['Index'][x], values['ptsrc_index_%s' % x])
 
     for x in attribs:
-        assert_allclose(sp['Prefactor'][x],values['ptsrc_prefactor_%s'%x])
+        assert_allclose(sp['Prefactor'][x], values['ptsrc_prefactor_%s' % x])
 
     for x in attribs:
-        assert_allclose(sp['Scale'][x],values['ptsrc_scale_%s'%x])
+        assert_allclose(sp['Scale'][x], values['ptsrc_scale_%s' % x])
 
     assert_allclose(src.params['Prefactor'][0],
-                    values['ptsrc_prefactor_value']*values['ptsrc_prefactor_scale'])
+                    values['ptsrc_prefactor_value'] * values['ptsrc_prefactor_scale'])
     assert_allclose(src.params['Index'][0],
-                    values['ptsrc_index_value']*values['ptsrc_index_scale'])
+                    values['ptsrc_index_value'] * values['ptsrc_index_scale'])
     assert_allclose(src.params['Scale'][0],
-                    values['ptsrc_scale_value']*values['ptsrc_scale_scale'])
+                    values['ptsrc_scale_value'] * values['ptsrc_scale_scale'])
 
     src = roi['galdiff']
-    assert(src['SpatialType'] == 'MapCubeFunction')
-    assert(src['SpatialModel'] == 'MapCubeFunction')
+    assert (src['SpatialType'] == 'MapCubeFunction')
+    assert (src['SpatialModel'] == 'MapCubeFunction')
 
     src = roi['isodiff']
-    assert(src['SpatialType'] == 'ConstantValue')
-    assert(src['SpatialModel'] == 'ConstantValue')
+    assert (src['SpatialType'] == 'ConstantValue')
+    assert (src['SpatialModel'] == 'ConstantValue')
 
 
 def test_create_source_from_dict(tmppath):
-
     ra = 252.367
     dec = 52.6356
 
-    src = Source.create_from_dict({'name' : 'testsrc',
-                                   'SpatialModel' : 'PointSource',
-                                   'SpectrumType' : 'PowerLaw',
-                                   'Index' : 2.3,
-                                   'ra' : ra, 'dec' : dec})
+    src = Source.create_from_dict({'name': 'testsrc',
+                                   'SpatialModel': 'PointSource',
+                                   'SpectrumType': 'PowerLaw',
+                                   'Index': 2.3,
+                                   'ra': ra, 'dec': dec})
 
-    assert_allclose(src['ra'],ra)
-    assert_allclose(src['dec'],dec)
-    assert(src['SpatialModel'] == 'PointSource')
-    assert(src['SpatialType'] == 'SkyDirFunction')
-    assert(src['SourceType'] == 'PointSource')
-    assert(src.extended is False)
+    assert_allclose(src['ra'], ra)
+    assert_allclose(src['dec'], dec)
+    assert src['SpatialModel'] == 'PointSource'
+    assert src['SpatialType'] == 'SkyDirFunction'
+    assert src['SourceType'] == 'PointSource'
+    assert src.extended is False
 
-    src = Source.create_from_dict({'name' : 'testsrc',
-                                   'SpatialModel' : 'GaussianSource',
-                                   'SpectrumType' : 'PowerLaw',
-                                   'Index' : 2.3,
-                                   'ra' : ra, 'dec' : dec})
+    src = Source.create_from_dict({'name': 'testsrc',
+                                   'SpatialModel': 'GaussianSource',
+                                   'SpectrumType': 'PowerLaw',
+                                   'Index': 2.3,
+                                   'ra': ra, 'dec': dec})
 
-    assert_allclose(src['ra'],ra)
-    assert_allclose(src['dec'],dec)
-    assert(src['SpatialModel'] == 'GaussianSource')
-    assert(src['SpatialType'] == 'SpatialMap')
-    assert(src['SourceType'] == 'DiffuseSource')
-    assert(src.extended is True)
+    assert_allclose(src['ra'], ra)
+    assert_allclose(src['dec'], dec)
+    assert src['SpatialModel'] == 'GaussianSource'
+    assert src['SpatialType'] == 'SpatialMap'
+    assert src['SourceType'] == 'DiffuseSource'
+    assert src.extended is True
 
-    src = Source.create_from_dict({'name' : 'testsrc',
-                                   'SpatialModel' : 'RadialGaussian',
-                                   'SpectrumType' : 'PowerLaw',
-                                   'Index' : 2.3, 'Sigma' : 0.5,
-                                   'ra' : ra, 'dec' : dec})
+    src = Source.create_from_dict({'name': 'testsrc',
+                                   'SpatialModel': 'RadialGaussian',
+                                   'SpectrumType': 'PowerLaw',
+                                   'Index': 2.3, 'Sigma': 0.5,
+                                   'ra': ra, 'dec': dec})
 
-    assert_allclose(src['ra'],ra)
-    assert_allclose(src['dec'],dec)
-    assert_allclose(src['Sigma'],0.5)
+    assert_allclose(src['ra'], ra)
+    assert_allclose(src['dec'], dec)
+    assert_allclose(src['Sigma'], 0.5)
     if src['SpatialType'] == 'RadialGaussian':
-        assert_allclose(src.spatial_pars['Sigma']['value'],0.5)
+        assert_allclose(src.spatial_pars['Sigma']['value'], 0.5)
 
-    assert(src['SpatialModel'] == 'RadialGaussian')
-    assert(src['SourceType'] == 'DiffuseSource')
-    assert(src.extended is True)
+    assert src['SpatialModel'] == 'RadialGaussian'
+    assert src['SourceType'] == 'DiffuseSource'
+    assert src.extended is True
 
-    src = Source.create_from_dict({'name' : 'testsrc',
-                                   'SpatialModel' : 'RadialDisk',
-                                   'SpectrumType' : 'PowerLaw',
-                                   'Index' : 2.3, 'Radius' : 0.5,
-                                   'ra' : ra, 'dec' : dec})
+    src = Source.create_from_dict({'name': 'testsrc',
+                                   'SpatialModel': 'RadialDisk',
+                                   'SpectrumType': 'PowerLaw',
+                                   'Index': 2.3, 'Radius': 0.5,
+                                   'ra': ra, 'dec': dec})
 
-    assert_allclose(src['ra'],ra)
-    assert_allclose(src['dec'],dec)
-    assert_allclose(src['Radius'],0.5)
+    assert_allclose(src['ra'], ra)
+    assert_allclose(src['dec'], dec)
+    assert_allclose(src['Radius'], 0.5)
     if src['SpatialType'] == 'RadialDisk':
-        assert_allclose(src.spatial_pars['Radius']['value'],0.5)
+        assert_allclose(src.spatial_pars['Radius']['value'], 0.5)
 
-    assert(src['SpatialModel'] == 'RadialDisk')
-    assert(src['SourceType'] == 'DiffuseSource')
-    assert(src.extended is True)
+    assert src['SpatialModel'] == 'RadialDisk'
+    assert src['SourceType'] == 'DiffuseSource'
+    assert src.extended is True
 
 
 def test_create_source(tmppath):
-
     ra = 252.367
     dec = 52.6356
     sigma = 0.5
 
-    src_dict = {'SpatialModel' : 'GaussianSource', 'ra' : ra, 'dec' : dec, 'Sigma' : sigma}    
-    src = Source('testsrc',src_dict)
+    src_dict = {'SpatialModel': 'GaussianSource', 'ra': ra, 'dec': dec, 'Sigma': sigma}
+    src = Source('testsrc', src_dict)
 
-    assert_allclose(src['ra'],ra)
-    assert_allclose(src['dec'],dec)
-    assert_allclose(src['Sigma'],sigma)
-    assert(src['SpatialModel'] == 'GaussianSource')
+    assert_allclose(src['ra'], ra)
+    assert_allclose(src['dec'], dec)
+    assert_allclose(src['Sigma'], sigma)
+    assert src['SpatialModel'] == 'GaussianSource'
 
 
 def test_set_spatial_model(tmppath):
-
     ra = 252.367
     dec = 52.6356
 
-    src_dict = {'SpatialModel' : 'GaussianSource', 'ra' : ra, 'dec' : dec}    
-    src = Source('testsrc',src_dict)
+    src_dict = {'SpatialModel': 'GaussianSource', 'ra': ra, 'dec': dec}
+    src = Source('testsrc', src_dict)
 
     src.set_spatial_model('PointSource')
-    assert(src['SpatialModel'] == 'PointSource')
-    assert(src['SpatialType'] == 'SkyDirFunction')
-    assert(src['SourceType'] == 'PointSource')
-
+    assert src['SpatialModel'] == 'PointSource'
+    assert src['SpatialType'] == 'SkyDirFunction'
+    assert src['SourceType'] == 'PointSource'

--- a/fermipy/tests/test_skymap.py
+++ b/fermipy/tests/test_skymap.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function
+import numpy as np
+from fermipy.hpx_utils import HPX
+from fermipy.fits_utils import write_fits_image
+from fermipy.skymap import HpxMap
+
+
+def test_hpxmap(tmpdir):
+    n = np.ones((10, 192), 'd')
+    hpx = HPX(4, False, 'GAL')
+
+    filename = str(tmpdir / 'test_hpx.fits')
+    hpx.write_fits(n, filename, clobber=True)
+
+    ebins = np.logspace(2, 5, 8)
+
+    hpx_2 = HPX(1024, False, 'GAL', region='DISK(110.,75.,2.)', ebins=ebins)
+    npixels = hpx_2.npix
+
+    n2 = np.ndarray((8, npixels), 'd')
+    for i in range(8):
+        n2[i].flat = np.arange(npixels)
+
+    hpx_map = HpxMap(n2, hpx_2)
+    wcs, wcs_data = hpx_map.make_wcs_from_hpx(normalize=True)
+
+    wcs_out = hpx_2.make_wcs(3)
+
+    filename = str(tmpdir / 'test_hpx_2_wcs.fits')
+    write_fits_image(wcs_data, wcs_out, filename)
+
+    # TODO: add assert statements

--- a/fermipy/tests/utils.py
+++ b/fermipy/tests/utils.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.tests.helper import pytest
+
+__all__ = ['requires_dependency']
+
+
+def requires_dependency(name):
+    """Decorator to declare required dependencies for tests.
+
+    Examples
+    --------
+
+    ::
+
+        from fermipy.tests.utils import requires_dependency
+
+        @requires_dependency('scipy')
+        def test_using_scipy():
+            import scipy
+            ...
+
+        @requires_dependency('Fermi ST')
+        def test_using_fermi_science_tools():
+            import pyLikelihood
+            ...
+    """
+    if name == 'Fermi ST':
+        name = 'pyLikelihood'
+
+    try:
+        __import__(name)
+        skip_it = False
+    except ImportError:
+        skip_it = True
+
+    reason = 'Missing dependency: {}'.format(name)
+    return pytest.mark.skipif(skip_it, reason=reason)

--- a/fermipy/tests/utils.py
+++ b/fermipy/tests/utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 from astropy.tests.helper import pytest
 
 __all__ = ['requires_dependency']

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import copy
 import logging

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -1,22 +1,17 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import logging
 import itertools
 import functools
 from multiprocessing import Pool
-
 import numpy as np
 import warnings
-
 import pyLikelihood as pyLike
-
 import astropy.io.fits as pyfits
 from astropy.table import Table
 import astropy.wcs as pywcs
-
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.fits_utils as fits_utils
@@ -24,9 +19,7 @@ import fermipy.plotting as plotting
 import fermipy.castro as castro
 from fermipy.skymap import Map
 from fermipy.roi_model import Source
-
 from fermipy.spectrum import PowerLaw
-
 from LikelihoodState import LikelihoodState
 
 MAX_NITER = 100

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -1,20 +1,17 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import re
 import copy
 from collections import OrderedDict
-
+import xml.etree.cElementTree as et
 import yaml
 import numpy as np
-import scipy
-import xml.etree.cElementTree as et
-from astropy.extern import six
 import scipy.optimize
 from scipy.interpolate import UnivariateSpline
 from scipy.optimize import brentq
 import scipy.special as special
+from astropy.extern import six
 
 
 def unicode_representer(dumper, uni):
@@ -111,7 +108,6 @@ def match_regex_list(patterns, string):
 
 
 def join_strings(strings, sep='_'):
-
     if strings is None:
         return ''
     else:
@@ -135,11 +131,11 @@ def format_filename(outdir, basename, prefix=None, extension=None):
 
 
 def strip_suffix(filename, suffix):
-
     for s in suffix:
         filename = re.sub(r'\.%s$' % s, '', filename)
 
     return filename
+
 
 RA_NGP = np.radians(192.8594812065348)
 DEC_NGP = np.radians(27.12825118085622)
@@ -147,7 +143,6 @@ L_CP = np.radians(122.9319185680026)
 
 
 def gal2eq(l, b):
-
     L_0 = L_CP - np.pi / 2.
     RA_0 = RA_NGP + np.pi / 2.
 
@@ -181,7 +176,6 @@ def gal2eq(l, b):
 
 
 def eq2gal(ra, dec):
-
     L_0 = L_CP - np.pi / 2.
     RA_0 = RA_NGP + np.pi / 2.
     DEC_0 = np.pi / 2. - DEC_NGP
@@ -335,7 +329,6 @@ def create_model_name(src):
 
 
 def cov_to_correlation(cov):
-
     err = np.sqrt(np.diag(cov))
     corr = np.array(cov)
     corr *= np.outer(1 / err, 1 / err)
@@ -443,10 +436,10 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, tol=1E-3):
     deltalnl = cl_to_dlnl(ul_confidence)
 
     spline = UnivariateSpline(xval, loglike, k=2, s=tol)
-    #m = np.abs(loglike[1:] - loglike[:-1]) > delta_tol
-    #xval = np.concatenate((xval[:1],xval[1:][m]))
-    #loglike = np.concatenate((loglike[:1],loglike[1:][m]))
-    #spline = InterpolatedUnivariateSpline(xval, loglike, k=2)
+    # m = np.abs(loglike[1:] - loglike[:-1]) > delta_tol
+    # xval = np.concatenate((xval[:1],xval[1:][m]))
+    # loglike = np.concatenate((loglike[:1],loglike[1:][m]))
+    # spline = InterpolatedUnivariateSpline(xval, loglike, k=2)
 
     sd = spline.derivative()
 
@@ -481,10 +474,9 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, tol=1E-3):
 
 
 def poly_to_parabola(coeff):
-
     sigma = np.sqrt(1. / np.abs(2.0 * coeff[0]))
     x0 = -coeff[1] / (2 * coeff[0])
-    y0 = (1. - (coeff[1]**2 - 4 * coeff[0] * coeff[2])) / (4 * coeff[0])
+    y0 = (1. - (coeff[1] ** 2 - 4 * coeff[0] * coeff[2])) / (4 * coeff[0])
 
     return x0, sigma, y0
 
@@ -535,10 +527,10 @@ def parabola(xy, amplitude, x0, y0, sx, sy, theta):
        `xy` input tuple.
     
     """
-    
+
     x = xy[0]
     y = xy[1]
-    
+
     cth = np.cos(theta)
     sth = np.sin(theta)
     a = (cth ** 2) / (2 * sx ** 2) + (sth ** 2) / (2 * sy ** 2)
@@ -574,7 +566,7 @@ def fit_parabola(z, ix, iy, dpix=2, zmin=None):
        centroid.  The size of the sub-array will be (dpix*2 + 1) x
        (dpix*2 + 1).
     """
-    
+
     xmin = max(0, ix - dpix)
     xmax = min(z.shape[0], ix + dpix + 1)
 
@@ -606,7 +598,7 @@ def fit_parabola(z, ix, iy, dpix=2, zmin=None):
 
     def curve_fit_fn(*args):
         return np.ravel(parabola(*args))
-        
+
     try:
         popt, pcov = scipy.optimize.curve_fit(curve_fit_fn,
                                               (np.ravel(x[m]), np.ravel(y[m])),
@@ -617,14 +609,14 @@ def fit_parabola(z, ix, iy, dpix=2, zmin=None):
 
     fm = parabola((x[m], y[m]), *popt)
     df = fm - z[sx, sy][m]
-    rchi2 = np.sum(df**2) / len(fm)
+    rchi2 = np.sum(df ** 2) / len(fm)
 
     o['rchi2'] = rchi2
     o['x0'] = popt[1]
     o['y0'] = popt[2]
     o['sigmax'] = popt[3]
     o['sigmay'] = popt[4]
-    o['sigma'] = np.sqrt(o['sigmax']**2 + o['sigmay']**2)
+    o['sigma'] = np.sqrt(o['sigmax'] ** 2 + o['sigmay'] ** 2)
     o['z0'] = popt[0]
     o['theta'] = popt[5]
     o['popt'] = popt
@@ -632,8 +624,8 @@ def fit_parabola(z, ix, iy, dpix=2, zmin=None):
     a = max(o['sigmax'], o['sigmay'])
     b = min(o['sigmax'], o['sigmay'])
 
-    o['eccentricity'] = np.sqrt(1 - b**2 / a**2)
-    o['eccentricity2'] = np.sqrt(a**2 / b**2 - 1)
+    o['eccentricity'] = np.sqrt(1 - b ** 2 / a ** 2)
+    o['eccentricity2'] = np.sqrt(a ** 2 / b ** 2 - 1)
 
     return o
 
@@ -743,7 +735,6 @@ def isstr(s):
 
 
 def xmlpath_to_path(path):
-
     if path is None:
         return path
 
@@ -751,7 +742,6 @@ def xmlpath_to_path(path):
 
 
 def path_to_xmlpath(path):
-
     if path is None:
         return path
 
@@ -795,17 +785,15 @@ def prettify_xml(elem):
 
 
 def arg_to_list(arg):
-
     if arg is None:
-        return []    
-    elif isinstance(arg,list):
+        return []
+    elif isinstance(arg, list):
         return arg
     else:
         return [arg]
 
 
 def update_keys(input_dict, key_map):
-
     o = {}
     for k, v in input_dict.items():
 
@@ -1007,7 +995,7 @@ def convolve2d_disk(fn, r, sig, nstep=200):
     delta = (rmax - rmin) / nstep
 
     redge = rmin[:, np.newaxis] + \
-        delta[:, np.newaxis] * np.linspace(0, nstep, nstep + 1)[np.newaxis, :]
+            delta[:, np.newaxis] * np.linspace(0, nstep, nstep + 1)[np.newaxis, :]
     rp = 0.5 * (redge[:, 1:] + redge[:, :-1])
     dr = redge[:, 1:] - redge[:, :-1]
     fnv = fn(rp)

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import re
 import copy

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -1,16 +1,11 @@
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
-
 import numpy as np
-
 from astropy.wcs import WCS
 from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-
 import fermipy.utils as utils
 
 
@@ -20,7 +15,6 @@ class WCSProj(object):
     helper methods for accessing the properties of the WCS object."""
 
     def __init__(self, wcs, npix):
-
         self._wcs = wcs
         self._npix = np.array(npix, ndmin=1)
         self._coordsys = get_coordsys(wcs)
@@ -64,7 +58,6 @@ class WCSProj(object):
 
     @staticmethod
     def create(skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
-
         npix = np.array(npix, ndmin=1)
         crpix = npix / 2. + 0.5
         wcs = create_wcs(skydir, coordsys, projection,
@@ -103,10 +96,8 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
 
     Parameters
     ----------
-
     skydir : `~astropy.coordinates.SkyCoord`
         Sky coordinate of the WCS reference point.
-
     coordsys : str
 
     projection : str
@@ -115,13 +106,10 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
 
     crpix : float or (float,float)
         In the first case the same value is used for x and y axes
-
-    naxis : 2
-       Number of dimensions of the projection.  Valid inputs are 2 or 3.
-
+    naxis : {2, 3}
+       Number of dimensions of the projection.
     energies : array-like
        Array of energies that defines the third dimension if naxis=3.
-
     """
 
     w = WCS(naxis=naxis)
@@ -160,16 +148,14 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
 
 
 def wcs_add_energy_axis(wcs, energies):
-    """ Copy a WCS object, and add on the energy axis
+    """Copy a WCS object, and add on the energy axis.
 
     Parameters
     ----------
-
     wcs : `~astropy.wcs.WCS`
-
+        WCS
     energies : array-like
        Array of energies.
-
     """
     if wcs.naxis != 2:
         raise Exception(
@@ -231,12 +217,13 @@ def offset_to_skydir(skydir, offset_lon, offset_lat,
 
 
 def skydir_to_pix(skydir, wcs):
-    """Convert skydir object to pixel coordinates.  Gracefully handles
-    0-d coordinate arrays.
+    """Convert skydir object to pixel coordinates.
+
+    Gracefully handles 0-d coordinate arrays.
 
     Parameters
     ----------
-    skydir : `~astropy.coordinates.SkyCOord`
+    skydir : `~astropy.coordinates.SkyCoord`
 
     wcs : `~astropy.wcs.WCS`
 
@@ -253,9 +240,10 @@ def skydir_to_pix(skydir, wcs):
 
 
 def pix_to_skydir(xpix, ypix, wcs):
-    """Convert pixel coordinates to a skydir object.  Gracefully
-    handles 0-d coordinate arrays.  Always returns a celestial
-    coordinate.
+    """Convert pixel coordinates to a skydir object.
+
+    Gracefully handles 0-d coordinate arrays.
+    Always returns a celestial coordinate.
 
     Parameters
     ----------
@@ -287,7 +275,6 @@ def get_coordsys(wcs):
 
 
 def get_target_skydir(config, ref_skydir=None):
-
     if ref_skydir is None:
         ref_skydir = SkyCoord(0.0, 0.0, unit=u.deg)
 
@@ -374,7 +361,6 @@ def wcs_to_coords(w, shape):
 
 
 def wcs_to_skydir(wcs):
-
     lon = wcs.wcs.crval[0]
     lat = wcs.wcs.crval[1]
 
@@ -388,7 +374,6 @@ def wcs_to_skydir(wcs):
 
 
 def is_galactic(wcs):
-
     coordsys = get_coordsys(wcs)
     if coordsys == 'GAL':
         return True

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from astropy.wcs import WCS

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,45 @@
 #!/usr/bin/env python
-
 from setuptools import setup, find_packages
-import os
-import sys
-
 from fermipy.version import get_git_version
 
-##Check to make sure we're using the python in the STs.
-#if 'GLAST_EXT' in os.environ:
-#    print("Looks like you're using the SLAC version of the tools.")
-#    print("Not checking for correct python.")
-#elif 'FERMI_DIR' in os.environ:
-#    print("Looks like you're using the FSSC version of the tools.")
-#    fermi_dir = os.getenv('FERMI_DIR')
-#    os_file = os.__file__
-#    if fermi_dir not in os_file:
-#        print("Python executable is not the one in $FERMI_DIR/bin.  Exiting.")
-#        sys.exit(1)
-#else:
-#    print("Looks like the Fermi Science Tools are not setup.  Exiting.")
-#    sys.exit(1)
-
-setup(name='fermipy',
-      version=get_git_version(),
-      author='The Fermipy developers',
-      author_email='fermipy.developers@gmail.com',
-      description='A Python package for analysis of Fermi-LAT data',
-      license='BSD',
-      packages=find_packages(exclude='tests'),
-      include_package_data = True, 
-      url = "https://github.com/fermiPy/fermipy",
-      classifiers=[
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: BSD License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Topic :: Scientific/Engineering :: Astronomy',
-          'Development Status :: 4 - Beta',
-      ],
-      scripts = [],
-      entry_points= {'console_scripts': [
-          'fermipy-dispatch = fermipy.scripts.dispatch:main',
-          'fermipy-clone-configs = fermipy.scripts.clone_configs:main',
-          'fermipy-collect-sources = fermipy.scripts.collect_sources:main',
-          'fermipy-cluster-sources = fermipy.scripts.cluster_sources:main',
-          ]},
-      install_requires=['numpy >= 1.6.1',
-                        'matplotlib >= 1.4.0',
-                        'scipy >= 0.14',
-                        'astropy >= 1.0',
-                        'pyyaml',
-                        'healpy',
-                        'wcsaxes'])
-
+setup(
+    name='fermipy',
+    version=get_git_version(),
+    author='The Fermipy developers',
+    author_email='fermipy.developers@gmail.com',
+    description='A Python package for analysis of Fermi-LAT data',
+    license='BSD',
+    packages=find_packages(exclude='tests'),
+    include_package_data=True,
+    url="https://github.com/fermiPy/fermipy",
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Scientific/Engineering :: Astronomy',
+        'Development Status :: 4 - Beta',
+    ],
+    scripts=[],
+    entry_points={'console_scripts': [
+        'fermipy-dispatch = fermipy.scripts.dispatch:main',
+        'fermipy-clone-configs = fermipy.scripts.clone_configs:main',
+        'fermipy-collect-sources = fermipy.scripts.collect_sources:main',
+        'fermipy-cluster-sources = fermipy.scripts.cluster_sources:main',
+    ]},
+    install_requires=[
+        'numpy >= 1.6.1',
+        'astropy >= 1.0',
+    ],
+    extras_require=dict(
+        all=[
+            'matplotlib >= 1.4.0',
+            'scipy >= 0.14',
+            'pyyaml',
+            'healpy',
+            'wcsaxes',
+        ],
+    ),
+)


### PR DESCRIPTION
This PR does the following changes:
- [x] Declare dependencies other than Numpy and Astropy as optional in `setup.py`.
- [x] Add a Python 3 build to `.travis.yml` with all dependencies present except ST.
- [x] Add a Python 2 build to `.travis.yml` with all dependencies present except ST.
- [x] Add a Python 3 build to `.travis.yml` with only Numpy / Astropy present, i.e. minimal dependencies (doesn't pass yet, commented out)
- [x] Add `fermipy/tests/test_skymap.py`
- [x] Add `requires_dependency` decorators to tests, just like we do in Gammapy.
- [x] Misc code cleanup, especially in tests.

This should make `pip install fermipy` work for more users and developers and help a little with testing / interoperability with Gammapy.