### PR TITLE
Exposure correction

### DIFF
--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -14,3 +14,4 @@ in the following pages:
    extension
    detection
    localization
+   phased

--- a/docs/advanced/phased.rst
+++ b/docs/advanced/phased.rst
@@ -1,0 +1,57 @@
+.. _phased:
+
+Phased Analysis
+===============
+
+Fermipy provides several options to support analysis with selections
+on pulsar phase.  The following examples assume that you already have
+a phased FT1 file that contains a PULSE_PHASE column with the pulsar
+phase for each event.
+
+The following examples illustrates the settings for the
+:ref:`config_gtlike` and :ref:`config_selection` sections of the
+configuration file that would be used for a single-component ON- or
+OFF-phase analysis:
+
+.. code-block:: yaml
+   
+   selection :
+     emin : 100
+     emax : 316227.76
+     zmax    : 90
+     evclass : 128
+     evtype  : 3
+     tmin    : 239557414
+     tmax    : 428903014
+     target : '3FGL J0534.5+2201p'
+     phasemin : 0.68
+     phasemax : 1.00
+
+   gtlike :
+     edisp : True
+     irfs : 'P8R2_SOURCE_V6'
+     edisp_disable : ['isodiff','galdiff']
+     expscale : 0.32
+
+The ``gtlike.expscale`` parameter defines the correction that should
+be applied to the nominal exposure to account for the phase selection
+defined by ``selection.phasemin`` and ``selection.phasemax``.
+Normally this should be set to the size of the phase selection
+interval.
+
+
+To perform a joint analysis of multiple phase selections you can use
+the :ref:`config_components` section to define separate ON- and OFF-phase
+components:
+
+.. code-block:: yaml
+
+   components:
+     - selection : {phasemin : 0.68, phasemax: 1.0}
+       gtlike    : {expscale : 0.32, src_expscale : {'3FGL J0534.5+2201p':0.0}}
+     - selection : {phasemin : 0.0 , phasemax: 0.68}
+       gtlike    : {expscale : 0.68, src_expscale : {'3FGL J0534.5+2201p':1.0}}
+
+The ``src_expscale`` parameter can be used to define an exposure
+correction for indvidual sources.  In this example it is used to zero
+the pulsar component for the OFF-phase selection.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -119,6 +119,8 @@ Options in the *binning* section control the spatial and spectral binning of the
    :delim: tab
    :widths: 10,10,80
 
+.. _config_components:
+
 components
 ----------
 
@@ -355,6 +357,8 @@ about using this method see the :ref:`sed` page.
    :file: config/sed.csv
    :delim: tab
    :widths: 10,10,80
+
+.. _config_selection:
 
 selection
 ---------

--- a/docs/config/extension.csv
+++ b/docs/config/extension.csv
@@ -1,4 +1,6 @@
 ``fix_background``	False	Fix any background parameters that are currently free in the model when performing the likelihood scan over extension.
+``psf_scale_fn``	None	Tuple of vectors (logE,f) defining an energy-dependent PSF scaling function that will be applied when building spatial models for the source of interest.  The tuple (logE,f) defines the fractional corrections f at the sequence of energies logE = log10(E/MeV) where f=0 means no correction.  The correction function f(E) is evaluated by linearly interpolating the fractional correction factors f in log(E).  The corrected PSF is given by P'(x;E) = P(x/(1+f(E));E) where x is the angular separation.
+``save_model_map``	False	Save model counts cubes for the best-fit model of extension.
 ``spatial_model``	RadialGaussian	Spatial model use for extension test.
 ``sqrt_ts_threshold``	None	Threshold on sqrt(TS_ext) that will be applied when ``update`` is True.  If None then nothreshold is applied.
 ``update``	False	Update the source model with the best-fit spatial extension.

--- a/docs/config/gtlike.csv
+++ b/docs/config/gtlike.csv
@@ -2,10 +2,12 @@
 ``convolve``	True	
 ``edisp``	True	Enable the correction for energy dispersion.
 ``edisp_disable``	None	Provide a list of sources for which the edisp correction should be disabled.
