### PR TITLE
Test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ matrix:
         # The main build:
         # Python 2, Fermi ST, all dependencies
         - os: linux
-          env: PYTHON_VERSION=2.7
+          env: NAME=main
+               PYTHON_VERSION=2.7
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
@@ -18,7 +19,8 @@ matrix:
 
         # Python 3, no Fermi ST, all other dependencies
         - os: linux
-          env: PYTHON_VERSION=3.5
+          env: NAME=py3_st-no_dep-yes
+               PYTHON_VERSION=3.5
                ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
@@ -26,7 +28,8 @@ matrix:
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
-          env: PYTHON_VERSION=2.7
+          env: NAME=NAME=py2_st-no_dep-yes
+               PYTHON_VERSION=2.7
                ST_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='scipy matplotlib pytest pyyaml'
@@ -50,8 +53,9 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n fermi-env python=$PYTHON_VERSION numpy astropy pytest $CONDA_DEPS
+  - conda create -q -n fermi-env python=$PYTHON_VERSION pip numpy astropy pytest $CONDA_DEPS
   - source activate fermi-env
+  - python -m pip install coverage pytest-cov coveralls
   - $CONDA2
 #  - pip install healpy
   - python setup.py install
@@ -75,8 +79,13 @@ install:
 
 # Run test
 script:
-  - py.test -vv -s
+  - python -m pytest -vv -s --cov=fermipy --cov-config=fermipy/tests/coveragerc
  
 #cache:
 #  directories:
 #  - $HOME/ScienceTools
+
+after_success:
+    - if [[ $NAME == 'main' ]]; then
+          coveralls --rcfile='fermipy/tests/coveragerc';
+      fi

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ Fermi-LAT Python Analysis Framework
 .. image:: https://travis-ci.org/fermiPy/fermipy.svg
     :target: https://travis-ci.org/fermiPy/fermipy
 
+* .. image:: https://img.shields.io/coveralls/fermipy/fermipy.svg
+    :target: https://coveralls.io/r/fermipy/fermipy
+    :alt: Code Coverage
+
 .. image:: http://img.shields.io/pypi/v/fermipy.svg?text=version
     :target: https://pypi.python.org/pypi/fermipy/
     :alt: Latest release

--- a/fermipy/tests/coveragerc
+++ b/fermipy/tests/coveragerc
@@ -1,0 +1,22 @@
+[run]
+source = fermipy
+omit =
+   *tests*
+
+[report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+
+   # Don't complain about packages we have installed
+   except ImportError
+
+   # Don't complain if tests don't hit assertions
+   raise AssertionError
+   raise NotImplementedError
+
+   # Don't complain about script hooks
+   def main\(.*\):
+
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}


### PR DESCRIPTION
We should add test coverage measure, to see which parts of Fermipy are completely untested.

It's easy to do with [pytest-cov](https://pypi.python.org/pypi/pytest-cov):
```
pip install pytest-cov
py.test -vv -s --cov=fermipy
```

Adding a test coverage report online is also useful and pretty easy.

- Activate https://coveralls.io/
- Add some lines to travis-ci to pip install `pytest-cov`, `coveralls` and submit the coverage command via a command like [this](https://github.com/gammapy/gammapy/blob/master/.travis.yml#L177)
- Add a badge to the README like [this](https://github.com/astropy/astropy/blame/master/README.rst#L38) so that it's visible and easy to find the link
- Disable coverage commenting on pull requests. (most devs find this annoying, checking this is something maintainers do once in a while)

Again, I could make a PR once #51 is merged (but @woodmd, you'd have to activate Fermipy for coveralls.