### PR TITLE
Matplotlib backend fix

### DIFF
--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -14,6 +14,27 @@ import scipy.special as special
 from astropy.extern import six
 
 
+def init_matplotlib_backend(backend=None):
+    """This function initializes the matplotlib backend.  When no
+    DISPLAY is available the backend is automatically set to 'Agg'.
+
+    Parameters
+    ----------
+    backend : str
+       matplotlib backend name.
+    """
+
+    import matplotlib
+    
+    try:
+        os.environ['DISPLAY']
+    except KeyError:
+        matplotlib.use('Agg')
+    else:
+        if backend is not None:
+            matplotlib.use(backend)
+
+
 def unicode_representer(dumper, uni):
     node = yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
     return node


### PR DESCRIPTION
This PR adds a `init_matplotlib_backend` function to the `utils` module that can be used to set the matplotlib backend.  If a DISPLAY is not detected then the backend is set to `Agg`.  Otherwise the function will set the backend with the string provided in the `backend` argument.  The recommended usage for this function is to call it at the top of one's analysis script but *before* importing any other fermipy modules, e.g.

```
from fermipy import utils
utils.init_matplotlib_backend()
from fermipy.gtanalysis import GTAnalysis
```