### PR TITLE
Lightcurve bugfix

### DIFF
--- a/docs/config/common.csv
+++ b/docs/config/common.csv
@@ -2,5 +2,6 @@
 ``free_radius``	None	Free normalizations of background sources within this angular distance in degrees from the source of interest.  If None then no sources will be freed.
 ``loge_bounds``	None	Restrict the analysis to an energy range (emin,emax) in log10(E/MeV) that is a subset of the analysis energy range. By default the full analysis energy range will be used.  If either emin/emax are None then only an upper/lower bound on the energy range wil be applied.
 ``make_plots``	False	Generate diagnostic plots.
+``model``	None	Dictionary defining the spatial/spectral properties of the test source. If model is None the test source will be a PointSource with an Index 2 power-law spectrum.
 ``write_fits``	True	Write the output to a FITS file.
 ``write_npy``	True	Write the output dictionary to a numpy file.

--- a/docs/config/residmap.csv
+++ b/docs/config/residmap.csv
@@ -1,6 +1,6 @@
 ``exclude``	None	List of sources that will be removed from the model when computing the residual map.
 ``loge_bounds``	None	Restrict the analysis to an energy range (emin,emax) in log10(E/MeV) that is a subset of the analysis energy range. By default the full analysis energy range will be used.  If either emin/emax are None then only an upper/lower bound on the energy range wil be applied.
 ``make_plots``	False	Generate diagnostic plots.
-``model``	None	Dictionary defining the properties of the test source.
+``model``	None	Dictionary defining the spatial/spectral properties of the test source. If model is None the test source will be a PointSource with an Index 2 power-law spectrum.
 ``write_fits``	True	Write the output to a FITS file.
 ``write_npy``	True	Write the output dictionary to a numpy file.

--- a/docs/config/sourcefind.csv
+++ b/docs/config/sourcefind.csv
@@ -1,7 +1,8 @@
 ``free_params``	None	
-``max_iter``	3	Set the number of search iterations.
-``min_separation``	1.0	Set the minimum separation in deg for sources added in each iteration.
-``model``	None	Set the source model dictionary.  By default the test source will be a PointSource with an Index 2 power-law specturm.
-``sources_per_iter``	3	
-``sqrt_ts_threshold``	5.0	Set the threshold on sqrt(TS).
-``tsmap_fitter``	tsmap	Set the method for generating the TS map.
+``max_iter``	5	Maximum number of source finding iterations.  The source finder will continue adding sources until no additional peaks are found or the number of iterations exceeds this number.
+``min_separation``	1.0	Minimum separation in degrees between sources detected in each iteration. The source finder will look for the maximum peak in the TS map within a circular region of this radius.
+``model``	None	Dictionary defining the spatial/spectral properties of the test source. If model is None the test source will be a PointSource with an Index 2 power-law spectrum.
+``multithread``	False	Split the calculation across all available cores.
+``sources_per_iter``	4	Maximum number of sources that will be added in each iteration.  If the number of detected peaks in a given iteration is larger than this number, only the N peaks with the largest TS will be used as seeds for the current iteration.
+``sqrt_ts_threshold``	5.0	Source threshold in sqrt(TS).  Only peaks with sqrt(TS) exceeding this threshold will be used as seeds for new sources.
+``tsmap_fitter``	tsmap	Set the method for generating the TS map.  Valid options are tsmap or tscube.

--- a/docs/config/tscube.csv
+++ b/docs/config/tscube.csv
@@ -3,7 +3,7 @@
 ``do_sed``	True	Compute the energy bin-by-bin fits
 ``init_lambda``	0	Initial value of damping parameter for newton step size calculation.   A value of zero disables damping.
 ``max_iter``	30	Maximum number of iterations for the Newtons method fitter.
-``model``	None	Dictionary defining the properties of the test source.  By default the test source will be a PointSource with an Index 2 power-law specturm.
+``model``	None	Dictionary defining the spatial/spectral properties of the test source. If model is None the test source will be a PointSource with an Index 2 power-law spectrum.
 ``nnorm``	10	Number of points in the likelihood v. normalization scan
 ``norm_sigma``	5.0	Number of sigma to use for the scan range 
 ``remake_test_source``	False	If true, recomputes the test source image (otherwise just shifts it)

--- a/docs/config/tsmap.csv
+++ b/docs/config/tsmap.csv
@@ -2,7 +2,7 @@
 ``loge_bounds``	None	Restrict the analysis to an energy range (emin,emax) in log10(E/MeV) that is a subset of the analysis energy range. By default the full analysis energy range will be used.  If either emin/emax are None then only an upper/lower bound on the energy range wil be applied.
 ``make_plots``	False	Generate diagnostic plots.
 ``max_kernel_radius``	3.0	Set the maximum radius of the test source kernel.  Using a smaller value will speed up the TS calculation at the loss of accuracy.
