### PR TITLE
Srcmap improvements

### DIFF
--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -446,8 +446,8 @@ class ExtensionFit(object):
             fit_ext['ra'] = skydir.ra.deg
             fit_ext['dec'] = skydir.dec.deg
             fit_ext['offset'] = skydir.separation(src.skydir).deg
-            fit_ext['loglike_ext'] = fit_pos['loglike']
-            dloglike = fit_pos['loglike'] - loglike
+            fit_ext['loglike_ext'] = -gta.like()
+            dloglike = fit_ext['loglike_ext'] - loglike
 
             self.logger.info('Extension Fit Iteration %i', i)
             self.logger.info('R68 = %8.3f Offset = %8.3f Delta-LogLikelihood = %8.2f',

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -2802,8 +2802,8 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         # FIXME: Figure out why currentLogLike gets out of sync
         #loglike = fitcache.fitcache.currentLogLike()
         #prior_vals, prior_errs, has_prior = gtutils.get_priors(self.like)
-        #loglike -= np.sum(has_prior) * np.log(np.sqrt(2 * np.pi))            
-        loglike = -self.like()        
+        #loglike -= np.sum(has_prior) * np.log(np.sqrt(2 * np.pi))
+        loglike = -self.like()
         o['loglike'] = loglike
 
         return o
@@ -3178,7 +3178,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             self._roi_data['loge_bounds'] = self._roi_data.pop('erange')
 
         self._loge_bounds = self._roi_data.setdefault('loge_bounds',
-                                                       self.loge_bounds)
+                                                      self.loge_bounds)
 
         sources = roi_data.pop('sources')
         sources = utils.update_keys(sources, key_map)
@@ -3306,11 +3306,11 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             tab = self.roi.create_source_table()
             tab['component'] = i
             tab['expscale'] = np.nan
-            
-            for k,v in c.src_expscale.items():
+
+            for k, v in c.src_expscale.items():
                 m = tab['source_name'] == k
                 tab['expscale'][m] = v
-            
+
             tab_srcs += [tab]
 
             tab = self.roi.create_param_table()
@@ -3318,14 +3318,14 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             tab_params += [tab]
 
         from astropy.table import vstack
-            
+
         hdu_srcs = fits.table_to_hdu(vstack(tab_srcs))
         hdu_srcs.name = 'SOURCES'
         hdu_params = fits.table_to_hdu(vstack(tab_params))
-        hdu_params.name = 'PARAMS'        
+        hdu_params.name = 'PARAMS'
         hdu_roi = fits.table_to_hdu(self.create_roi_table())
         hdu_roi.name = 'ROI'
-        
+
         hdus = [fits.PrimaryHDU(), hdu_data, hdu_roi, hdu_srcs, hdu_params]
         hdus[0].header['CONFIG'] = json.dumps(self.config)
         hdus[1].header['CONFIG'] = json.dumps(self.config)
@@ -3335,11 +3335,11 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
 
         rd = copy.deepcopy(self._roi_data)
         loge_bounds = rd.pop('loge_bounds').tolist()
-        
+
         tab = fits_utils.dict_to_table(rd)
         tab['component'] = -1
         tab.meta['loge_bounds'] = loge_bounds
-        
+
         row_dict = {}
         for i, c in enumerate(rd['components']):
             c['component'] = i
@@ -3348,16 +3348,16 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             for k in tab.columns:
 
                 shape = tab.columns[k].shape
-                ndim = tab.columns[k].ndim                
+                ndim = tab.columns[k].ndim
                 if ndim == 1:
                     val = c[k]
                 else:
-                    val = np.ones(shape[1:])*np.nan
+                    val = np.ones(shape[1:]) * np.nan
                     val[:len(c[k])] = c[k]
                 row += [val]
             tab.add_row(row)
         return tab
-        
+
     def make_plots(self, prefix, mcube_map=None, **kwargs):
         """Make diagnostic plots using the current ROI model."""
 
