### PR TITLE
Improve CastroData fit interface

### DIFF
--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -14,14 +14,17 @@ particle.
 from __future__ import absolute_import, division, print_function
 import numpy as np
 import scipy
+from scipy import stats
+from scipy.optimize import fmin
 
 from astropy.table import Table, Column
 import astropy.units as u
+from fermipy import spectrum
 from fermipy.wcs_utils import wcs_add_energy_axis
 from fermipy.skymap import read_map_from_fits, Map
 from fermipy.sourcefind_utils import fit_error_ellipse
 from fermipy.sourcefind_utils import find_peaks
-from fermipy.spectrum import SpectralFunction
+from fermipy.spectrum import SpectralFunction, SEDFunctor
 from fermipy.utils import onesided_cl_to_dlnl
 from fermipy.utils import twosided_cl_to_dlnl
 
@@ -663,7 +666,7 @@ class CastroData_Base(object):
 
         return nll_val
 
-
+    
     def norm_derivative(self, spec, norm):
         """
         """
@@ -731,6 +734,35 @@ class CastroData_Base(object):
 
         return ts_vals
 
+    def chi2_vals(self,x):
+        """Compute the difference in the log-likelihood between the
+        MLE in each energy bin and the normalization predicted by a
+        global best-fit model.  This array can be summed to get a
+        goodness-of-fit chi2 for the model.
+
+        Parameter
+        ---------
+        x : `~numpy.ndarray`        
+            An array of normalizations derived from a global fit to
+            all energy bins.
+
+        Returns
+        -------
+        chi2_vals : `~numpy.ndarray`
+            An array of chi2 values for each energy bin.        
+        """
+        
+        chi2_vals = np.ndarray((self._nx))
+        for i in range(self._nx):
+
+            mle = self._loglikes[i].mle()
+            nll0 = self._loglikes[i].interp(mle)
+            nll1 = self._loglikes[i].interp(x[i])
+            chi2_vals[i] = 2.0*np.abs(nll0-nll1)
+
+        return chi2_vals
+            
+    
     def getLimits(self, alpha, upper=True):
         """ Evaluate the limits corresponding to a C.L. of (1-alpha)%.
 
@@ -824,40 +856,84 @@ class CastroData_Base(object):
         result = fmin(fToMin, 0., disp=False, xtol=1e-6)
         return result
 
-    def fit_spectrum(self, specFunc, initPars):
+    def fit_spectrum(self, specFunc, initPars, freePars=None):
         """ Fit for the free parameters of a spectral function
 
         Parameters
         ----------
         specFunc : `~fermipy.spectrum.SpectralFunction`
-           The Spectral Function
-        initPars : `~numpy.ndarray`
-           The initial values of the parameters
+            The Spectral Function
 
+        initPars : `~numpy.ndarray`
+            The initial values of the parameters
+
+        freePars : `~numpy.ndarray`        
+            Boolean array indicating which parameters should be free in
+            the fit.
+           
         Returns
         -------
