### PR TITLE
Adding first implementation of dmfitfunction class.

### DIFF
--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
+import os
 import copy
 import numpy as np
-
+from scipy.interpolate import RegularGridInterpolator
 
 def cast_args(x):
 
@@ -85,24 +86,34 @@ class SEDEFluxFunctor(SEDFunctor):
 class SpectralFunction(object):
     """Base class for spectral model classes."""
 
-    def __init__(self, params, scale=1.0):
+    def __init__(self, params, scale=1.0, extra_params=None):
         self._params = params
         self._scale = scale
+        self._extra_params = extra_params
 
     @property
     def params(self):
+        """Return parameter vector of the function."""
         return self._params
 
     @property
     def log_params(self):
+        """Return transformed parameter vector in which norm and scale
+        parameters are converted to log10."""
         return self.params_to_log(self._params)
 
     @property
     def scale(self):
         return self._scale
 
+    @property
+    def extra_params(self):
+        """Dictionary containing additional parameters needed for evaluation
+        of the function."""
+        return self._extra_params
+    
     @staticmethod
-    def create_functor(spec_type, func_type, emin, emax, scale=1.0):
+    def create_functor(spec_type, func_type, emin, emax, scale=1.0, extra_params=None):
 
         if func_type.lower() == 'flux':
             return eval(spec_type).create_flux_functor(emin, emax, scale)
@@ -112,55 +123,55 @@ class SpectralFunction(object):
             raise Exception("Did not recognize func_type: %s" % func_type)
 
     @classmethod
-    def create_flux_functor(cls, emin, emax, escale=1.0):
+    def create_flux_functor(cls, emin, emax, escale=1.0, extra_params=None):
         return SEDFluxFunctor(cls, escale, emin, emax)
 
     @classmethod
-    def create_eflux_functor(cls, emin, emax, escale=1.0):
+    def create_eflux_functor(cls, emin, emax, escale=1.0, extra_params=None):
         return SEDEFluxFunctor(cls, escale, emin, emax)
 
     @classmethod