@@ -4195,7 +4195,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         if (not save_template and
             src['Spatial_Filename'] is not None and
             os.path.isfile(src['Spatial_Filename']) and
-            os.path.dirname(src['Spatial_Filename']) == self.config['fileio']['workdir']):
+                os.path.dirname(src['Spatial_Filename']) == self.config['fileio']['workdir']):
             os.remove(src['Spatial_Filename'])
 
         self.roi.delete_sources([src])
@@ -4446,6 +4446,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         if not use_external_srcmap:
             self._bin_data(overwrite=overwrite, **kwargs)
             self._create_expcube(overwrite=overwrite, **kwargs)
+
+        self._bexp = Map.create_from_fits(self.files['bexpmap'])
 
         # Make spatial maps for extended sources
         for s in self.roi.sources:
@@ -4927,9 +4929,10 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         spatial_model = src['SpatialModel']
         spatial_width = src['SpatialWidth']
         xpix, ypix = wcs_utils.skydir_to_pix(skydir, self._skywcs)
+        exp = self._bexp.interpolate_at_skydir(skydir)
         rebin = min(int(np.ceil(self.binsz / 0.01)), 8)
         shape_out = (self.enumbins + 1, self.npix, self.npix)
-        cache = SourceMapCache.create(self._psf, spatial_model,
+        cache = SourceMapCache.create(self._psf, exp, spatial_model,
                                       spatial_width, shape_out,
                                       self.config['binning']['binsz'],
                                       rebin=rebin)
@@ -4943,11 +4946,13 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         spatial_model = src['SpatialModel']
         spatial_width = src['SpatialWidth']
         xpix, ypix = wcs_utils.skydir_to_pix(skydir, self._skywcs)
+        exp = self._bexp.interpolate_at_skydir(skydir)
+
         cache = self._srcmap_cache.get(name, None)
         if cache is not None:
             k = cache.create_map([ypix, xpix])
         else:
-            k = srcmap_utils.make_srcmap(self._psf, spatial_model,
+            k = srcmap_utils.make_srcmap(self._psf, exp, spatial_model,
                                          spatial_width,
                                          npix=self.npix, xpix=xpix, ypix=ypix,
                                          cdelt=self.config['binning']['binsz'],

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4951,7 +4951,6 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                                          spatial_width,
                                          npix=self.npix, xpix=xpix, ypix=ypix,
                                          cdelt=self.config['binning']['binsz'],
-                                         rebin=rebin,
                                          psf_scale_fn=psf_scale_fn,
                                          sparse=True)
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4943,7 +4943,6 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         spatial_model = src['SpatialModel']
         spatial_width = src['SpatialWidth']
         xpix, ypix = wcs_utils.skydir_to_pix(skydir, self._skywcs)
-        rebin = min(int(np.ceil(self.binsz / 0.01)), 8)
         cache = self._srcmap_cache.get(name, None)
         if cache is not None:
             k = cache.create_map([ypix, xpix])
@@ -4953,7 +4952,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                                          npix=self.npix, xpix=xpix, ypix=ypix,
                                          cdelt=self.config['binning']['binsz'],
                                          rebin=rebin,
-                                         psf_scale_fn=psf_scale_fn)
+                                         psf_scale_fn=psf_scale_fn,
+                                         sparse=True)
 
         return k
 

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -593,7 +593,7 @@ def calc_exp(skydir, ltc, event_class, event_types,
     """
 
     if npts is None:
-        npts = int(np.ceil(np.max(cth_bins[1:] - cth_bins[:-1]) / 0.05))
+        npts = int(np.ceil(np.max(cth_bins[1:] - cth_bins[:-1]) / 0.025))
 
     exp = np.zeros((len(egy), len(cth_bins) - 1))
     cth_bins = utils.split_bin_edges(cth_bins, npts)

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -308,8 +308,8 @@ class LTCube(HpxMap):
         width = edge_to_width(bins)
         ipix = hp.ang2pix(self.hpx.nside, np.pi / 2. - np.radians(dec),
                           np.radians(ra), nest=self.hpx.nest)
-        lt = np.interp(center, self._cth_center,
-                       self.data[:, ipix] / self._cth_width) * width
+        lt = np.histogram(self._cth_center,
+                          weights=self.data[:, ipix], bins=bins)[0]
         lt = np.sum(lt.reshape(-1, npts), axis=1)
         return lt
 

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -367,6 +367,16 @@ class Map(Map_Base):
                                      fill_value=None)
         return fn(np.column_stack(pixcrd))
 
+    def interpolate_at_skydir(self, skydir):
+
+        coordsys = wcs_utils.get_coordsys(self.wcs)
+        if coordsys == 'CEL':
+            skydir = skydir.transform_to('icrs')
+            return self.interpolate(skydir.ra.deg, skydir.dec.deg)
+        else:
+            skydir = skydir.transform_to('galactic')
+            return self.interpolate(skydir.l.deg, skydir.b.deg)
+
 
 class HpxMap(Map_Base):
     """ Representation of a 2D or 3D counts map using HEALPix. """

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -473,25 +473,32 @@ class SourceFind(object):
 
         prefix = kwargs.get('prefix', '')
         dtheta_max = kwargs.get('dtheta_max', 0.5)
-        write_fits = kwargs.get('write_fits', False)
-        write_npy = kwargs.get('write_npy', False)
-        use_pylike = kwargs.get('use_pylike', True)
         zmin = kwargs.get('zmin', -3.0)
 
+        kw = {
+            'map_size': 2.0 * dtheta_max,
+            'write_fits':  kwargs.get('write_fits', False),
+            'write_npy':  kwargs.get('write_npy', False),
+            'use_pylike': kwargs.get('use_pylike', True),
+            'max_kernel_radius': self.config['tsmap']['max_kernel_radius'],
+            'loglevel': logging.DEBUG
+        }
+
         src = self.roi.copy_source(name)
+
+        if src['SpatialModel'] in ['RadialDisk', 'RadialGaussian']:
+            kw['max_kernel_radius'] = max(kw['max_kernel_radius'],
+                                          2.0 * src['SpatialWidth'])
+
         skydir = kwargs.get('skydir', src.skydir)
         tsmap = self.tsmap(utils.join_strings([prefix, name.lower().
                                                replace(' ', '_')]),
                            model=src.data,
                            map_skydir=skydir,
-                           map_size=2.0 * dtheta_max,
                            exclude=[name],
-                           write_fits=write_fits,
-                           write_npy=write_npy,
-                           use_pylike=use_pylike,
-                           make_plots=False,
-                           loglevel=logging.DEBUG)
+                           make_plots=False, **kw)
 
+        # Find peaks with TS > 4
         peaks = find_peaks(tsmap['ts'], 4.0, 0.2)
         peak_best = None
         o = {}

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -337,7 +337,8 @@ class SourceFind(object):
 
         fit0 = self._fit_position_tsmap(name, prefix=prefix,
                                         dtheta_max=dtheta_max,
-                                        zmin=-3.0)
+                                        zmin=-3.0,
+                                        use_pylike=False)
 
         self.logger.debug('Completed localization with TS Map.\n'
                           '(ra,dec) = (%10.4f,%10.4f) '

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -4,11 +4,13 @@ import os
 import re
 import copy
 import tempfile
+import functools
 from collections import OrderedDict
 import xml.etree.cElementTree as et
 import yaml
 import numpy as np
 import scipy.optimize
+from scipy.ndimage import map_coordinates
 from scipy.interpolate import UnivariateSpline
 from scipy.optimize import brentq
 from scipy.ndimage.measurements import label
@@ -1498,6 +1500,107 @@ def make_cgauss_kernel(psf, sigma, npix, cdelt, xpix, ypix, psf_scale_fn=None,
         k /= (np.sum(k, axis=0)[np.newaxis, ...] * np.radians(cdelt) ** 2)
 
     return k
+
+
+def memoize(obj):
+    obj.cache = {}
+
+    @functools.wraps(obj)
+    def memoizer(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in obj.cache:
+            obj.cache = {}
+            obj.cache[key] = obj(*args, **kwargs)
+        return obj.cache[key]
+    return memoizer
+
+
+def make_radial_kernel(psf, fn, sigma, npix, cdelt, xpix, ypix, psf_scale_fn=None,
+                       normalize=False, sparse=False):
+    """Make a kernel for a general radially symmetric 2D function.
+
+    Parameters
+    ----------
+
+    psf : `~fermipy.irfs.PSFModel`
+
+    sigma : float
+      68% containment radius in degrees.
+    """
+    
+    egy = psf.energies
+    ang_dist = make_pixel_distance(npix, xpix, ypix)*cdelt
+    dtheta = np.linspace(0.0,(np.max(ang_dist)*1.05)**0.5,400)**2.0    
+    z = create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn)
+    #z = create_radial_spline(psf, fn, sigma, egy, dtheta, psf_scale_fn)
+    x2 = val_to_pix(dtheta, np.ravel(ang_dist))
+
+    shape = (len(egy),npix,npix)
+    k = np.zeros(shape)
+
+    r99 = psf.containment_angle(energies=psf.energies,fraction=0.99)
+    r34 = psf.containment_angle(energies=psf.energies,fraction=0.34)
+
+    rmin = np.minimum(r34/4.,0.01)
+    rmax = r99
+    if sigma is not None:
+        rmin = np.minimum(rmin, 0.5*sigma)
+        rmax = np.maximum(rmax, 3.0*sigma)
+
+    for i in range(len(egy)):
+        
+        rebin = min(int(np.ceil(cdelt / rmin[i])), 8)
+        xdist = make_pixel_distance(npix * rebin,
+                                    xpix * rebin + (rebin-1.0) / 2.,
+                                    ypix * rebin + (rebin-1.0) / 2.)
+        xdist *= cdelt/float(rebin)
+        m = np.ravel(xdist) < rmax[i]
+        x = val_to_pix(dtheta, np.ravel(xdist))
+        
+        if sparse:
+            kk = np.zeros(xdist.size)
+            kk[m] = map_coordinates(z[i],[x[m]],order=2,prefilter=False)
+            kk = kk.reshape(xdist.shape)
+        else:
+            kk = map_coordinates(z[i],[x],order=2,prefilter=False).reshape(xdist.shape)
+
+        if rebin > 1:
+            kk = sum_bins(kk, 0, rebin)
+            kk = sum_bins(kk, 1, rebin)
+        
+        k[i] = kk/float(rebin)**2
+
+    k = k.reshape((len(egy),) + ang_dist.shape)
+    if normalize:
+        k /= (np.sum(k, axis=0)[np.newaxis, ...] * np.radians(cdelt) ** 2)
+    
+    return k
+
+
+#@memoize
+def create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn):
+
+    z =  np.zeros((len(egy), len(dtheta)))
+    for i in range(len(egy)):
+
+        if fn is None:
+            z[i] = psf.eval(i, dtheta, scale_fn=psf_scale_fn)
+        else:
+            z[i] = fn(lambda t: psf.eval(i, t, scale_fn=psf_scale_fn),
+                      dtheta, sigma)
+
+    return z
+
+
+def create_radial_spline(psf, fn, sigma, egy, dtheta, psf_scale_fn):
+
+    from scipy.ndimage.interpolation import spline_filter
+
+    z =  create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn)
+    sp = []
+    for i in range(z.shape[0]):
+        sp += [spline_filter(z[i], order=2)]
+    return sp
 
 
 def make_psf_kernel(psf, npix, cdelt, xpix, ypix, psf_scale_fn=None, normalize=False):

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -1527,60 +1527,62 @@ def make_radial_kernel(psf, fn, sigma, npix, cdelt, xpix, ypix, psf_scale_fn=Non
     sigma : float
       68% containment radius in degrees.
     """
-    
+
     egy = psf.energies
-    ang_dist = make_pixel_distance(npix, xpix, ypix)*cdelt
-    dtheta = np.linspace(0.0,(np.max(ang_dist)*1.05)**0.5,400)**2.0    
-    z = create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn)
+    ang_dist = make_pixel_distance(npix, xpix, ypix) * cdelt
+    dtheta = np.linspace(0.0, (np.max(ang_dist) * 1.05)**0.5, 400)**2.0
+    z = create_kernel_function_lookup(psf, fn, sigma, egy,
+                                      dtheta, psf_scale_fn)
     #z = create_radial_spline(psf, fn, sigma, egy, dtheta, psf_scale_fn)
     x2 = val_to_pix(dtheta, np.ravel(ang_dist))
 