-        result   : tuple
-           The output of scipy.optimize.fmin
-        spec_out : `~numpy.ndarray`
-           The best-fit spectral values
-        TS_spec  : float
-           The TS of the best-fit spectrum
+        params : `~numpy.ndarray`
+            Best-fit parameters.
+           
+        spec_vals : `~numpy.ndarray`
+            The values of the best-fit spectral model in each energy bin.
+           
+        ts_spec : float
+            The TS of the best-fit spectrum
+
+        chi2_vals : `~numpy.ndarray`
+            Array of chi-squared values for each energy bin.
+
+        chi2_spec : float
+            Global chi-squared value for the sum of all energy bins.
+
+        pval_spec : float
+            p-value of chi-squared for the best-fit spectrum.
         """
-        from scipy.optimize import fmin
+        if not isinstance(specFunc,SEDFunctor):
+            specFunc = self.create_functor(specFunc,initPars)
+        
+        if freePars is None:
+            freePars = np.empty(len(initPars),dtype=bool)
+            freePars.fill(True)
 
+        initPars = np.array(initPars)
+        freePars = np.array(freePars)
+            
         def fToMin(x):
-            return self.__call__(specFunc(x))
 
-        result = fmin(fToMin, initPars, disp=False, xtol=1e-6)
-        spec_out = specFunc(result)
-        TS_spec = self.TS_spectrum(spec_out)
-        return result, spec_out, TS_spec
+            xp = np.array(specFunc.params)
+            xp[freePars] = x
+            return self.__call__(specFunc(xp))
+
+        result = fmin(fToMin, initPars[freePars], disp=False, xtol=1e-6)
+
+        out_pars = specFunc.params
+        out_pars[freePars] = np.array(result)
+
+        spec_vals = specFunc(out_pars)
+        spec_npred = np.zeros(len(spec_vals))
+        
+        if isinstance(specFunc,spectrum.SEDFluxFunctor): 
+            spec_npred = spec_vals*self.refSpec.ref_npred/self.refSpec.ref_flux
+        elif isinstance(specFunc,spectrum.SEDEFluxFunctor):
+            spec_npred = spec_vals*self.refSpec.ref_npred/self.refSpec.ref_eflux
+            
+        ts_spec = self.TS_spectrum(spec_vals)
+        chi2_vals = self.chi2_vals(spec_vals)
+        chi2_spec = np.sum(chi2_vals)
+        pval_spec = stats.chisqprob(chi2_spec,len(spec_vals))
+        return dict(params=out_pars, spec_vals=spec_vals,
+                    spec_npred=spec_npred,
+                    ts_spec=ts_spec, chi2_spec=chi2_spec,
+                    chi2_vals=chi2_vals, pval_spec=pval_spec )
 
     def TS_spectrum(self, spec_vals):
         """Calculate and the TS for a given set of spectral values.
         """
         return 2. * (self._nll_null - self.__call__(spec_vals))
-
+    
     def build_scandata_table(self):
         """
         """
@@ -1195,9 +1271,7 @@ class CastroData(CastroData_Base):
         sfn = self.create_functor(specType, scale)[0]
         return self.__call__(sfn(params))
 
-    def test_spectra(self, spec_types=['PowerLaw', 
-                                       'LogParabola', 
-                                       'PLExpCutoff']):
+    def test_spectra(self, spec_types=None):
         """Test different spectral types against the SED represented by this
         CastroData.
 
@@ -1219,59 +1293,50 @@ class CastroData(CastroData_Base):
            * "TS"          : float, the TS for the best-fit spectrum
 
         """
+        if spec_types is None:
+            spec_types = ["PowerLaw", "LogParabola", "PLExpCutoff"]
+        
         retDict = {}
         for specType in spec_types:
-            spec_func, init_pars, scaleEnergy = self.create_functor(specType)
-            fit_result, fit_spec, fit_ts = self.fit_spectrum(
-                spec_func, init_pars)
-
+            spec_func = self.create_functor(specType)
+            fit_out = self.fit_spectrum(spec_func, spec_func.params)
+            
             specDict = {"Function": spec_func,
-                        "Result": fit_result,
-                        "Spectrum": fit_spec,
-                        "ScaleEnergy": scaleEnergy,
-                        "TS": fit_ts}
+                        "Result": fit_out['params'],
+                        "Spectrum": fit_out['spec_vals'],
+                        "ScaleEnergy": spec_func.scale,
+                        "TS": fit_out['ts_spec']}
 
             retDict[specType] = specDict
 
         return retDict
 
-    def create_functor(self, specType, scale=1E3):
+    def create_functor(self, specType, initPars=None, scale=1E3):
         """Create a functor object that computes normalizations in a
         sequence of energy bins for a given spectral model.
 
         Parameters
         ----------
-        specType : str
-            The type of spectrum to use.
-            'PowerLaw','LogParabola','PLExpCutoff' are implemented.
+        specType : str        
+            The type of spectrum to use.  This can be a string
+            corresponding to the spectral model class name or a
+            `~fermipy.spectrum.SpectralFunction` object.
 
+        initPars : `~numpy.ndarray`        
+            Arrays of parameter values with which the spectral
+            function will be initialized.
+        
         scale : float
             The 'pivot energy' or energy scale to use for the spectrum
 
         Returns
         -------