+``expscale``	None	Exposure correction that is applied to all sources in the analysis component.  This correction is superseded by `src_expscale` if it is defined for a source.
 ``irfs``	None	Set the IRF string.
 ``llscan_npts``	20	Number of evaluation points to use when performing a likelihood scan.
 ``minbinsz``	0.05	Set the minimum bin size used for resampling diffuse maps.
 ``resample``	True	
 ``rfactor``	2	
+``src_expscale``	None	Dictionary of exposure corrections for individual sources keyed to source name.  The exposure for a given source will be scaled by this value.  A value of 1.0 corresponds to the nominal exposure.
 ``srcmap``	None	
 ``wmap``	None	Likelihood weights map.

--- a/docs/config/selection.csv
+++ b/docs/config/selection.csv
@@ -9,6 +9,8 @@
 ``glon``	None	
 ``logemax``	None	Maximum Energy (log10(MeV))
 ``logemin``	None	Minimum Energy (log10(MeV))
+``phasemax``	None	Maximum pulsar phase
+``phasemin``	None	Minimum pulsar phase
 ``ra``	None	
 ``radius``	None	Radius of data selection.  If none this will be automatically set from the ROI size.
 ``roicut``	no	

--- a/docs/config/tsmap.csv
+++ b/docs/config/tsmap.csv
@@ -1,4 +1,4 @@
 ``loge_bounds``	None	Lower and upper energy bounds in log10(E/MeV).  By default the calculation will be performed over the full analysis energy range.
 ``max_kernel_radius``	3.0	
 ``model``	None	Dictionary defining the properties of the test source.
-``multithread``	False	
+``multithread``	False	Split the TS map calculation across multiple cores.

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -77,7 +77,7 @@ def validate_config(config, defaults, section=None):
                 raise Exception('Invalid key in \'%s\' section of configuration: %s' %
                                 (section, key))
 
-        if isinstance(item, dict):
+        if isinstance(item, dict) and isinstance(defaults[key], dict):
             validate_config(config[key], defaults[key], key)
 
 
@@ -114,7 +114,8 @@ class Configurable(object):
         if validate:
             validate_config(config, self.defaults)
         cast_config(config, self.defaults)
-        self._config = utils.merge_dict(self._config, config)
+        self._config = utils.merge_dict(self._config, config,
+                                        add_new_keys=True)
 
     @classmethod
     def get_config(cls):

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -1,18 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function
 import os
+import copy
 import fermipy
 from fermipy import utils
 
 
-def create_default_config(defaults):
-    """Create a configuration dictionary from a defaults dictionary.
-    The defaults dictionary defines valid configuration keys with
-    default values and docstrings.  Each dictionary element should be
-    a tuple or list containing (default value,docstring,type)."""
+def create_default_config(schema):
+    """Create a configuration dictionary from a schema dictionary.
+    The schema defines the valid configuration keys and their default
+    values.  Each element of ``schema`` should be a tuple/list
+    containing (default value,docstring,type) or a dict containing a
+    nested schema."""
 
     o = {}
-    for key, item in defaults.items():
+    for key, item in schema.items():
 
         if isinstance(item, dict):
             o[key] = create_default_config(item)
@@ -27,14 +29,86 @@ def create_default_config(defaults):
                 value = item_type()
 
             if key in o:
-                raise Exception('Duplicate key.')
+                raise KeyError('Duplicate key in schema.')
 
             o[key] = value
         else:
-            print(key, item, type(item))
-            raise Exception('Unrecognized type for default dict element.')
+            raise TypeError('Unrecognized type for schema dict element: %s %s'%
+                            (key,type(item)))
 
     return o