-``model``	None	Dictionary defining the properties of the test source.
-``multithread``	False	Split the TS map calculation across multiple cores.
+``model``	None	Dictionary defining the spatial/spectral properties of the test source. If model is None the test source will be a PointSource with an Index 2 power-law spectrum.
+``multithread``	False	Split the calculation across all available cores.
 ``write_fits``	True	Write the output to a FITS file.
 ``write_npy``	True	Write the output dictionary to a numpy file.

--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -19,6 +19,8 @@ ENERGY_FLUX_UNIT = ':math:`\mathrm{MeV}~\mathrm{cm}^{-2}~\mathrm{s}^{-1}`'
 
 # Options that are common to several sections
 common = {
+    'model': (None, 'Dictionary defining the spatial/spectral properties of the test source. '
+              'If model is None the test source will be a PointSource with an Index 2 power-law spectrum.', dict),
     'free_background': (False, 'Leave background parameters free when performing the fit. If True then any '
                         'parameters that are currently free in the model will be fit simultaneously '
                         'with the source of interest.', bool),
@@ -245,7 +247,7 @@ roiopt_output = {
 
 # Residual Maps
 residmap = {
-    'model': (None, 'Dictionary defining the properties of the test source.', dict),
+    'model': common['model'],
     'exclude': (None, 'List of sources that will be removed from the model when '
                 'computing the residual map.', list),
     'loge_bounds': common['loge_bounds'],
@@ -256,10 +258,10 @@ residmap = {
 
 # TS Map
 tsmap = {
-    'model': (None, 'Dictionary defining the properties of the test source.', dict),
+    'model': common['model'],
     'exclude': (None, 'List of sources that will be removed from the model when '
                 'computing the TS map.', list),
-    'multithread': (False, 'Split the TS map calculation across multiple cores.', bool),
+    'multithread': (False, 'Split the calculation across all available cores.', bool),
     'max_kernel_radius': (3.0, 'Set the maximum radius of the test source kernel.  Using a '
                           'smaller value will speed up the TS calculation at the loss of '
                           'accuracy.', float),
@@ -271,7 +273,7 @@ tsmap = {
 
 # TS Cube
 tscube = {
-    'model': (None, 'Dictionary defining the properties of the test source.  By default the test source will be a PointSource with an Index 2 power-law specturm.', dict),
+    'model': common['model'],
     'do_sed': (True, 'Compute the energy bin-by-bin fits', bool),
     'nnorm': (10, 'Number of points in the likelihood v. normalization scan', int),
     'norm_sigma': (5.0, 'Number of sigma to use for the scan range ', float),
@@ -289,13 +291,26 @@ tscube = {
 
 # Options for Source Finder
 sourcefind = {
-    'model': (None, 'Set the source model dictionary.  By default the test source will be a PointSource with an Index 2 power-law specturm.', dict),
-    'min_separation': (1.0, 'Set the minimum separation in deg for sources added in each iteration.', float),
-    'sqrt_ts_threshold': (5.0, 'Set the threshold on sqrt(TS).', float),
-    'max_iter': (3, 'Set the number of search iterations.', int),
-    'sources_per_iter': (3, '', int),
-    'tsmap_fitter': ('tsmap', 'Set the method for generating the TS map.', str),
-    'free_params': (None, '', list)
+    'model': common['model'],
+    'min_separation': (1.0,
+                       'Minimum separation in degrees between sources detected in each '
+                       'iteration. The source finder will look for the maximum peak '
+                       'in the TS map within a circular region of this radius.', float),
+    'sqrt_ts_threshold': (5.0, 'Source threshold in sqrt(TS).  Only peaks with sqrt(TS) '
+                          'exceeding this threshold will be used as seeds for new '
+                          'sources.', float),
+    'max_iter': (5, 'Maximum number of source finding iterations.  The source '
+                 'finder will continue adding sources until no additional '
+                 'peaks are found or the number of iterations exceeds this '
+                 'number.', int),
+    'sources_per_iter': (4, 'Maximum number of sources that will be added in each '
+                         'iteration.  If the number of detected peaks in a given '
+                         'iteration is larger than this number, only the N peaks with '
+                         'the largest TS will be used as seeds for the current '
+                         'iteration.', int),
+    'tsmap_fitter': ('tsmap', 'Set the method for generating the TS map.  Valid options are tsmap or tscube.', str),
+    'free_params': (None, '', list),
+    'multithread': (False, 'Split the calculation across all available cores.', bool),
 }
 
 # Options for lightcurve analysis
@@ -311,7 +326,7 @@ lightcurve = {
     'free_sources': (None, 'List of sources to be freed.  These sources will be added to the list of sources '
                      'satisfying the free_radius selection.', list),
     'free_params': (None, 'Set the parameters of the source of interest that will be re-fit in each time bin. '
-                    'If this list is empty then all parameters will be freed.', list),    
+                    'If this list is empty then all parameters will be freed.', list),
     'make_plots': common['make_plots'],
     'write_fits': common['write_fits'],
     'write_npy': common['write_npy'],
@@ -554,7 +569,7 @@ plotting = {
     'format': ('png', '', str),
     'cmap': ('magma', 'Set the colormap for 2D plots.', str),
     'cmap_resid': ('RdBu_r', 'Set the colormap for 2D residual plots.', str),
-    'figsize': ([8.0,6.0], 'Set the default figure size.', list),
+    'figsize': ([8.0, 6.0], 'Set the default figure size.', list),
     'label_ts_threshold':
         (0., 'TS threshold for labeling sources in sky maps.  If None then no sources will be labeled.', float),
 }

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -194,7 +194,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         'tsmap': defaults.tsmap,
         'residmap': defaults.residmap,
         'lightcurve': defaults.lightcurve,
-        'sourcefind': defaults.sourcefind,
+        'find_sources': defaults.sourcefind,
     }
 
     defaults = {'logging': defaults.logging,

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -194,6 +194,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         'tsmap': defaults.tsmap,
         'residmap': defaults.residmap,
         'lightcurve': defaults.lightcurve,
+        'sourcefind': defaults.sourcefind,
     }
 
     defaults = {'logging': defaults.logging,
@@ -512,8 +513,8 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         """Make a clone of this analysis instance."""
         gta = GTAnalysis(config, **kwargs)
         gta._roi = copy.deepcopy(self.roi)
-        for c in self.components:
-            gta.components[0]._roi = copy.deepcopy(c.roi)
+        for i, c in enumerate(self.components):
+            gta.components[i]._roi = copy.deepcopy(c.roi)
 
         return gta
 

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -28,51 +28,22 @@ class SourceFind(object):
     `~fermipy.gtanalysis.GTAnalysis`."""
 
     def find_sources(self, prefix='', **kwargs):
-        """An iterative source-finding algorithm.
+        """An iterative source-finding algorithm that uses likelihood
+        ratio (TS) maps of the region of interest to find new sources.
+        After each iteration a new TS map is generated incorporating
+        sources found in the previous iteration.  The method stops
+        when the number of iterations exceeds ``max_iter`` or no
+        sources exceeding ``sqrt_ts_threshold`` are found.
 
         Parameters
         ----------
-
-        model : dict
-           Dictionary defining the properties of the test source.
-           This is the model that will be used for generating TS maps.
-
-        sqrt_ts_threshold : float
-           Source threshold in sqrt(TS).  Only peaks with sqrt(TS)
-           exceeding this threshold will be used as seeds for new
-           sources.
-
-        min_separation : float
-           Minimum separation in degrees of sources detected in each
-           iteration. The source finder will look for the maximum peak
-           in the TS map within a circular region of this radius.
-
-        max_iter : int
-           Maximum number of source finding iterations.  The source
-           finder will continue adding sources until no additional
-           peaks are found or the number of iterations exceeds this
-           number.
-
-        sources_per_iter : int
-           Maximum number of sources that will be added in each
-           iteration.  If the number of detected peaks in a given
-           iteration is larger than this number, only the N peaks with
-           the largest TS will be used as seeds for the current
-           iteration.
-
-        tsmap_fitter : str
-           Set the method used internally for generating TS maps.
-           Valid options:
-
-           * tsmap
-           * tscube
+        {options}
 
         tsmap : dict
            Keyword arguments dictionary for tsmap method.
 
         tscube : dict
            Keyword arguments dictionary for tscube method.
-
 
         Returns
         -------
@@ -173,6 +144,7 @@ class SourceFind(object):
         src_dict_template = kwargs.pop('model')
 
         threshold = kwargs.get('sqrt_ts_threshold')
+        multithread = kwargs.get('multithread', False)
         min_separation = kwargs.get('min_separation')
         sources_per_iter = kwargs.get('sources_per_iter')
         search_skydir = kwargs.get('search_skydir', None)
@@ -185,13 +157,16 @@ class SourceFind(object):
         if tsmap_fitter == 'tsmap':
             kw = kwargs.get('tsmap', {})
             kw['model'] = src_dict_template
-            m = self.tsmap('%s_sourcefind_%02i' % (prefix, iiter),
+            kw['multithread'] = multithread
+            m = self.tsmap(utils.join_strings([prefix,
+                                               'sourcefind_%02i' % iiter]),
                            **kw)
 
         elif tsmap_fitter == 'tscube':
             kw = kwargs.get('tscube', {})
             kw['model'] = src_dict_template
-            m = self.tscube('%s_sourcefind_%02i' % (prefix, iiter),
+            m = self.tscube(utils.join_strings([prefix,
+                                                'sourcefind_%02i' % iiter]),
                             **kw)
         else:
             raise Exception(


### PR DESCRIPTION
This PR fixes a bug in `GTAnalysis.clone()` that was breaking lightcurve analysis with multiple components.  Also includes some minor improvements to the `find_sources` docstring.