-        fn : `~fermipy.spectrum.SpectralFunction`
-            The functor
-
-        initPars : `~numpy.ndarray`
-            Default set of initial parameter for this spectral type
-
-        scale : float
-            Energy scale (same as input)
-
+        fn : `~fermipy.spectrum.SEDFunctor`
+            A functor object.
         """
 
         emin = self._refSpec.emin
         emax = self._refSpec.emax
-
-        if specType == 'PowerLaw':
-            initPars = np.array([5e-13, -2.0])
-        elif specType == 'LogParabola':
-            initPars = np.array([5e-13, -2.0, 0.0])
-        elif specType == 'PLExpCutoff':
-            initPars = np.array([5e-13, -1.0, 1E4])
-        else:
-            raise Exception('Unknown spectral type: %s' % specType)
 
         fn = SpectralFunction.create_functor(specType,
                                              self.norm_type,
@@ -1279,7 +1344,16 @@ class CastroData(CastroData_Base):
                                              emax,
                                              scale=scale)
 
-        return (fn, initPars, scale)
+        if initPars is None:
+            if specType == 'PowerLaw':
+                initPars = np.array([5e-13, -2.0])
+            elif specType == 'LogParabola':
+                initPars = np.array([5e-13, -2.0, 0.0])
+            elif specType == 'PLExpCutoff':
+                initPars = np.array([5e-13, -1.0, 1E4])
+        
+        fn.params = initPars
+        return fn
 
 
 class TSCube(object):

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -740,8 +740,8 @@ class CastroData_Base(object):
         global best-fit model.  This array can be summed to get a
         goodness-of-fit chi2 for the model.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         x : `~numpy.ndarray`        
             An array of normalizations derived from a global fit to
             all energy bins.
@@ -892,7 +892,8 @@ class CastroData_Base(object):
             p-value of chi-squared for the best-fit spectrum.
         """
         if not isinstance(specFunc,SEDFunctor):
-            specFunc = self.create_functor(specFunc,initPars)
+            specFunc = self.create_functor(specFunc,initPars,
+                                           scale=specFunc.scale)
         
         if freePars is None:
             freePars = np.empty(len(initPars),dtype=bool)

--- a/fermipy/tests/test_castro.py
+++ b/fermipy/tests/test_castro.py
@@ -3,28 +3,42 @@ from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
 from fermipy import castro
+from fermipy.spectrum import DMFitFunction
 
 
-def test_castro_test_spectra_sed(tmpdir):
-    sedfile = str(tmpdir.join('sed.fits'))
-    url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extras/master/data/sed.fits'
-    os.system('curl -o %s -OL %s' % (sedfile, url))
+@pytest.fixture(scope='module')
+def sedfile(request, tmpdir_factory):
+    path = tmpdir_factory.mktemp('data')
+
+    outfile = 'sed.fits'
+    url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extra/master/data/sed.fits'
+    os.system('curl -o %s -OL %s' % (outfile, url))
+    request.addfinalizer(lambda: path.remove(rec=1))
+
+    return outfile
+
+
+def test_castro_test_spectra_sed(sedfile):
     c = castro.CastroData.create_from_sedfile(sedfile)
     test_dict = c.test_spectra()
 
-    assert_allclose(test_dict['PowerLaw']['TS'][0], 26.88, atol=0.01)
-    assert_allclose(test_dict['LogParabola']['TS'][0], 27.30, atol=0.01)
-    assert_allclose(test_dict['PLExpCutoff']['TS'][0], 28.17, atol=0.01)
+    assert_allclose(test_dict['PowerLaw']['TS'][0], 28.20377, atol=0.01)
+    assert_allclose(test_dict['LogParabola']['TS'][0], 28.2466, atol=0.01)
+    assert_allclose(test_dict['PLExpCutoff']['TS'][0], 28.32140, atol=0.01)
 
-    assert_allclose(test_dict['PowerLaw']['Result'], np.array([1.10610705e-16, -3.86502196e+00]))
-    assert_allclose(test_dict['LogParabola']['Result'], np.array([4.22089847e-17, -3.71123256e+00, -5.72287142e-02]))
-    assert_allclose(test_dict['PLExpCutoff']['Result'], np.array([5.53464102e-13, -2.88974835e+00, 1.19098881e+00]))
+    assert_allclose(test_dict['PowerLaw']['Result'],
+                    np.array([1.12719216e-12, -2.60937952e+00]))
+    assert_allclose(test_dict['LogParabola']['Result'],
+                    np.array([1.01468889e-12, -2.43974568e+00, 6.66682177e-02]))
+    assert_allclose(test_dict['PLExpCutoff']['Result'],
+                    np.array([1.04931290e-12, -2.50472567e+00, 6.35096327e+04]))
 
 
 def test_castro_test_spectra_castro(tmpdir):
     castrofile = str(tmpdir.join('castro.fits'))