+
+
+def validate_from_schema(cfg, schema, section=None):
+    for k, v in cfg.items():
+
+        if k not in schema:
+            if section is None:
+                raise KeyError('Invalid configuration key: %s' % k)
+            else:
+                raise KeyError('Invalid configuration key: %s (section : %s)'
+                               %(k, section))
+
+        # This is a section
+        if isinstance(schema[k],dict):
+
+            if not isinstance(cfg[k],dict):
+                raise TypeError('')
+            
+            validate_from_schema(cfg[k],schema[k],k)
+        else:
+            validate_option(k,cfg[k],schema[k][2])
+            
+
+def validate_option(opt_name, opt_val, schema_type):
+
+    if opt_val is None:
+        return
+
+    type_match = type(opt_val) is schema_type
+    type_checks = (schema_type in [list,dict,bool] or
+                   type(opt_val) in [list,dict,bool])
+    if type_checks and not type_match:
+        raise TypeError('Wrong type for %s %s %s'%
+                        (opt_name,type(opt_val),schema_type))
+    
+    
+        
+def update_from_schema(cfg, cfgin, schema):
+    """Update configuration dictionary ``cfg`` with the contents of
+    ``cfgin`` using the ``defaults`` schema dictionary to determine
+    the valid input keys.
+
+    Parameters
+    ----------
+    cfg : dict
+        Configuration dictionary to be updated.
+    
+    cfgin : dict
+        New configuration dictionary that will be merged with ``cfg``.
+    
+    schema : dict    
+        Configuration schema defining the valid configuration keys and
+        their types.
+
+    Returns
+    -------
+    cfgout : dict
+    """
+    cfgout = copy.deepcopy(cfg)
+    for k, v in schema.items():
+
+        if not k in cfgin:
+            continue
+        if isinstance(v,dict):
+            cfgout.setdefault(k,{})
+            cfgout[k] = update_from_schema(cfg[k],cfgin[k],v)            
+        elif v[2] is dict:
+            cfgout[k] = utils.merge_dict(cfg[k],cfgin[k],add_new_keys=True)
+        else:
+            cfgout[k] = cfgin[k]
+            
+    return cfgout
 
 
 def cast_config(config, defaults):
@@ -60,25 +134,68 @@ def cast_config(config, defaults):
 
 def validate_config(config, defaults, section=None):
     for key, item in config.items():
-
+        
         if (key in defaults and isinstance(defaults[key], dict)
             and not isinstance(item, dict)):
             type0 = type(defaults[key])
             type1 = type(item)
 
