### PR TITLE
Make skymap independent of utils

### DIFF
--- a/fermipy/batch.py
+++ b/fermipy/batch.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import subprocess
 

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -11,7 +11,7 @@ other variables, such as the Flux normalization and the spectral
 index, or the mass and cross-section of a putative dark matter
 particle.
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import scipy
 

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
 from astropy import units as u

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 from astropy.extern import six
 import fermipy

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
 import os
+from astropy.extern import six
 import fermipy
 from fermipy import utils
 
@@ -52,7 +53,7 @@ def cast_config(config, defaults):
             if item_type is None or isinstance(item_type, tuple):
                 continue
 
-            if utils.isstr(item) and item_type == list:
+            if isinstance(item, six.text_type) and item_type == list:
                 config[key] = [item]
             else:
                 config[key] = item_type(config[key])
@@ -91,12 +92,12 @@ class Configurable(object):
         self._config = self.get_config()
         self._configdir = None
 
-        if utils.isstr(config) and os.path.isfile(config):
+        if isinstance(config, six.text_type) and os.path.isfile(config):
             self._configdir = os.path.abspath(os.path.dirname(config))
             config_dict = yaml.load(open(config))
         elif isinstance(config, dict) or config is None:
             config_dict = config
-        elif utils.isstr(config) and not os.path.isfile(config):
+        elif isinstance(config, six.text_type) and not os.path.isfile(config):
             raise Exception('Invalid path to configuration file: %s' % config)
         else:
             raise Exception('Invalid config argument.')

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 from collections import OrderedDict
 import numpy as np

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
 from astropy.io import fits

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
-import astropy.io.fits as pyfits
-import astropy.wcs as pywcs
+from astropy.io import fits
+from astropy.wcs import WCS
 import fermipy
 from fermipy.hpx_utils import HPX
 
@@ -40,15 +40,15 @@ def write_maps(primary_map, maps, outfile):
     for k, v in sorted(maps.items()):
         hdu_images += [v.create_image_hdu(k)]
 
-    hdulist = pyfits.HDUList(hdu_images)
+    hdulist = fits.HDUList(hdu_images)
     for h in hdulist:
         h.header['CREATOR'] = 'fermipy ' + fermipy.__version__
     hdulist.writeto(outfile, clobber=True)
 
 
 def write_fits_image(data, wcs, outfile):
-    hdu_image = pyfits.PrimaryHDU(data, header=wcs.to_header())
-    hdulist = pyfits.HDUList([hdu_image])
+    hdu_image = fits.PrimaryHDU(data, header=wcs.to_header())
+    hdulist = fits.HDUList([hdu_image])
     hdulist.writeto(outfile, clobber=True)
 
 
@@ -60,7 +60,7 @@ def read_projection_from_fits(fitsfile, extname=None):
     """
     Load a WCS or HPX projection.
     """
-    f = pyfits.open(fitsfile)
+    f = fits.open(fitsfile)
     nhdu = len(f)
     # Try and get the energy bounds
     try:
@@ -72,11 +72,11 @@ def read_projection_from_fits(fitsfile, extname=None):
         # If there is an image in the Primary HDU we can return a WCS-based
         # projection
         if f[0].header['NAXIS'] != 0:
-            proj = pywcs.WCS(f[0].header)
+            proj = WCS(f[0].header)
             return proj, f, f[0]
     else:
         if f[extname].header['XTENSION'] == 'IMAGE':
-            proj = pywcs.WCS(f[extname].header)
+            proj = WCS(f[extname].header)
             return proj, f, f[extname]
         elif f[extname].header['XTENSION'] == 'BINTABLE':
             try:
@@ -91,7 +91,7 @@ def read_projection_from_fits(fitsfile, extname=None):
     for i in range(1, nhdu):
         # if there is an image we can return a WCS-based projection
         if f[i].header['XTENSION'] == 'IMAGE':
-            proj = pywcs.WCS(f[i].header)
+            proj = WCS(f[i].header)
             return proj, f, f[i]
         elif f[i].header['XTENSION'] == 'BINTABLE':
             try:
@@ -109,7 +109,7 @@ def write_tables_to_fits(filepath, tablelist, clobber=False,
     """
     Write some astropy.table.Table objects to a single fits file
     """
-    outhdulist = [pyfits.PrimaryHDU()]
+    outhdulist = [fits.PrimaryHDU()]
     rmlist = []
     for i, table in enumerate(tablelist):
         ft_name = "%s._%i" % (filepath, i)
@@ -119,7 +119,7 @@ def write_tables_to_fits(filepath, tablelist, clobber=False,
         except:
             pass
         table.write(ft_name, format="fits")
-        ft_in = pyfits.open(ft_name)
+        ft_in = fits.open(ft_name)
         if namelist:
             ft_in[1].name = namelist[i]
         if cardslist:
@@ -132,6 +132,6 @@ def write_tables_to_fits(filepath, tablelist, clobber=False,
         for h in hdu_list:
             outhdulist.append(h)
 
-    pyfits.HDUList(outhdulist).writeto(filepath, clobber=clobber)
+    fits.HDUList(outhdulist).writeto(filepath, clobber=clobber)
     for rm in rmlist:
         os.unlink(rm)

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import shutil

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
 import pyLikelihood as pyLike

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -77,23 +77,23 @@ def hpx_to_coords(h, shape):
 
 
 def make_hpx_to_wcs_mapping(hpx, wcs):
-    """Make the mapping data needed to from from HPX pixelization to a
-    WCS-based array
+    """Make the mapping data needed to from from HPX pixelization to a WCS-based array.
 
     Parameters
     ----------
-    hpx     : `~fermipy.hpx_utils.HPX`
-       The healpix mapping (an HPX object)
-
-    wcs     : `~astropy.wcs.WCS`
-       The wcs mapping (a pywcs.wcs object)
+    hpx : `~fermipy.hpx_utils.HPX`
+       The healpix mapping
+    wcs : `~astropy.wcs.WCS`
+       The WCS mapping
 
     Returns
     -------
-      ipixs    :  array(nx,ny) of HEALPix pixel indices for each wcs pixel
-      mult_val :  array(nx,ny) of 1./number of wcs pixels pointing at each HEALPix pixel
-      npix     :  tuple(nx,ny) with the shape of the wcs grid
-
+    ipixs : `~numpy.array`
+        array(nx,ny) of HEALPix pixel indices for each wcs pixel
+    mult_val : `~numpy.array`
+        array(nx,ny) of 1./number of wcs pixels pointing at each HEALPix pixel
+    npix : tuple
+        tuple(nx,ny) with the shape of the wcs grid
     """
     npix = (int(wcs.wcs.crpix[0] * 2), int(wcs.wcs.crpix[1] * 2))
     pix_crds = np.dstack(np.meshgrid(np.arange(npix[0]),

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -2,7 +2,7 @@
 """
 Utilities for dealing with HEALPix projections and mappings
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 import healpy as hp
 import numpy as np

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import glob
 import re
 import numpy as np

--- a/fermipy/logger.py
+++ b/fermipy/logger.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import sys
 import logging

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import os
 import matplotlib.pyplot as plt

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -7,7 +7,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.patheffects as PathEffects
 from matplotlib.patches import Circle, Ellipse
 from matplotlib.colors import LogNorm, Normalize, PowerNorm
-
+from astropy.extern import six
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
@@ -275,7 +275,7 @@ class ROIPlotter(fermipy.config.Configurable):
         self._data_map = data_map
         self._catalogs = []
         for c in self.config['catalogs']:
-            if utils.isstr(c):
+            if isinstance(c, six.text_type):
                 self._catalogs += [catalog.Catalog.create(c)]
             else:
                 self._catalogs += [c]

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import os
 import numpy as np

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import re

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -9,6 +9,7 @@ import xml.etree.cElementTree as ElementTree
 
 import pyLikelihood as pyLike
 
+from astropy.extern import six
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -1254,7 +1255,7 @@ class ROIModel(fermipy.config.Configurable):
 
         for i, t in enumerate(srcs):
 
-            if utils.isstr(t):
+            if isinstance(t, six.text_type):
                 src_dict = {'file': t}
             elif isinstance(t, dict):
                 src_dict = copy.deepcopy(t)

--- a/fermipy/scripts/clone_configs.py
+++ b/fermipy/scripts/clone_configs.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import yaml

--- a/fermipy/scripts/cluster_sources.py
+++ b/fermipy/scripts/cluster_sources.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import argparse
 import yaml

--- a/fermipy/scripts/collect_sources.py
+++ b/fermipy/scripts/collect_sources.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import argparse
 import yaml

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -7,6 +7,7 @@ import stat
 import datetime
 import argparse
 import pprint
+from astropy.extern import six
 from fermipy import utils
 from fermipy.batch import check_log, get_lsf_status
 
@@ -102,7 +103,7 @@ def main():
     lsf_opt_string = ''
     for optname, optval in lsf_opts.items():
 
-        if utils.isstr(optval):
+        if isinstance(optval, six.text_type):
             optval = '\"%s\"' % optval
 
         lsf_opt_string += '-%s %s ' % (optname, optval)

--- a/fermipy/scripts/dispatch.py
+++ b/fermipy/scripts/dispatch.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import time
 import os

--- a/fermipy/sed.py
+++ b/fermipy/sed.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import pyLikelihood as pyLike
 
-import astropy.io.fits as pyfits
+from astropy.io import fits
 from astropy.table import Table, Column
 
 import fermipy.config
@@ -176,52 +176,52 @@ class SEDGenerator(object):
 
         tab.write(filename, format='fits', overwrite=True)
 
-        columns = pyfits.ColDefs([])
+        columns = fits.ColDefs([])
 
-        columns.add_col(pyfits.Column(name=str('ENERGY'), format='E',
-                                      array=sed['model_flux']['energies'],
-                                      unit='MeV'))
-        columns.add_col(pyfits.Column(name=str('DFDE'), format='E',
-                                      array=sed['model_flux']['dfde'],
-                                      unit='ph / (MeV cm2 s)'))
-        columns.add_col(pyfits.Column(name=str('DFDE_LO'), format='E',
-                                      array=sed['model_flux']['dfde_lo'],
-                                      unit='ph / (MeV cm2 s)'))
-        columns.add_col(pyfits.Column(name=str('DFDE_HI'), format='E',
-                                      array=sed['model_flux']['dfde_hi'],
-                                      unit='ph / (MeV cm2 s)'))
-        columns.add_col(pyfits.Column(name=str('DFDE_ERR'), format='E',
-                                      array=sed['model_flux']['dfde_err'],
-                                      unit='ph / (MeV cm2 s)'))
-        columns.add_col(pyfits.Column(name=str('DFDE_FERR'), format='E',
-                                      array=sed['model_flux']['dfde_ferr']))
+        columns.add_col(fits.Column(name=str('ENERGY'), format='E',
+                                    array=sed['model_flux']['energies'],
+                                    unit='MeV'))
+        columns.add_col(fits.Column(name=str('DFDE'), format='E',
+                                    array=sed['model_flux']['dfde'],
+                                    unit='ph / (MeV cm2 s)'))
+        columns.add_col(fits.Column(name=str('DFDE_LO'), format='E',
+                                    array=sed['model_flux']['dfde_lo'],
+                                    unit='ph / (MeV cm2 s)'))
+        columns.add_col(fits.Column(name=str('DFDE_HI'), format='E',
+                                    array=sed['model_flux']['dfde_hi'],
+                                    unit='ph / (MeV cm2 s)'))
+        columns.add_col(fits.Column(name=str('DFDE_ERR'), format='E',
+                                    array=sed['model_flux']['dfde_err'],
+                                    unit='ph / (MeV cm2 s)'))
+        columns.add_col(fits.Column(name=str('DFDE_FERR'), format='E',
+                                    array=sed['model_flux']['dfde_ferr']))
 
-        hdu_f = pyfits.BinTableHDU.from_columns(columns, name='MODEL_FLUX')
+        hdu_f = fits.BinTableHDU.from_columns(columns, name='MODEL_FLUX')
 
-        columns = pyfits.ColDefs([])
+        columns = fits.ColDefs([])
 
         npar = len(sed['param_names'])
-        columns.add_col(pyfits.Column(name=str('NAME'),
-                                      format='A32',
-                                      array=sed['param_names']))
-        columns.add_col(pyfits.Column(name=str('VALUE'), format='E',
-                                      array=sed['param_values']))
-        columns.add_col(pyfits.Column(name=str('ERROR'), format='E',
-                                      array=sed['param_errors']))
-        columns.add_col(pyfits.Column(name=str('COVARIANCE'),
-                                      format='%iE' % npar,
-                                      dim=str('(%i)' % npar),
-                                      array=sed['param_covariance']))
-        columns.add_col(pyfits.Column(name=str('CORRELATION'),
-                                      format='%iE' % npar,
-                                      dim=str('(%i)' % npar),
-                                      array=sed['param_correlation']))
+        columns.add_col(fits.Column(name=str('NAME'),
+                                    format='A32',
+                                    array=sed['param_names']))
+        columns.add_col(fits.Column(name=str('VALUE'), format='E',
+                                    array=sed['param_values']))
+        columns.add_col(fits.Column(name=str('ERROR'), format='E',
+                                    array=sed['param_errors']))
+        columns.add_col(fits.Column(name=str('COVARIANCE'),
+                                    format='%iE' % npar,
+                                    dim=str('(%i)' % npar),
+                                    array=sed['param_covariance']))
+        columns.add_col(fits.Column(name=str('CORRELATION'),
+                                    format='%iE' % npar,
+                                    dim=str('(%i)' % npar),
+                                    array=sed['param_correlation']))
 
-        hdu_p = pyfits.BinTableHDU.from_columns(columns, name='PARAMS')
+        hdu_p = fits.BinTableHDU.from_columns(columns, name='PARAMS')
 
-        hdulist = pyfits.open(filename)
+        hdulist = fits.open(filename)
         hdulist[1].name = 'SED'
-        hdulist = pyfits.HDUList([hdulist[0], hdulist[1], hdu_f, hdu_p])
+        hdulist = fits.HDUList([hdulist[0], hdulist[1], hdu_f, hdu_p])
 
         for h in hdulist:
             h.header['SRCNAME'] = sed['name']

--- a/fermipy/sed.py
+++ b/fermipy/sed.py
@@ -6,7 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import logging
 import os

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -6,7 +6,7 @@ Many parts of this code are taken from dsphs/like/lnlfn.py by
   Matthew Wood <mdwood@slac.stanford.edu>
   Alex Drlica-Wagner <kadrlica@slac.stanford.edu>
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
 NORM_LABEL = {

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -5,10 +5,9 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
-import fermipy.utils as utils
-import fermipy.wcs_utils as wcs_utils
-import fermipy.hpx_utils as hpx_utils
-import fermipy.fits_utils as fits_utils
+from fermipy import wcs_utils
+from fermipy import hpx_utils
+from fermipy import fits_utils
 from fermipy.hpx_utils import HPX, HpxToWcsMapping
 
 
@@ -299,7 +298,7 @@ class HpxMap(Map_Base):
         """
         if ebounds is not None:
             try:
-                ebins = utils.read_energy_bounds(hdulist[ebounds])
+                ebins = fits_utils.read_energy_bounds(hdulist[ebounds])
             except:
                 ebins = None
         else:

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
 from astropy.io import fits

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import logging
 import numpy as np

--- a/fermipy/sourcefind_utils.py
+++ b/fermipy/sourcefind_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from scipy.ndimage.filters import maximum_filter
 from astropy.coordinates import SkyCoord

--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
 

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
 from fermipy import utils

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
 import numpy as np
-import astropy.io.fits as pyfits
-import fermipy.utils as utils
-import fermipy.wcs_utils as wcs_utils
+from astropy.io import fits
+from fermipy import utils
+from fermipy import wcs_utils
 
 
 def make_srcmap(skydir, psf, spatial_model, sigma, npix=500, xpix=0.0, ypix=0.0,
@@ -24,13 +24,13 @@ def make_srcmap(skydir, psf, spatial_model, sigma, npix=500, xpix=0.0, ypix=0.0,
 
     if spatial_model == 'GaussianSource' or spatial_model == 'RadialGaussian':
         k = utils.make_cgauss_kernel(psf, sigma, npix * rebin, cdelt / rebin,
-                               xpix * rebin, ypix * rebin)
+                                     xpix * rebin, ypix * rebin)
     elif spatial_model == 'DiskSource' or spatial_model == 'RadialDisk':
         k = utils.make_cdisk_kernel(psf, sigma, npix * rebin, cdelt / rebin,
-                              xpix * rebin, ypix * rebin)
+                                    xpix * rebin, ypix * rebin)
     elif spatial_model == 'PSFSource' or spatial_model == 'PointSource':
         k = utils.make_psf_kernel(psf, npix * rebin, cdelt / rebin,
-                            xpix * rebin, ypix * rebin)
+                                  xpix * rebin, ypix * rebin)
     else:
         raise Exception('Unrecognized spatial model: %s' % spatial_model)
 
@@ -58,17 +58,17 @@ def make_cgauss_mapcube(skydir, psf, sigma, outfile, npix=500, cdelt=0.01,
     w.wcs.cdelt[2] = energies[1] - energies[0]
     w.wcs.ctype[2] = 'Energy'
 
-    ecol = pyfits.Column(name='Energy', format='D', array=10 ** energies)
-    hdu_energies = pyfits.BinTableHDU.from_columns([ecol], name='ENERGIES')
+    ecol = fits.Column(name='Energy', format='D', array=10 ** energies)
+    hdu_energies = fits.BinTableHDU.from_columns([ecol], name='ENERGIES')
 
-    hdu_image = pyfits.PrimaryHDU(np.zeros((nebin, npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((nebin, npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[...] = k
 
     hdu_image.header['CUNIT3'] = 'MeV'
 
-    hdulist = pyfits.HDUList([hdu_image, hdu_energies])
+    hdulist = fits.HDUList([hdu_image, hdu_energies])
     hdulist.writeto(outfile, clobber=True)
 
 
@@ -87,38 +87,38 @@ def make_psf_mapcube(skydir, psf, outfile, npix=500, cdelt=0.01, rebin=1):
     w.wcs.cdelt[2] = energies[1] - energies[0]
     w.wcs.ctype[2] = 'Energy'
 
-    ecol = pyfits.Column(name='Energy', format='D', array=10 ** energies)
-    hdu_energies = pyfits.BinTableHDU.from_columns([ecol], name='ENERGIES')
+    ecol = fits.Column(name='Energy', format='D', array=10 ** energies)
+    hdu_energies = fits.BinTableHDU.from_columns([ecol], name='ENERGIES')
 
-    hdu_image = pyfits.PrimaryHDU(np.zeros((nebin, npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((nebin, npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[...] = k
 
     hdu_image.header['CUNIT3'] = 'MeV'
 
-    hdulist = pyfits.HDUList([hdu_image, hdu_energies])
+    hdulist = fits.HDUList([hdu_image, hdu_energies])
     hdulist.writeto(outfile, clobber=True)
 
 
 def make_gaussian_spatial_map(skydir, sigma, outfile, npix=501, cdelt=0.01):
     w = wcs_utils.create_wcs(skydir, cdelt=cdelt, crpix=npix / 2. + 0.5)
-    hdu_image = pyfits.PrimaryHDU(np.zeros((npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[:, :] = utils.make_gaussian_kernel(sigma, npix=npix, cdelt=cdelt)
-    hdulist = pyfits.HDUList([hdu_image])
+    hdulist = fits.HDUList([hdu_image])
     hdulist.writeto(outfile, clobber=True)
 
 
 def make_disk_spatial_map(skydir, sigma, outfile, npix=501, cdelt=0.01):
     w = wcs_utils.create_wcs(skydir, cdelt=cdelt, crpix=npix / 2. + 0.5)
 
-    hdu_image = pyfits.PrimaryHDU(np.zeros((npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[:, :] = utils.make_disk_kernel(sigma, npix=npix, cdelt=cdelt)
-    hdulist = pyfits.HDUList([hdu_image])
+    hdulist = fits.HDUList([hdu_image])
     hdulist.writeto(outfile, clobber=True)
 
 
@@ -134,13 +134,13 @@ def delete_source_map(srcmap_file, names, logger=None):
        List of HDU keys of source maps to be deleted.
 
     """
-    hdulist = pyfits.open(srcmap_file)
+    hdulist = fits.open(srcmap_file)
     hdunames = [hdu.name.upper() for hdu in hdulist]
 
-    if not isinstance(names,list):
+    if not isinstance(names, list):
         names = [names]
 
-    for name in names:        
+    for name in names:
         if not name.upper() in hdunames:
             continue
         del hdulist[name.upper()]
@@ -149,7 +149,7 @@ def delete_source_map(srcmap_file, names, logger=None):
 
 
 def update_source_maps(srcmap_file, srcmaps, logger=None):
-    hdulist = pyfits.open(srcmap_file)
+    hdulist = fits.open(srcmap_file)
     hdunames = [hdu.name.upper() for hdu in hdulist]
 
     for name, data in srcmaps.items():
@@ -160,7 +160,7 @@ def update_source_maps(srcmap_file, srcmaps, logger=None):
                 if hdu.header['XTENSION'] == 'IMAGE':
                     break
 
-            newhdu = pyfits.ImageHDU(data, hdu.header, name=name)
+            newhdu = fits.ImageHDU(data, hdu.header, name=name)
             newhdu.header['EXTNAME'] = name
             hdulist.append(newhdu)
 

--- a/fermipy/stats_utils.py
+++ b/fermipy/stats_utils.py
@@ -2,7 +2,7 @@
 """
 Utilities to fit dark matter spectra to castro data
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import scipy.stats as stats
 import scipy.optimize as opt

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/fermipy/tests/test_roi_model.py
+++ b/fermipy/tests/test_roi_model.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import xml.etree.cElementTree as ElementTree
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest

--- a/fermipy/tests/test_skymap.py
+++ b/fermipy/tests/test_skymap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from fermipy.hpx_utils import HPX
 from fermipy.fits_utils import write_fits_image

--- a/fermipy/tests/utils.py
+++ b/fermipy/tests/utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.tests.helper import pytest
 
 __all__ = ['requires_dependency']

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import copy
 import logging

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -276,7 +276,7 @@ def project(lon0, lat0, lon1, lat1):
 
 
 def scale_parameter(p):
-    if isstr(p):
+    if isinstance(p, six.text_type):
         p = float(p)
 
     if p > 0:
@@ -737,22 +737,12 @@ def fits_recarray_to_dict(table):
 def unicode_to_str(args):
     o = {}
     for k, v in args.items():
-        if isinstance(v, unicode):
+        if isinstance(v, six.text_type):
             o[k] = str(v)
         else:
             o[k] = v
 
     return o
-
-
-def isstr(s):
-    """String instance testing method that works under both Python 2.X
-    and 3.X.  Returns true if the input is a string."""
-
-    try:
-        return isinstance(s, basestring)
-    except NameError:
-        return isinstance(s, str)
 
 
 def xmlpath_to_path(path):
@@ -775,7 +765,7 @@ def create_xml_element(root, name, attrib):
 
         if isinstance(v, bool):
             el.set(k, str(int(v)))
-        elif isstr(v):
+        elif isinstance(v, six.text_type):
             el.set(k, v)
         elif np.isfinite(v):
             el.set(k, str(v))
@@ -872,7 +862,7 @@ def merge_dict(d0, d1, add_new_keys=False, append_arrays=False):
             od[k] = copy.deepcopy(d0[k])
         elif isinstance(v, dict) and isinstance(d1[k], dict):
             od[k] = merge_dict(d0[k], d1[k], add_new_keys, append_arrays)
-        elif isinstance(v, list) and isstr(d1[k]):
+        elif isinstance(v, list) and isinstance(d1[k], six.text_type):
             od[k] = d1[k].split(',')
         elif isinstance(v, dict) and d1[k] is None:
             od[k] = copy.deepcopy(d0[k])
@@ -947,7 +937,7 @@ def tolist(x):
         return dict(x)
     elif isinstance(x, np.bool_):
         return bool(x)
-    elif isinstance(x, basestring) or isinstance(x, np.str):
+    elif isinstance(x, six.text_type) or isinstance(x, np.str):
         x = str(x)  # convert unicode & numpy strings
         try:
             return int(x)

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import re
 import copy

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -2,11 +2,12 @@
 from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
+from astropy.extern import six
 from astropy.wcs import WCS
 from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-import fermipy.utils as utils
+
 
 
 class WCSProj(object):
@@ -280,7 +281,7 @@ def get_target_skydir(config, ref_skydir=None):
 
     radec = config.get('radec', None)
 
-    if utils.isstr(radec):
+    if isinstance(radec, six.text_type):
         return SkyCoord(radec, unit=u.deg)
     elif isinstance(radec, list):
         return SkyCoord(radec[0], radec[1], unit=u.deg)

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import numpy as np
 from astropy.extern import six


### PR DESCRIPTION
The main goal of this PR is to make `skymap.py` independent of `utils.py`, so that it can be moved over to Gammapy more easily.

I've changed `utils.isstr(item)` to `isinstance(item, six.text_type)` everywhere.
I think that's the right thing to do (it's what Astropy and other do for simultaneous Py 2 / 3 string checking), but @woodmd - please check and test that things still work the same before merging this.

I've also added in one cleanup commit to use the common import conventions of `from astropy.io import fits` and `from astropy.wcs import WCS` instead of the olden-days `pyfits` and `pywcs` conventions.