-    def eval_e2dfde(cls, x, params, scale=1.0):
+    def eval_e2dfde(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        return cls._eval_dfde(x, params, scale) * x**2
+        return cls._eval_dfde(x, params, scale, extra_params) * x**2
 
     @classmethod
-    def eval_edfde(cls, x, params, scale=1.0):
+    def eval_edfde(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        return cls._eval_dfde(x, params, scale) * x
+        return cls._eval_dfde(x, params, scale, extra_params) * x
 
     @classmethod
-    def eval_dfde(cls, x, params, scale=1.0):
+    def eval_dfde(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        return cls._eval_dfde(x, params, scale)
+        return cls._eval_dfde(x, params, scale, extra_params)
 
     @classmethod
-    def eval_dfde_deriv(cls, x, params, scale=1.0):
+    def eval_dfde_deriv(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        return cls._eval_dfde_deriv(x, params, scale)
+        return cls._eval_dfde_deriv(x, params, scale, extra_params)
 
     @classmethod
-    def eval_edfde_deriv(cls, x, params, scale=1.0):
+    def eval_edfde_deriv(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        dfde_deriv = cls._eval_dfde_deriv(x, params, scale)
+        dfde_deriv = cls._eval_dfde_deriv(x, params, scale, extra_params)
         dfde = cls._eval_dfde(x, params, scale)
         return x*dfde_deriv + dfde
 
     @classmethod
-    def eval_e2dfde_deriv(cls, x, params, scale=1.0):
+    def eval_e2dfde_deriv(cls, x, params, scale=1.0, extra_params=None):
         x = cast_args(x)
         params = cast_params(params)
-        dfde_deriv = cls._eval_dfde_deriv(x, params, scale)
+        dfde_deriv = cls._eval_dfde_deriv(x, params, scale, extra_params)
         dfde = cls._eval_dfde(x, params, scale)
         return x**2*dfde_deriv + 2*x*dfde
 
     @classmethod
-    def _integrate(cls, fn, emin, emax, params, scale=1.0, npt=20):
+    def _integrate(cls, fn, emin, emax, params, scale=1.0, extra_params=None, npt=20):
         """Fast numerical integration method using mid-point rule."""
 
         emin = np.expand_dims(emin, -1)
@@ -174,69 +185,78 @@ class SpectralFunction(object):
         logx_edge = np.log(emin) + xedges * (np.log(emax) - np.log(emin))
         logx = 0.5 * (logx_edge[..., 1:] + logx_edge[..., :-1])
         xw = np.exp(logx_edge[..., 1:]) - np.exp(logx_edge[..., :-1])
-        dfde = fn(np.exp(logx), params, scale)
+        dfde = fn(np.exp(logx), params, scale, extra_params)
         return np.sum(dfde * xw, axis=-1)
 
     @classmethod
-    def _eval_dfde_deriv(cls, x, params, scale=1.0, eps=1E-6):
+    def _eval_dfde_deriv(cls, x, params, scale=1.0, extra_params=None, eps=1E-6):
         return (cls._eval_dfde(x+eps, params, scale) -
                 cls._eval_dfde(x, params, scale))/eps
 
     @classmethod
-    def eval_flux(cls, emin, emax, params, scale=1.0):
+    def eval_flux(cls, emin, emax, params, scale=1.0, extra_params=None):
         emin = cast_args(emin)
         emax = cast_args(emax)
         params = cast_params(params)
-        return cls._integrate(cls.eval_dfde, emin, emax, params, scale)
+        return cls._integrate(cls.eval_dfde, emin, emax, params, scale, extra_params)
 
     @classmethod
-    def eval_eflux(cls, emin, emax, params, scale=1.0):
+    def eval_eflux(cls, emin, emax, params, scale=1.0, extra_params=None):
         emin = cast_args(emin)
         emax = cast_args(emax)
         params = cast_params(params)
-        return cls._integrate(cls.eval_edfde, emin, emax, params, scale)
+        return cls._integrate(cls.eval_edfde, emin, emax, params, scale,
+                              extra_params)
 
     def dfde(self, x, params=None):
         """Evaluate differential flux."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_dfde(x, params, self.scale))
+        return np.squeeze(self.eval_dfde(x, params, self.scale,
+                                         self.extra_params))
 
     def edfde(self, x, params=None):
         """Evaluate E times differential flux."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_edfde(x, params, self.scale))
+        return np.squeeze(self.eval_edfde(x, params, self.scale,
+                                          self.extra_params))
 
     def e2dfde(self, x, params=None):
         """Evaluate E^2 times differential flux."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_e2dfde(x, params, self.scale))
+        return np.squeeze(self.eval_e2dfde(x, params, self.scale,
+                                           self.extra_params))
 
     def dfde_deriv(self, x, params=None):
         """Evaluate derivative of the differential flux with respect to E."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_dfde_deriv(x, params, self.scale))
+        return np.squeeze(self.eval_dfde_deriv(x, params, self.scale,
+                                               self.extra_params))
 
     def edfde_deriv(self, x, params=None):
         """Evaluate derivative of E times differential flux with respect to
         E."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_edfde_deriv(x, params, self.scale))
+        return np.squeeze(self.eval_edfde_deriv(x, params, self.scale,
+                                                self.extra_params))
 
     def e2dfde_deriv(self, x, params=None):
         """Evaluate derivative of E^2 times differential flux with respect to
         E."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_e2dfde_deriv(x, params, self.scale))
+        return np.squeeze(self.eval_e2dfde_deriv(x, params, self.scale,
+                                                 self.extra_params))
 
     def flux(self, emin, emax, params=None):
         """Evaluate the integral flux."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_flux(emin, emax, params, self.scale))
+        return np.squeeze(self.eval_flux(emin, emax, params, self.scale,
+                                         self.extra_params))
 
     def eflux(self, emin, emax, params=None):
         """Evaluate the energy flux flux."""
         params = self.params if params is None else params
-        return np.squeeze(self.eval_eflux(emin, emax, params, self.scale))
+        return np.squeeze(self.eval_eflux(emin, emax, params, self.scale,
+                                          self.extra_params))
 
 
 class PowerLaw(SpectralFunction):
@@ -256,11 +276,11 @@ class PowerLaw(SpectralFunction):
         super(PowerLaw, self).__init__(params, scale)
 
     @staticmethod
-    def _eval_dfde(x, params, scale=1.0):
+    def _eval_dfde(x, params, scale=1.0, extra_params=None):
         return params[0] * (x / scale) ** params[1]
 
     @classmethod
-    def eval_flux(cls, emin, emax, params, scale=1.0):
+    def eval_flux(cls, emin, emax, params, scale=1.0, extra_params=None):
 
         phi0 = np.array(params[0], ndmin=1)
         index = np.array(params[1], ndmin=1)
@@ -286,7 +306,7 @@ class PowerLaw(SpectralFunction):
 #        return v2
 
     @classmethod
-    def eval_eflux(cls, emin, emax, params, scale=1.0):
+    def eval_eflux(cls, emin, emax, params, scale=1.0, extra_params=None):
 
         params = copy.deepcopy(params)
         params[1] += 1.0
@@ -298,18 +318,40 @@ class PowerLaw(SpectralFunction):
 
 
 class LogParabola(SpectralFunction):
+    """Class that evaluates a function with the parameterization:
 
+    F(x) = p_0 * (x/x_s)^(p_1 - p_2*log(x/x_s) )
+
+    where x_s is a scale parameter.  The `params` array should be
+    defined with:
+
+    * params[0] : Prefactor (p_0)
+    * params[1] : Index (p_1)
+    * params[2] : Curvature (p_2)
+
+    """
     def __init__(self, params, scale=1.0):
         super(LogParabola, self).__init__(params, scale)
 
     @staticmethod
-    def _eval_dfde(x, params, scale=1.0):
+    def _eval_dfde(x, params, scale=1.0, extra_params=None):
         return (params[0] * (x / scale) **
                 (params[1] - params[2] * np.log(x / scale)))
 
 
 class PLExpCutoff(SpectralFunction):
+    """Class that evaluates a function with the parameterization:
 
+    F(x) = p_0 * (x/x_s)^(p_1 - p_2*log(x/x_s) )
+
+    where x_s is the scale parameter.  The `params` array should be
+    defined with:
+
+    * params[0] : Prefactor (p_0)
+    * params[1] : Index (p_1)
+    * params[2] : Curvature (p_2)
+
+    """
     def __init__(self, params, scale=1.0):
         super(PLExpCutoff, self).__init__(params, scale)
 
@@ -326,10 +368,106 @@ class PLExpCutoff(SpectralFunction):
                 10**params[2]]
 
     @staticmethod
-    def _eval_dfde(x, params, scale=1.0):
+    def _eval_dfde(x, params, scale=1.0, extra_params=None):
         return params[0] * (x / scale) ** (params[1]) * np.exp(-x / params[2])
 
     @classmethod
-    def _eval_dfde_deriv(cls, x, params, scale=1.0):
+    def _eval_dfde_deriv(cls, x, params, scale=1.0, extra_params=None):
         return (cls._eval_dfde(x, params, scale) *
                 (params[1]*params[2] - x)/(params[2]*x))
+
+
+class DMFitFunction(SpectralFunction):
+    """Class that evaluates a spectrum for a DM particle of a given mass,
+    channel, cross section, and J-factor.  The parameterization is
+    given by:
+
+    F(x) = 1 / (8 * pi) * (1/mass^2) * sigmav * J * dN/dE(E,mass,i)
+
+    where the `params` array should be defined with:
+
+    * params[0] : sigmav
+    * params[1] : mass
+
+    """    
+    def __init__(self, params, chan='bb', jfactor = 1E25, tablepath=None):
+        """Constructor.
+
+        Parameters
+        ----------
+        params : list
+            Parameter vector.
+
+        chan : str
+            Channel string.  Can be one of cc, bb, tt, tautau, ww, zz,
+            mumu, gg, ee, ss, uu, dd.
+
+        jfactor : float
+            J-factor of this object.  Note that this needs to be given
+            in the same units as the mass parameter.
+
+        tablepath : str
+            Path to lookup table with pre-computed DM spectra on a
+            grid of energy, mass, and channel.
+
+        """
+        
+        if tablepath is None:        
+            tablepath = os.path.join('$FERMIPY_DATA_DIR',
+                                     'gammamc_dif.dat')
+        data = np.loadtxt(os.path.expandvars(tablepath))
+
+        # Number of decades in x = log10(E/M)
+        ndec = 10.0        
+        xedge = np.linspace(0,1.0,251)
+        self._x = 0.5*(xedge[1:]+xedge[:-1])*ndec - ndec
+
+        # Lookup table for chan string to table index
+        chan_index = { 'cc' : 0,
+                       'bb' : 1,
+                       'tt' : 2,
+                       'tautau' : 3,
+                       'ww' : 4,
+                       'zz' : 5,
+                       'mumu' : 6,
+                       'gg' : 7,
+                       'ee' : 8,
+                       'ss' : 9,
+                       'uu' : 10,
+                       'dd' : 11 }
+        
+        ichan = chan_index[chan]
+        self._chan = chan
+        
+        # These are the mass points
+        self._mass = np.array([2.0,4.0,6.0,8.0,10.0,
+                               25.0,50.0,80.3,91.2,100.0,
+                               150.0,176.0,200.0,250.0,350.0,500.0,750.0,
+                               1000.0,1500.0,2000.0,3000.0,5000.0,7000.0,1E4])
+        self._mass *= 1E3
+        self._dndx = data.reshape((12,24,250))
+        self._dndx_interp = RegularGridInterpolator([self._mass,self._x],
+                                                    self._dndx[ichan,:,:],
+                                                    bounds_error=False,
+                                                    fill_value=None)
+        extra_params = {'dndx_interp' : self._dndx_interp, 'chan' : 'bb',
+                        'jfactor' : jfactor }        
+        super(DMFitFunction, self).__init__(params, 1.0, extra_params)
+            
+    @property
+    def chan(self):
+        return self._chan
+
+    @staticmethod
+    def _eval_dfde(x, params, scale=1.0, extra_params=None):
+
+        dndx_interp = extra_params.get('dndx_interp')
+        jfactor = extra_params.get('jfactor')
+        sigmav = params[0]
+        mass = params[1]
+        xm = np.log10(x/mass)
+        phip = 1./(8.*np.pi)*np.power(mass,-2)*(sigmav*jfactor)
+        #dndx = self._dndx_interp[ichan]((np.log10(mass),xm))
+        dndx = dndx_interp((mass,xm))
+        dndx[xm > 0] = 0        
+        return phip*dndx/x

--- a/fermipy/tests/test_spectrum.py
+++ b/fermipy/tests/test_spectrum.py
@@ -1,0 +1,66 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function
+import os
+import numpy as np
+from numpy.testing import assert_allclose
+from fermipy import spectrum
+
+def test_powerlaw_spectrum():
+
+    params = [1E-13,-2.3]
+    fn = spectrum.PowerLaw(params, scale=2E3)
+    
+def test_logparabola_spectrum():
+
+    params = [1E-13,-2.3,0.5]
+    fn = spectrum.LogParabola(params, scale=2E3)
+
+def test_plexpcutoff_spectrum():
+
+    params = [1E-13,-2.3,1E3]
+    fn = spectrum.PLExpCutoff(params, scale=2E3)
+
+def test_dmfitfunction_spectrum():
+
+    sigmav = 3E-26
+    mass = 100.*1E3
+    params = [sigmav,mass]
+    
+    fn0 = spectrum.DMFitFunction(params,chan='bb')
+    fn1 = spectrum.DMFitFunction(params,chan='tautau')
+
+    loge = np.linspace(2,4,5)
+
+    # Test energy scalar evaluation
+    assert_allclose(fn0.dfde(1E3),1.15754e-14, rtol=1E-3)
+    assert_allclose(fn1.dfde(1E3),2.72232e-16, rtol=1E-3)
+
+    fn0.flux(1E3,1E4)
+    fn1.flux(1E3,1E4)
+
+    fn0.eflux(1E3,1E4)
+    fn1.eflux(1E3,1E4)
+    
+    # Test energy vector evaluation
+    assert_allclose(fn0.dfde(10**loge),
+                    [ 5.39894e-14, 3.26639e-14, 1.15754e-14,
+                      2.13262e-15, 1.79554e-16], rtol=1E-3)
+    assert_allclose(fn1.dfde(10**loge),
+                    [ 7.12808e-16, 3.79861e-16, 2.72232e-16,
+                      1.96952e-16, 9.49478e-17], rtol=1E-3)
+
+    fn0.flux(loge[:-1],loge[1:])
+    fn1.flux(loge[:-1],loge[1:])
+
+    fn0.eflux(loge[:-1],loge[1:])
+    fn1.eflux(loge[:-1],loge[1:])
+    
+    # Test energy vector + parameter vector evaluation
+    dfde0 = fn0.dfde(10**loge,params=[sigmav,[100E3,200E3]])
+    dfde1 = fn1.dfde(10**loge,params=[sigmav,[100E3,200E3]])
+
+    assert_allclose(dfde0[:,0], fn0.dfde(10**loge,params=[sigmav,100E3]))
+    assert_allclose(dfde0[:,1], fn0.dfde(10**loge,params=[sigmav,200E3]))
+    assert_allclose(dfde1[:,0], fn1.dfde(10**loge,params=[sigmav,100E3]))
+    assert_allclose(dfde1[:,1], fn1.dfde(10**loge,params=[sigmav,200E3]))
+    


### PR DESCRIPTION
This PR implements a pure-python version of DMFitFunction which can be used with a `CastroData` or `TSCube` class to perform spectral fits of various DM models.