-            raise Exception('Wrong type for configuration key: '
+            raise TypeError('Wrong type for configuration key: '
                             '%s\ntype: %s required type: %s' % (key, type1, type0))
 
         if key not in defaults:
 
             if section is None:
-                raise Exception('Invalid key in configuration: %s' % key)
+                raise KeyError('Invalid configuration key: %s' % key)
             else:
-                raise Exception('Invalid key in \'%s\' section of configuration: %s' %
-                                (section, key))
+                raise KeyError('Invalid configuration key: %s (section : %s)'
+                               %(key, section))
 
         if isinstance(item, dict) and isinstance(defaults[key], dict):
             validate_config(config[key], defaults[key], key)
+
+
+class ConfigSchema(object):
+    """Class encapsulating a configuration schema."""
+    
+    def __init__(self, options=None, **kwargs):
+        self._options = {} if options is None else options
+        self._options = utils.merge_dict(self._options,kwargs,
+                                         add_new_keys=True)
+
+    def add_option(self,name,default_value,helpstr='',otype=None):
+
+        if otype is None:
+            otype = type(default_value)        
+        self._options[name] = (default_value,helpstr,otype)
+
+    def add_section(self,name, section):
+        self._options[name] = section
+
+    def create_config(self,config=None,validate=True,**kwargs):
+
+        config = {} if config is None else config
+        
+        o = create_default_config(self)
+        config = utils.merge_dict(config, kwargs, add_new_keys=True)
+        cast_config(config, self)
+        if validate:
+            validate_from_schema(config,self)
+        
+        o = update_from_schema(o,config,self)
+        return o
+
+    def items(self):
+        return self._options.items()
+        
+    def __contains__(self, key):
+        return key in self._options
+
+    def __getitem__(self, key):
+        return self._options[key]
+
+    def __setitem__(self, key, value):
+        self._options[key] = value
 
 
 class Configurable(object):
@@ -108,14 +225,10 @@ class Configurable(object):
             self.config['fileio']['outdir'] = self.configdir
 
     def configure(self, config, **kwargs):
-
-        validate = kwargs.pop('validate', False)
-        config = utils.merge_dict(config, kwargs, add_new_keys=True)
-        if validate:
-            validate_config(config, self.defaults)
-        cast_config(config, self.defaults)
-        self._config = utils.merge_dict(self._config, config,
-                                        add_new_keys=True)
+        schema = ConfigSchema(self.defaults)
+        config = schema.create_config(config,**kwargs)
+        cast_config(config, schema)
+        self._config = config
 
     @classmethod
     def get_config(cls):
@@ -127,6 +240,11 @@ class Configurable(object):
         """Return the configuration dictionary of this class."""
         return self._config
 
+    @property
+    def schema(self):
+        """Return the configuration schema of this class."""
+        return ConfigSchema(self.defaults)
+    
     @property
     def configdir(self):
         return self._configdir

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -222,7 +222,7 @@ residmap = {
 # TS Map
 tsmap = {
     'model': (None, 'Dictionary defining the properties of the test source.', dict),
-    'multithread': (False, '', bool),
+    'multithread': (False, 'Split the TS map calculation across multiple cores.', bool),
     'max_kernel_radius': (3.0, '', float),
     'loge_bounds': (None, 'Lower and upper energy bounds in log10(E/MeV).  By default the calculation will be performed over the full analysis energy range.', list),
 }
@@ -335,7 +335,7 @@ sed_output = OrderedDict((
 extension = {
     'spatial_model': ('RadialGaussian', 'Spatial model use for extension test.', str),
     'width': (None, 'Parameter vector for scan over spatial extent.  If none then the parameter '
-              'vector will be set from ``width_min``, ``width_max``, and ``width_nstep``.', str),
+              'vector will be set from ``width_min``, ``width_max``, and ``width_nstep``.', list),
     'width_min': (0.01, 'Minimum value in degrees for the likelihood scan over spatial extent.', float),
     'width_max': (1.0, 'Maximum value in degrees for the likelihood scan over spatial extent.', float),
     'width_nstep': (21, 'Number of steps for the spatial likelihood scan.', int),

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -37,6 +37,8 @@ selection = {
     'evclass': (None, 'Event class selection.', int),
     'evtype': (None, 'Event type selection.', int),
     'convtype': (None, 'Conversion type selection.', int),
+    'phasemin': (None, 'Minimum pulsar phase', float),
+    'phasemax': (None, 'Maximum pulsar phase', float),
     'target': (None, 'Choose an object on which to center the ROI.  '
                      'This option takes precendence over ra/dec or glon/glat.', str),
     'ra': (None, '', float),

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -102,7 +102,11 @@ gtlike = {
     'srcmap': (None, '', str),
     'bexpmap': (None, '', str),
     'wmap': (None, 'Likelihood weights map.', str),
-    'llscan_npts' : (20,'Number of evaluation points to use when performing a likelihood scan.',int)
+    'llscan_npts': (20,'Number of evaluation points to use when performing a likelihood scan.',int),
+    'src_expscale': (None, 'Dictionary of exposure corrections for individual sources keyed to source name.  The exposure '
+                     'for a given source will be scaled by this value.  A value of 1.0 corresponds to the nominal exposure.', dict),
+    'expscale': (None, 'Exposure correction that is applied to all sources in the analysis component.  '
+                 'This correction is superseded by `src_expscale` if it is defined for a source.', float),
 }
 
 # Options for binning.

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4822,6 +4822,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                            dec=self.roi.skydir.dec.deg,
                            rad=self.config['selection']['radius'],
                            convtype=self.config['selection']['convtype'],
+                           phasemin=self.config['selection']['phasemin'],
+                           phasemax=self.config['selection']['phasemax'],
                            evtype=self.config['selection']['evtype'],
                            evclass=self.config['selection']['evclass'],
                            tmin=self.config['selection']['tmin'],
@@ -4909,11 +4911,13 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                 continue
 
             scale = scale_map[hdu.name]
+            if scale<1e-20:
+                self.logger.warning("The expscale parameter was zero, setting it to 1e-8")
+                scale = 1e-8
             if 'SRCMAP_SCALE' in hdu.header:
                 old_scale = hdu.header['SRCMAP_SCALE']
             else:
                 old_scale = 1.0
-
             hdu.data *= scale/old_scale
             hdu.header['SRCMAP_SCALE'] = scale
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4330,6 +4330,10 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         src = self.roi.create_source(name, src_dict)
         self.make_template(src, self.config['file_suffix'])
 
+        if self.config['gtlike']['expscale'] is not None and \
+                name not in self._src_expscale:
+            self._src_expscale[name] = self.config['gtlike']['expscale']
+                    
         if self._like is None:
             return
 
@@ -4341,6 +4345,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         self.like.logLike.buildFixedModelWts()
         if save_source_maps:
             self.like.logLike.saveSourceMaps(str(self.files['srcmap']))
+
+        self.set_exposure_scale(name)
 
     def _create_source(self, src, free=False):
         """Create a pyLikelihood Source object from a
@@ -4435,7 +4441,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
 
         return src
 
-    def set_exposure_scale(self, name, scale):
+    def set_exposure_scale(self, name, scale=None):
         """Set the exposure correction of a source.
 
         Parameters
@@ -4448,7 +4454,12 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
 
         """
         name = self.roi.get_source_by_name(name).name
-        self._src_expscale[name] = scale
+        if scale is None and name not in self._src_expscale:
+            return        
+        elif scale is None:
+            scale = self._src_expscale.get(name,1.0)
+        else:
+            self._src_expscale[name] = scale
         self._scale_srcmap({name: scale})
 
     def set_edisp_flag(self, name, flag=True):

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -33,6 +33,7 @@ from fermipy.hpx_utils import HPX
 from fermipy.roi_model import ROIModel
 from fermipy.plotting import AnalysisPlotter
 from fermipy.logger import Logger, log_level
+from fermipy.config import ConfigSchema
 # pylikelihood
 import GtApp
 import FluxDensity
@@ -931,6 +932,10 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
 
         cfg['fileio']['workdir'] = self.config['fileio']['workdir']
 
+        for k in cfg.keys():
+            if not k in GTBinnedAnalysis.defaults:
+                cfg.pop(k)
+        
         comp = GTBinnedAnalysis(cfg, logging=self.config['logging'])
 
         return comp
@@ -2158,15 +2163,15 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
 
         name = self.roi.get_source_by_name(name).name
 
-        # Extract options from kwargs
-        config = copy.deepcopy(self.config['extension'])
-        config['optimizer'] = copy.deepcopy(self.config['optimizer'])
-        config.setdefault('prefix', '')
-        config.setdefault('write_fits', True)
-        config.setdefault('write_npy', True)
-        fermipy.config.validate_config(kwargs, config)
-        config = merge_dict(config, kwargs)
-
+        schema = ConfigSchema(self.defaults['extension'],
+                              optimizer=self.defaults['optimizer'])
+        schema.add_option('prefix', '')
+        schema.add_option('write_fits', True)
+        schema.add_option('write_npy', True)
+        config = utils.create_dict(self.config['extension'],
+                                   optimizer=self.config['optimizer'])
+        config = schema.create_config(config, **kwargs)
+        
         spatial_model = config['spatial_model']
         width_min = config['width_min']
         width_max = config['width_max']

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4930,12 +4930,12 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
             if scale<1e-20:
                 self.logger.warning("The expscale parameter was zero, setting it to 1e-8")
                 scale = 1e-8
-            if 'SRCMAP_SCALE' in hdu.header:
-                old_scale = hdu.header['SRCMAP_SCALE']
+            if 'EXPSCALE' in hdu.header:
+                old_scale = hdu.header['EXPSCALE']
             else:
                 old_scale = 1.0
             hdu.data *= scale/old_scale
-            hdu.header['SRCMAP_SCALE'] = scale
+            hdu.header['EXPSCALE'] = scale
 
         srcmap.writeto(self.files['srcmap'], clobber=True)
 

--- a/fermipy/tests/test_config.py
+++ b/fermipy/tests/test_config.py
@@ -30,18 +30,15 @@ default_config = {
     'secB' : secB_default_config,
     }
 
-
-    
 class TestClass(config.Configurable):
     defaults = default_config    
     def __init__(self,config=None,**kwargs):
         super(TestClass, self).__init__(config, **kwargs)
 
-    def test_method(self,**kwargs):
+    def method(self,**kwargs):
 
         schema = config.ConfigSchema(self.defaults['secA'],
                                      secB=self.defaults['secB'])
-#        schema.add_section('secB',self.defaults['secB'])
         schema.add_option('extraOptA',3.0)
         schema.add_option('extraOptB',False)
         cfg = utils.create_dict(self.config['secA'],secB=self.config['secB'])
@@ -88,19 +85,19 @@ def test_method_config():
     cfg = {'secA' : {'optFloatA' : 1.0}}
     cls = TestClass(cfg)
     
-    outcfg = cls.test_method()
+    outcfg = cls.method()
     assert(outcfg['optFloatA'] == 1.0)
     assert(outcfg['secB']['optFloatA'] == 7.0)
     assert(outcfg['extraOptA'] == 3.0)
     assert(outcfg['extraOptB'] == False)
     
     cfg = {'optFloatA' : 5.0, 'extraOptB' : True}
-    outcfg = cls.test_method(**cfg)
+    outcfg = cls.method(**cfg)
     assert(outcfg['optFloatA'] == 5.0)
     assert(outcfg['extraOptA'] == 3.0)
     assert(outcfg['extraOptB'] == True)
     
-    outcfg = cls.test_method(extraOptA=4.0,
+    outcfg = cls.method(extraOptA=4.0,
                              secB={'optFloatA' : 2.0},**cfg)
     assert(outcfg['extraOptA'] == 4.0)
     assert(outcfg['secB']['optFloatA'] == 2.0)
@@ -135,13 +132,13 @@ def test_config_method_validation():
 
     cls = TestClass()    
     with pytest.raises(KeyError):    
-        cls.test_method(optInvalid=3.0)
+        cls.method(optInvalid=3.0)
 
     with pytest.raises(KeyError):    
-        cls.test_method(secB={'optInvalid' : 3.0})
+        cls.method(secB={'optInvalid' : 3.0})
         
     with pytest.raises(TypeError):    
-        cls.test_method(**{'optFloatA' : {}})
+        cls.method(**{'optFloatA' : {}})
     
     with pytest.raises(TypeError):    
-        cls.test_method(**{'secB' : {'optFloatA' : {}}})
+        cls.method(**{'secB' : {'optFloatA' : {}}})

--- a/fermipy/tests/test_config.py
+++ b/fermipy/tests/test_config.py
@@ -1,0 +1,147 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function
+import os
+import copy
+import numpy as np
+import pytest
+from fermipy import utils
+from fermipy import config
+from fermipy import defaults
+
+
+secA_default_config = {
+    'optFloatA' : (None,'',float),
+    'optFloatB' : (3.0,'',float),
+    'optDict' : (None,'',dict)}
+
+secB_default_config = {
+    'optFloatA' : (7.0,'',float),
+    'optFloatB' : (None,'',float),
+    'optDict' : (None,'',dict)}
+
+default_config = {
+    'optFloatA' : (None,'',float),
+    'optFloatB' : (3.0,'',float),
+    'optFloatC' : (4.0,'',float),
+    'optDictA' : (None,'',dict),
+    'optDictB' : ({'x' : 3.0},'',dict),
+    'optListA' : (None,'',list),
+    'secA' : secA_default_config,
+    'secB' : secB_default_config,
+    }
+
+
+    
+class TestClass(config.Configurable):
+    defaults = default_config    
+    def __init__(self,config=None,**kwargs):
+        super(TestClass, self).__init__(config, **kwargs)
+
+    def test_method(self,**kwargs):
+
+        schema = config.ConfigSchema(self.defaults['secA'],
+                                     secB=self.defaults['secB'])
+#        schema.add_section('secB',self.defaults['secB'])
+        schema.add_option('extraOptA',3.0)
+        schema.add_option('extraOptB',False)
+        cfg = utils.create_dict(self.config['secA'],secB=self.config['secB'])
+        return schema.create_config(cfg, **kwargs)
+        
+def test_class_config():
+
+    cfg = {'optFloatA' : 2.0, 'optFloatB' : None,
+           'optDictA' : {},
+           'optDictB' : {'y' : 2.0},
+           'optListA' : ['a','b','c'],
+           'secA' : {'optFloatA' : 2.0 } }
+
+    # Default configuration
+    cls = TestClass()
+    assert(cls.config['optFloatA'] == None)
+    assert(cls.config['optFloatB'] == 3.0)
+    assert(cls.config['optFloatC'] == 4.0)
+    assert(cls.config['secA']['optFloatA'] == None)
+    assert(cls.config['secA']['optFloatB'] == 3.0)
+
+    # Configuration dictionary
+    cls = TestClass(cfg)
+    assert(cls.config['optFloatA'] == 2.0)
+    assert(cls.config['optFloatB'] == None)
+    assert(cls.config['optFloatC'] == 4.0)
+    assert(cls.config['optDictA'] == {} )
+    assert(cls.config['optDictB'] == {'x' : 3.0, 'y' : 2.0} )
+    assert(cls.config['optListA'] == ['a','b','c'] )
+    assert(cls.config['secA']['optFloatA'] == 2.0)
+    assert(cls.config['secA']['optFloatB'] == 3.0)
+
+    # Configuration dictionary + kwargs
+    cls = TestClass(cfg, **{'optFloatA' : 5.0,
+                            'optListA' : ['x','y','z'],
+                            'secA' : {'optFloatA' : 4.0} })
+    assert(cls.config['optFloatA'] == 5.0)
+    assert(cls.config['optListA'] == ['x','y','z'])
+    assert(cls.config['secA']['optFloatA'] == 4.0)
+
+
+def test_method_config():
+
+    cfg = {'secA' : {'optFloatA' : 1.0}}
+    cls = TestClass(cfg)
+    
+    outcfg = cls.test_method()
+    assert(outcfg['optFloatA'] == 1.0)
+    assert(outcfg['secB']['optFloatA'] == 7.0)
+    assert(outcfg['extraOptA'] == 3.0)
+    assert(outcfg['extraOptB'] == False)
+    
+    cfg = {'optFloatA' : 5.0, 'extraOptB' : True}
+    outcfg = cls.test_method(**cfg)
+    assert(outcfg['optFloatA'] == 5.0)
+    assert(outcfg['extraOptA'] == 3.0)
+    assert(outcfg['extraOptB'] == True)
+    
+    outcfg = cls.test_method(extraOptA=4.0,
+                             secB={'optFloatA' : 2.0},**cfg)
+    assert(outcfg['extraOptA'] == 4.0)
+    assert(outcfg['secB']['optFloatA'] == 2.0)
+
+    
+def test_config_class_validation():
+
+    cfg = {'optFloatA' : 2.0, 'optFloatB' : None, 'optInvalid' : 1.0,
+           'optDictA' : {},
+           'optDictB' : {'y' : 2.0},
+           'secA' : {'optFloatA' : 2.0 } }
+
+    cls = TestClass(cfg,validate=False,secA={'optInvalid' : 3.0})
+    assert('optInvalid' not in cls.config)
+    assert('optInvalid' not in cls.config['secA'])
+        
+    with pytest.raises(KeyError):
+        cls = TestClass(cfg,validate=True)
+
+    cfg.pop('optInvalid')
+    cfg['optFloatA'] = {}
+    with pytest.raises(TypeError):
+        cls = TestClass(cfg,validate=True)
+    
+
+def test_config_method_validation():
+
+    cfg = {'optFloatA' : 2.0, 'optFloatB' : None, 'optFloatD' : 1.0,
+           'optDictA' : {},
+           'optDictB' : {'y' : 2.0},
+           'secA' : {'optFloatA' : 2.0 } }
+
+    cls = TestClass()    
+    with pytest.raises(KeyError):    
+        cls.test_method(optInvalid=3.0)
+
+    with pytest.raises(KeyError):    
+        cls.test_method(secB={'optInvalid' : 3.0})
+        
+    with pytest.raises(TypeError):    
+        cls.test_method(**{'optFloatA' : {}})
+    
+    with pytest.raises(TypeError):    
+        cls.test_method(**{'secB' : {'optFloatA' : {}}})

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -896,6 +896,12 @@ def update_keys(input_dict, key_map):
     return o
 
 
+def create_dict(d0, **kwargs):
+    o = copy.deepcopy(d0)
+    o = merge_dict(o,kwargs,add_new_keys=True)
+    return o
+
+
 def merge_dict(d0, d1, add_new_keys=False, append_arrays=False):
     """Recursively merge the contents of python dictionary d0 with
     the contents of another python dictionary, d1.

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -961,7 +961,7 @@ def merge_dict(d0, d1, add_new_keys=False, append_arrays=False):
             od[k] = copy.copy(d1[k])
 
     if add_new_keys:
-        for k, v in d1.iteritems():
+        for k, v in d1.items():
             if k not in d0:
                 od[k] = copy.deepcopy(d1[k])
 


### PR DESCRIPTION
This PR adds support for analysis with phase selections.  The following new parameters can now be defined in the configuration file:

- `gtlike.expscale` : Exposure correction applied to all sources.  The exposure will be scaled by this factor.  For phased analysis this should be set to the fractional size of the phase interval.
- `gtlike.src_expscale` : Dictionary of exposure corrections for individual sources keyed to source name.  This option overrides the exposure correction set with `gtlike.expscale` and can be used to zero the amplitude of an individual component of the model (e.g. the pulsar). 
- `selection.phasemin` : `phasemin` parameter to `gtselect`
- `selection.phasemax` : `phasemax` parameter to `gtselect`

In a typical use case one can use a single phase selection for the ON or OFF phase interval:
```
gtlike: { expscale : 0.32 }
selection: { phasemin : 0.68, phasemax : 1.0 }
```
or perform a joint analysis of both phase intervals:
```
components:
  - selection : {phasemin : 0.68, phasemax: 1.0}
    gtlike    : {expscale : 0.32, src_expscale : {'3FGL J0534.5+2201p':0.0}}
  - selection : {phasemin : 0.0 , phasemax: 0.68}
    gtlike    : {expscale : 0.68, src_expscale : {'3FGL J0534.5+2201p':1.0}}
```
In the latter case the exposure correction for the pulsar should be set to zero during the OFF-phase selection.

In addition to the above changes this PR also includes a number of changes to how configuration parameters are parsed and validated.  Configuration is now performed by instantiating a `ConfigSchema` object that defines the valid keys and types of the input configuration and calling `ConfigSchema.create_config()` to create a validated configuration dictionary.  The new implementation provides more consistent handling for all parameter types.