-    url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extras/master/data/castro.fits'
+    url = 'https://raw.githubusercontent.com/fermiPy/fermipy-extra/master/data/castro.fits'
     os.system('curl -o %s -OL %s' % (castrofile, url))
     c = castro.CastroData.create_from_fits(castrofile, irow=19)
     test_dict = c.test_spectra()
@@ -32,3 +46,37 @@ def test_castro_test_spectra_castro(tmpdir):
     assert_allclose(test_dict['PowerLaw']['TS'][0], 0.00, atol=0.01)
     assert_allclose(test_dict['LogParabola']['TS'][0], 0.00, atol=0.01)
     assert_allclose(test_dict['PLExpCutoff']['TS'][0], 2.71, atol=0.01)
+
+
+def test_fit_dmfitfunction(sedfile):
+
+    cd = castro.CastroData.create_from_sedfile(sedfile)
+
+    init_pars = np.array([1E-26, 100.])
+    jfactor = 1E19
+    dmfn_bb = DMFitFunction(init_pars, chan='bb', jfactor=jfactor)
+    dmfn_mumu = DMFitFunction(init_pars, chan='mumu', jfactor=jfactor)
+    dmfn_tautau = DMFitFunction(init_pars, chan='tautau', jfactor=jfactor)
+
+    init_pars = np.array([1E-26, 100.])
+    spec_func = cd.create_functor(dmfn_bb, init_pars)
+    fit_out = cd.fit_spectrum(spec_func, init_pars, freePars=[True, False])
+
+    assert_allclose(fit_out['ts_spec'], 23.96697127, atol=0.01)
+    assert_allclose(fit_out['params'][0], 8.02000000e-25)
+
+
+    init_pars = np.array([1E-26, 30.])
+    spec_func = cd.create_functor(dmfn_mumu, init_pars)
+    fit_out = cd.fit_spectrum(spec_func, init_pars, freePars=[True, False])
+
+    assert_allclose(fit_out['ts_spec'], 14.66041109, atol=0.01)
+    assert_allclose(fit_out['params'][0], 2.45750000e-24, rtol=0.05)
+
+
+    init_pars = np.array([1E-26, 30.])
+    spec_func = cd.create_functor(dmfn_tautau, init_pars)
+    fit_out = cd.fit_spectrum(spec_func, init_pars, freePars=[True, False])
+
+    assert_allclose(fit_out['ts_spec'], 17.14991598, atol=0.01)
+    assert_allclose(fit_out['params'][0], 2.98000000e-25, rtol=0.05)

--- a/fermipy/tests/test_spectrum.py
+++ b/fermipy/tests/test_spectrum.py
@@ -23,7 +23,7 @@ def test_plexpcutoff_spectrum():
 def test_dmfitfunction_spectrum():
 
     sigmav = 3E-26
-    mass = 100.*1E3
+    mass = 100. # Mass in GeV
     params = [sigmav,mass]
     
     fn0 = spectrum.DMFitFunction(params,chan='bb')


### PR DESCRIPTION
This PR simplifies the interface for performing spectral fits with a `CastroData` object and allows `fit_spectrum` to be more easily used with `DMFitFunction` spectral models.  `DMFitFunction` has internal variables needed for evaluating the spectrum and the current scheme of passing the class state as a set of function arguments seemed too cumbersome.  In the new implementation the `SEDFunctor` classes own an instance of `SpectralFunction` and have an internal state for the scale and model parameters.  

The `fit_spectrum` method can now be called with either a `SEDFunctor` or `SpectralFunction` object (in the latter case a functor will be created on the fly), e.g.
```
cd = CastroData.create_from_fits('sed.fits')
fn = PowerLaw([1E-13,-2.0])
fit_out = cd.fit_spectrum(fn, [1E-13,-2.0])
```
The new `freePars` argument can now be used to fix one or more of the model parameters when performing a fit.  The return value of `fit_spectrum` is changed to a dictionary and includes chi2 values which can be used to assess goodness-of-fit.  

This PR also includes a few changes to the `castro` module unit tests.  The SED test file had an error in the energy column definitions and after fixing this the reference values needed to be updated.