-    shape = (len(egy),npix,npix)
+    shape = (len(egy), npix, npix)
     k = np.zeros(shape)
 
-    r99 = psf.containment_angle(energies=psf.energies,fraction=0.99)
-    r34 = psf.containment_angle(energies=psf.energies,fraction=0.34)
+    r99 = psf.containment_angle(energies=psf.energies, fraction=0.99)
+    r34 = psf.containment_angle(energies=psf.energies, fraction=0.34)
 
-    rmin = np.minimum(r34/4.,0.01)
+    rmin = np.minimum(r34 / 4., 0.01)
     rmax = r99
     if sigma is not None:
-        rmin = np.minimum(rmin, 0.5*sigma)
-        rmax = np.maximum(rmax, 3.0*sigma)
+        rmin = np.minimum(rmin, 0.5 * sigma)
+        rmax = np.maximum(rmax, 3.0 * sigma)
 
     for i in range(len(egy)):
-        
+
         rebin = min(int(np.ceil(cdelt / rmin[i])), 8)
         xdist = make_pixel_distance(npix * rebin,
-                                    xpix * rebin + (rebin-1.0) / 2.,
-                                    ypix * rebin + (rebin-1.0) / 2.)
-        xdist *= cdelt/float(rebin)
+                                    xpix * rebin + (rebin - 1.0) / 2.,
+                                    ypix * rebin + (rebin - 1.0) / 2.)
+        xdist *= cdelt / float(rebin)
         m = np.ravel(xdist) < rmax[i]
         x = val_to_pix(dtheta, np.ravel(xdist))
