### PR TITLE
Changes in castro to fix confidence interval calculation.

### DIFF
--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -2485,10 +2485,10 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             lims1 = utils.get_parameter_limits(xvals, dloglike,
                                                ul_confidence=0.99)
 
-#            print('iter',i,np.abs(np.abs(dloglike0) - utils.cl_to_dlnl(0.99)),xup)
+#            print('iter',i,np.abs(np.abs(dloglike0) - utils.onesided_cl_to_dlnl(0.99)),xup)
 #            print(loglike)
 
-            if np.abs(np.abs(dloglike0) - utils.cl_to_dlnl(0.99)) < 0.1:
+            if np.abs(np.abs(dloglike0) - utils.onesided_cl_to_dlnl(0.99)) < 0.1:
                 break
 
             if not np.isfinite(lims1['ul']) or np.abs(dloglike[-1]) < 1.0:
@@ -2517,7 +2517,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
 #        plt.plot(xvals,dloglike,marker='o')
 #        plt.plot(np.linspace(xvals[0],xvals[-1],100),s(np.linspace(xvals[0],xvals[-1],100)))
 #        plt.gca().set_ylim(-5,1)
-#        plt.gca().axhline(-utils.cl_to_dlnl(0.99))
+#        plt.gca().axhline(-utils.onesided_cl_to_dlnl(0.99))
 
         if np.isfinite(lims1['ll']):
             xlo = np.concatenate(

--- a/fermipy/sed_plotting.py
+++ b/fermipy/sed_plotting.py
@@ -150,9 +150,11 @@ def plotSED_OnAxis(ax, castroData, TS_thresh=4.0, errSigma=1.0,
     has_limit = ~has_point
     ul_vals = castroData.getLimits(0.05)
 
-    err_pos = castroData.getLimits(0.32) - mles
-    err_neg = mles - castroData.getLimits(0.32, upper=False) 
-
+    err_lims_lo, err_lims_hi = castroData.getIntervals(0.32)
+    
+    err_pos = err_lims_hi - mles
+    err_neg = mles - err_lims_lo
+    
     yerr_points = (err_neg[has_point], err_pos[has_point])
     xerrs = (castroData.refSpec.eref - castroData.refSpec.ebins[0:-1],
              castroData.refSpec.ebins[1:] - castroData.refSpec.eref)

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -356,11 +356,78 @@ def cov_to_correlation(cov):
     return corr
 
 
-def cl_to_dlnl(cl):
-    """Compute the delta-log-likehood corresponding to an upper limit of
-    the given confidence level."""
+def twosided_cl_to_dlnl(cl):
+    """Compute the delta-loglikehood value that corresponds to a
+    two-sided interval of the given confidence level.
+
+    Parameters
+    ----------
+    cl : float
+        Confidence level.
+    
+    Returns
+    -------
+    dlnl : float    
+        Delta-loglikelihood value with respect to the maximum of the
+        likelihood function.
+    """
+    return 0.5 * np.power( np.sqrt(2.) * special.erfinv(cl), 2)
+
+
+def twosided_dlnl_to_cl(dlnl):
+    """Compute the confidence level that corresponds to a two-sided
+    interval with a given change in the loglikelihood value.
+
+    Parameters
+    ----------
+    dlnl : float
+        Delta-loglikelihood value with respect to the maximum of the
+        likelihood function.
+    
+    Returns
+    -------
+    cl : float
+        Confidence level.
+    """
+    return special.erf( dlnl**0.5 )
+
+
+def onesided_cl_to_dlnl(cl):
+    """Compute the delta-loglikehood values that corresponds to an
+    upper limit of the given confidence level.
+
+    Parameters
+    ----------
+    cl : float
+        Confidence level.
+    
+    Returns
+    -------
+    dlnl : float
+        Delta-loglikelihood value with respect to the maximum of the
+        likelihood function.
+    """
     alpha = 1.0 - cl
     return 0.5 * np.power(np.sqrt(2.) * special.erfinv(1 - 2 * alpha), 2.)
+
+
+def onesided_dlnl_to_cl(dlnl):
+    """Compute the confidence level that corresponds to an upper limit
+    with a given change in the loglikelihood value.
+
+    Parameters
+    ----------
+    dlnl : float
+        Delta-loglikelihood value with respect to the maximum of the
+        likelihood function.
+    
+    Returns
+    -------
+    cl : float
+        Confidence level.
+    """
+    alpha = (1.0 - special.erf(dlnl**0.5))/2.0
+    return 1.0-alpha
 
 
 def interpolate_function_min(x, y):
@@ -454,7 +521,7 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, tol=1E-3):
 
     """
 
-    deltalnl = cl_to_dlnl(ul_confidence)
+    deltalnl = onesided_cl_to_dlnl(ul_confidence)
 
     spline = UnivariateSpline(xval, loglike, k=2, s=tol)
     # m = np.abs(loglike[1:] - loglike[:-1]) > delta_tol


### PR DESCRIPTION
This PR fixes the calculation of two-sided intervals in `CastroData`.  Previously the `LnLFn` was using the `getLimit` function to solve for both parameter limits and intervals.  The new implementation now uses separate delta-loglikelihood thresholds for limits and intervals calculated with `utils.onesided_cl_to_dlnl` and `utils.twosided_cl_to_dlnl`.  The function `getDeltaLogLike` is used to solve for the coordinate that corresponds a given change in the log-likelihood value in both cases.