-        
+
         if sparse:
             kk = np.zeros(xdist.size)
-            kk[m] = map_coordinates(z[i],[x[m]],order=2,prefilter=False)
+            kk[m] = map_coordinates(z[i], [x[m]], order=2, prefilter=False)
             kk = kk.reshape(xdist.shape)
         else:
-            kk = map_coordinates(z[i],[x],order=2,prefilter=False).reshape(xdist.shape)
+            kk = map_coordinates(z[i], [x], order=2,
+                                 prefilter=False).reshape(xdist.shape)
 
         if rebin > 1:
             kk = sum_bins(kk, 0, rebin)
             kk = sum_bins(kk, 1, rebin)
-        
-        k[i] = kk/float(rebin)**2
+
+        k[i] = kk / float(rebin)**2
 
     k = k.reshape((len(egy),) + ang_dist.shape)
     if normalize:
         k /= (np.sum(k, axis=0)[np.newaxis, ...] * np.radians(cdelt) ** 2)
-    
+
     return k
 
 
 #@memoize
 def create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn):
 
-    z =  np.zeros((len(egy), len(dtheta)))
+    z = np.zeros((len(egy), len(dtheta)))
     for i in range(len(egy)):
 
         if fn is None:
@@ -1596,7 +1598,8 @@ def create_radial_spline(psf, fn, sigma, egy, dtheta, psf_scale_fn):
 
     from scipy.ndimage.interpolation import spline_filter
 
-    z =  create_kernel_function_lookup(psf, fn, sigma, egy, dtheta, psf_scale_fn)
+    z = create_kernel_function_lookup(
+        psf, fn, sigma, egy, dtheta, psf_scale_fn)
     sp = []
     for i in range(z.shape[0]):
         sp += [spline_filter(z[i], order=2)]


### PR DESCRIPTION
This PR includes a variety of improvements to the source map generation code in fermipy:
- Fixes a bug in how the livetime histogram was being filled.
- Extracts exposures directly from binned exposure map of underlying analysis.
- New scheme for refining bin size based on PSF width and intrinsic source size.
- Option to compute sparse source maps -- i.e. skip calculation outside a certain angular distance from the source.