### PR TITLE
Use classmethod where useful

### DIFF
--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -395,8 +395,8 @@ class ReferenceSpec(object):
         """
         return self._ref_npred
 
-    @staticmethod
-    def create_from_table(tab_e):
+    @classmethod
+    def create_from_table(cls, tab_e):
         """
         Parameters
         ----------
@@ -433,9 +433,7 @@ class ReferenceSpec(object):
         except:
             ref_npred = np.ones((ne))
 
-        refSpec = ReferenceSpec(emin, emax,
-                                ref_dnde, ref_flux, ref_eflux, ref_npred)
-        return refSpec
+        return cls(emin, emax, ref_dnde, ref_flux, ref_eflux, ref_npred)
 
     def build_ebound_table(self):
         """ Build and return an EBOUNDS table with the encapsulated data.
@@ -548,12 +546,12 @@ class SpecData(ReferenceSpec):
     def e2dnde_err(self):
         return self._dnde_err * self.evals**2
 
-    @staticmethod
-    def create_from_table(tab):
+    @classmethod
+    def create_from_table(cls, tab):
         """
         """
         rs = ReferenceSpec.create_from_table(tab)
-        return SpecData(rs, tab['norm'], tab['norm_err'])
+        return cls(rs, tab['norm'], tab['norm_err'])
 
     def build_spec_table(self):
         """
@@ -1059,8 +1057,8 @@ class CastroData(CastroData_Base):
         """ Return a `~fermipy.castro.ReferenceSpec` with the spectral data """
         return self._refSpec
 
-    @staticmethod
-    def create_from_flux_points(txtfile):
+    @classmethod
+    def create_from_flux_points(cls, txtfile):
         """Create a Castro data object from a text file containing a
         sequence of differential flux points."""
 
@@ -1104,10 +1102,10 @@ class CastroData(CastroData_Base):
 
         norm_vals *= flux[:, np.newaxis] / norm[:, np.newaxis]
 
-        return CastroData(norm_vals, nll_vals, spec_data, 'flux')
+        return cls(norm_vals, nll_vals, spec_data, 'flux')
 
-    @staticmethod
-    def create_from_tables(norm_type='eflux',
+    @classmethod
+    def create_from_tables(cls, norm_type='eflux',
                            tab_s="SCANDATA",
                            tab_e="EBOUNDS"):
         """Create a CastroData object from two tables
@@ -1145,10 +1143,10 @@ class CastroData(CastroData_Base):
         nll_vals = -np.array(tab_s['dloglike_scan'])
 
         rs = ReferenceSpec.create_from_table(tab_e)
-        return CastroData(norm_vals, nll_vals, rs, norm_type)
+        return cls(norm_vals, nll_vals, rs, norm_type)
 
-    @staticmethod
-    def create_from_fits(fitsfile, norm_type='eflux',
+    @classmethod
+    def create_from_fits(cls, fitsfile, norm_type='eflux',
                          hdu_scan="SCANDATA",
                          hdu_energies="EBOUNDS",
                          irow=None):
@@ -1195,10 +1193,10 @@ class CastroData(CastroData_Base):
         tab_s = convert_sed_cols(tab_s)
         tab_e = convert_sed_cols(tab_e)
 
-        return CastroData.create_from_tables(norm_type, tab_s, tab_e)
+        return cls.create_from_tables(norm_type, tab_s, tab_e)
 
-    @staticmethod
-    def create_from_sedfile(fitsfile, norm_type='eflux'):
+    @classmethod
+    def create_from_sedfile(cls, fitsfile, norm_type='eflux'):
         """Create a CastroData object from an SED fits file
 
         Parameters
@@ -1235,10 +1233,10 @@ class CastroData(CastroData_Base):
         nll_vals = -np.array(tab_s['dloglike_scan'])
         ref_spec = ReferenceSpec.create_from_table(tab_s)
         spec_data = SpecData(ref_spec, tab_s['norm'], tab_s['norm_err'])
-        return CastroData(norm_vals, nll_vals, spec_data, norm_type)
+        return cls(norm_vals, nll_vals, spec_data, norm_type)
 
-    @staticmethod
-    def create_from_stack(shape, components, ylims, weights=None):
+    @classmethod
+    def create_from_stack(cls, shape, components, ylims, weights=None):
         """  Combine the log-likelihoods from a number of components.
 
         Parameters
@@ -1259,9 +1257,9 @@ class CastroData(CastroData_Base):
             return None
         norm_vals, nll_vals = CastroData_Base.stack_nll(
             shape, components, ylims, weights)
-        return CastroData(norm_vals, nll_vals,
-                          components[0].refSpec,
-                          components[0].norm_type)
+        return cls(norm_vals, nll_vals,
+                   components[0].refSpec,
+                   components[0].norm_type)
 
     def _buildLnLFn(self, normv, nllv):
         """
@@ -1483,8 +1481,8 @@ class TSCube(object):
         """ return the number of sample points in each energy bin """
         return self._nN
 
-    @staticmethod
-    def create_from_fits(fitsfile, norm_type='flux'):
+    @classmethod
+    def create_from_fits(cls, fitsfile, norm_type='flux'):
         """Build a TSCube object from a fits file created by gttscube
         Parameters
         ----------
@@ -1546,9 +1544,9 @@ class TSCube(object):
         ref_colname = 'ref_%s' % norm_type
         norm_vals *= tab_e[ref_colname][np.newaxis, :, np.newaxis]
 
-        return TSCube(tsmap, nmap, tscube, ncube,
-                      norm_vals, nll_vals, refSpec,
-                      norm_type)
+        return cls(tsmap, nmap, tscube, ncube,
+                   norm_vals, nll_vals, refSpec,
+                   norm_type)
 
     def castroData_from_ipix(self, ipix, colwise=False):
         """ Build a CastroData object for a particular pixel """

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -137,8 +137,8 @@ class Catalog(object):
     def glonlat(self):
         return self._glonlat
 
-    @staticmethod
-    def create(name):
+    @classmethod
+    def create(cls, name):
 
         extname = os.path.splitext(name)[1]
         if extname == '.fits' or extname == '.fit':
@@ -163,7 +163,8 @@ class Catalog(object):
             if 'NickName' in tab.columns:
                 return Catalog4FGLP(fitsfile)
             else:
-                return Catalog(Table.read(fitsfile))
+                table = Table.read(fitsfile)
+                return cls(table)
 
         elif name == '3FGL':
             return Catalog3FGL()

--- a/fermipy/config.py
+++ b/fermipy/config.py
@@ -265,8 +265,8 @@ class Configurable(object):
 
 class ConfigManager(object):
 
-    @staticmethod
-    def create(configfile):
+    @classmethod
+    def create(cls, configfile):
         """Create a configuration dictionary from a yaml config file.
         This function will first populate the dictionary with defaults
         taken from pre-defined configuration files.  The configuration
@@ -282,7 +282,7 @@ class ConfigManager(object):
             config['fileio']['outdir'] = os.path.abspath(
                 os.path.dirname(configfile))
 
-        user_config = ConfigManager.load(configfile)
+        user_config = cls.load(configfile)
         config = utils.merge_dict(config, user_config, True)
 
         config['fileio']['outdir'] = os.path.abspath(

--- a/fermipy/diffuse/binning.py
+++ b/fermipy/diffuse/binning.py
@@ -74,8 +74,8 @@ class Component(object):
         """ Event type bit mask for this component """
         return EVT_TYPE_DICT[self.evtype_name]
 
-    @staticmethod
-    def build_from_energy_dict(ebin_name, input_dict):
+    @classmethod
+    def build_from_energy_dict(cls, ebin_name, input_dict):
         """ Build a list of components from a dictionary for a single energy range
         """
         psf_types = input_dict.pop('psf_types')
@@ -85,23 +85,24 @@ class Component(object):
             fulldict.update(val_dict)
             fulldict['evtype_name'] = psf_type
             fulldict['ebin_name'] = ebin_name
-            output_list += [Component(**fulldict)]
+            component = cls(**fulldict)
+            output_list += [component]
         return output_list
 
-    @staticmethod
-    def build_from_yamlstr(yamlstr):
+    @classmethod
+    def build_from_yamlstr(cls, yamlstr):
         """ Build a list of components from a yaml string
         """
         top_dict = yaml.safe_load(yamlstr)
         output_list = []
         for e_key, e_dict in sorted(top_dict.items()):
             e_dict = top_dict[e_key]
-            output_list += Component.build_from_energy_dict(e_key, e_dict)
+            output_list += cls.build_from_energy_dict(e_key, e_dict)
         return output_list
 
-    @staticmethod
-    def build_from_yamlfile(yamlfile):
+    @classmethod
+    def build_from_yamlfile(cls, yamlfile):
         """ Build a list of components from a yaml file
         """
-        return Component.build_from_yamlstr(open(yamlfile))
+        return cls.build_from_yamlstr(open(yamlfile))
 

--- a/fermipy/diffuse/source_factory.py
+++ b/fermipy/diffuse/source_factory.py
@@ -184,12 +184,12 @@ class SourceFactory(object):
         return roi_model.ROIModel(data, skydir=SkyCoord(0.0, 0.0, unit='deg'))
         
 
-    @staticmethod
-    def make_roi(sources={}):
+    @classmethod
+    def make_roi(cls, sources={}):
         """Build and return a `fermipy.roi_model.ROIModel` object from
         a dict with information about the sources
         """
-        src_fact = SourceFactory()
+        src_fact = cls()
         src_fact.add_sources(sources)
         ret_model = roi_model.ROIModel(
             {}, skydir=SkyCoord(0.0, 0.0, unit='deg'))
@@ -198,12 +198,12 @@ class SourceFactory(object):
                                   build_index=False, merge_sources=False)
         return ret_model
 
-    @staticmethod
-    def copy_selected_sources(roi, source_names):
+    @classmethod
+    def copy_selected_sources(cls, roi, source_names):
         """Build and return a `fermipy.roi_model.ROIModel` object
         by copying selected sources from another such object
         """
-        roi_new = SourceFactory.make_roi()
+        roi_new = cls.make_roi()
         for source_name in source_names:
             try:
                 src_cp = roi.copy_source(source_name)

--- a/fermipy/diffuse/spectral.py
+++ b/fermipy/diffuse/spectral.py
@@ -24,15 +24,15 @@ class SpectralLibrary(object):
         """Get an item from the dictionary """
         return self.spectral_dict.get(key, {})
 
-    @staticmethod
-    def create_from_yamlstr(yamlstr):
+    @classmethod
+    def create_from_yamlstr(cls, yamlstr):
         """Create the dictionary for a yaml file
         """
         spectral_dict = yaml.load(yamlstr)
-        return SpectralLibrary(spectral_dict)
+        return cls(spectral_dict)
 
-    @staticmethod
-    def create_from_yaml(yamlfile):
+    @classmethod
+    def create_from_yaml(cls, yamlfile):
         """Create the dictionary for a yaml file
         """
-        return SpectralLibrary.create_from_yamlstr(open(yamlfile))
+        return cls.create_from_yamlstr(open(yamlfile))

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -475,8 +475,8 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
     def files(self):
         return self._files
 
-    @staticmethod
-    def create(infile, config=None):
+    @classmethod
+    def create(cls, infile, config=None):
         """Create a new instance of GTAnalysis from an analysis output file
         generated with `~fermipy.GTAnalysis.write_roi`.  By default
         the new instance will inherit the configuration of the saved
@@ -505,7 +505,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         else:
             validate = True
 
-        gta = GTAnalysis(config, validate=validate)
+        gta = cls(config, validate=validate)
         gta.setup(init_sources=False)
         gta.load_roi(infile)
         return gta

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -375,8 +375,8 @@ class HPX(object):
         """
         return HPX(self.nside, not self.nest, self.coordsys, -1, self.region, None, self.conv)
 
-    @staticmethod
-    def create_hpx(nside, nest, coordsys='CEL', order=-1, region=None,
+    @classmethod
+    def create_hpx(cls, nside, nest, coordsys='CEL', order=-1, region=None,
                    ebins=None, conv=HPX_Conv('FGST_CCUBE')):
         """Create a HPX object.
 
@@ -400,7 +400,7 @@ class HPX(object):
         ebins    : `~numpy.ndarray`
             Energy bin edges
         """
-        return HPX(nside, nest, coordsys, order, region, ebins, conv)
+        return cls(nside, nest, coordsys, order, region, ebins, conv)
 
     @staticmethod
     def identify_HPX_convention(header):
@@ -443,8 +443,8 @@ class HPX(object):
         else:
             raise ValueError("Could not identify HEALPix convention")
 
-    @staticmethod
-    def create_from_header(header, ebins=None):
+    @classmethod
+    def create_from_header(cls, header, ebins=None):
         """ Creates an HPX object from a FITS header.
 
         header : The FITS header
@@ -488,7 +488,7 @@ class HPX(object):
             except KeyError:
                 region = None
 
-        return HPX(nside, nest, coordsys, order, region, ebins=ebins, conv=conv)
+        return cls(nside, nest, coordsys, order, region, ebins=ebins, conv=conv)
 
     def make_header(self):
         """ Builds and returns FITS header for this HEALPix map """
@@ -878,8 +878,8 @@ class HpxToWcsMapping(object):
         hdulist = fits.HDUList([prim_hdu, mult_dhu])
         hdulist.writeto(fitsfile, clobber=clobber)
 
-    @staticmethod
-    def create_from_fitsfile(self, fitsfile):
+    @classmethod
+    def create_from_fitsfile(cls, fitsfile):
         """ Read a fits file and use it to make a mapping
         """
         from fermipy.skymap import Map
@@ -890,7 +890,7 @@ class HpxToWcsMapping(object):
         mapping_data = dict(ipixs=index_map.counts,
                             mult_val=mult_map.counts,
                             npix=mult_map.counts.shape)
-        return HpxToWcsMapping(hpx, index_map.wcs, mapping_data)
+        return cls(hpx, index_map.wcs, mapping_data)
 
     def fill_wcs_map_from_hpx_data(self, hpx_data, wcs_data, normalize=True):
         """Fills the wcs map from the hpx data using the pre-calculated

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -178,8 +178,8 @@ class ExposureMap(HpxMap):
     def __init__(self, data, hpx):
         HpxMap.__init__(self, data, hpx)
 
-    @staticmethod
-    def create(ltc, event_class, event_types, ebins):
+    @classmethod
+    def create(cls, ltc, event_class, event_types, ebins):
         """Create an exposure map from a livetime cube.  This method will
         generate an exposure map with the same geometry as the
         livetime cube (nside, etc.).
@@ -209,7 +209,7 @@ class ExposureMap(HpxMap):
 
         hpx = HPX(ltc.hpx.nside, ltc.hpx.nest,
                   ltc.hpx.coordsys, ebins=ebins)
-        return ExposureMap(exp, hpx)
+        return cls(exp, hpx)
 
 
 class PSFModel(object):
@@ -419,8 +419,8 @@ class PSFModel(object):
     def exp(self):
         return self._exp
 
-    @staticmethod
-    def create(skydir, ltc, event_class, event_types, energies, cth_bins=None,
+    @classmethod
+    def create(cls, skydir, ltc, event_class, event_types, energies, cth_bins=None,
                ndtheta=500, use_edisp=False, fn=None, nbin=64):
         """Create a PSFModel object.  This class can be used to evaluate the
         exposure-weighted PSF for a source with a given observing
@@ -475,8 +475,8 @@ class PSFModel(object):
         exp = calc_exp(skydir, ltc, event_class, event_types,
                        energies, cth_bins)
 
-        return PSFModel(dtheta, energies, cth_bins, np.squeeze(exp), np.squeeze(psf),
-                        np.squeeze(wts))
+        return cls(dtheta, energies, cth_bins, np.squeeze(exp), np.squeeze(psf),
+                   np.squeeze(wts))
 
 
 def create_irf(event_class, event_type):

--- a/fermipy/jobs/file_archive.py
+++ b/fermipy/jobs/file_archive.py
@@ -462,20 +462,20 @@ class FileHandle(object):
             val.append_to_table(table)
         return table
 
-    @staticmethod
-    def make_dict(table):
+    @classmethod
+    def make_dict(cls, table):
         """Build and return a dict of `FileHandle` from an `astropy.table.Table`
 
         The dictionary is keyed by FileHandle.key, which is a unique integer for each file
         """
         ret_dict = {}
         for row in table:
-            file_handle = FileHandle.create_from_row(row)
+            file_handle = cls.create_from_row(row)
         ret_dict[file_handle.key] = file_handle
         return ret_dict
 
-    @staticmethod
-    def create_from_row(table_row):
+    @classmethod
+    def create_from_row(cls, table_row):
         """Build and return a `FileHandle` from an `astropy.table.row.Row` """
         kwargs = {}
         for key in table_row.colnames:
@@ -484,7 +484,7 @@ class FileHandle(object):
             else:
                 kwargs[key] = table_row[key]
         try:
-            return FileHandle(**kwargs)
+            return cls(**kwargs)
         except KeyError:
             print (kwargs)
 
@@ -796,17 +796,17 @@ class FileArchive(object):
         sys.stdout.write("  superseded:   %i\n"%status_vect[4])
         sys.stdout.write("  temp_removed: %i\n"%status_vect[5])
 
-    @staticmethod
-    def get_archive():
+    @classmethod
+    def get_archive(cls):
         """Return the singleton `FileArchive` instance """
-        return FileArchive._archive
+        return cls._archive
 
-    @staticmethod
-    def build_archive(**kwargs):
+    @classmethod
+    def build_archive(cls, **kwargs):
         """Return the singleton `FileArchive` instance, building it if needed"""
-        if FileArchive._archive is None:
-            FileArchive._archive = FileArchive(**kwargs)
-        return FileArchive._archive
+        if cls._archive is None:
+            cls._archive = cls(**kwargs)
+        return cls._archive
 
 
 def main_browse():

--- a/fermipy/jobs/job_archive.py
+++ b/fermipy/jobs/job_archive.py
@@ -248,18 +248,18 @@ class JobDetails(object):
         """Fill a `list` from the nonzero members of an `array`"""
         return [v for v in the_array.nonzero()[0]]
 
-    @staticmethod
-    def make_dict(table, table_ids):
+    @classmethod
+    def make_dict(cls, table, table_ids):
         """Build a dictionary map int to `JobDetails` from an `astropy.table.Table`"""
         ret_dict = {}
         table_id_array = table_ids['file_id'].data
         for row in table:
-            job_details = JobDetails.create_from_row(row, table_id_array)
+            job_details = cls.create_from_row(row, table_id_array)
         ret_dict[job_details.dbkey] = job_details
         return ret_dict
 
-    @staticmethod
-    def create_from_row(table_row, table_id_array):
+    @classmethod
+    def create_from_row(cls, table_row, table_id_array):
         """Create a `JobDetails` from an `astropy.table.row.Row` """
         kwargs = {}
         for key in table_row.colnames:
@@ -277,7 +277,7 @@ class JobDetails(object):
         kwargs['outfile_ids'] = np.arange(outfile_refs[0], outfile_refs[1])
         kwargs['rmfile_ids'] = np.arange(rmfile_refs[0], rmfile_refs[1])
         kwargs['intfile_ids'] = np.arange(intfile_refs[0], intfile_refs[1])
-        return JobDetails(**kwargs)
+        return cls(**kwargs)
 
     def append_to_tables(self, table, table_ids):
         """Add this instance as a row on a `astropy.table.Table` """
@@ -482,8 +482,8 @@ class JobArchive(object):
         other.update_table_row(self._table, other.dbkey - 1)
         return other
 
-    @staticmethod
-    def build_temp_job_archive():
+    @classmethod
+    def build_temp_job_archive(cls):
         """Build and return a `JobArchive` using defualt locations of
         persistent files. """
         try:
@@ -491,10 +491,11 @@ class JobArchive(object):
             os.unlink('file_archive_temp.fits')
         except OSError:
             pass
-        JobArchive._archive = JobArchive(job_archive_table='job_archive_temp.fits',
-                                         file_archive_table='file_archive_temp.fits',
-                                         base_path=os.path.abspath('.') + '/')
-        return JobArchive._archive
+
+        cls._archive = cls(job_archive_table='job_archive_temp.fits',
+                           file_archive_table='file_archive_temp.fits',
+                           base_path=os.path.abspath('.') + '/')
+        return cls._archive
 
     def write_table_file(self, job_table_file=None, file_table_file=None):
         """Write the table to self._table_file"""
@@ -533,17 +534,17 @@ class JobArchive(object):
         sys.stdout.write("  done:     %i\n"%status_vect[3])
         sys.stdout.write("  failed:   %i\n"%status_vect[4])
 
-    @staticmethod
-    def get_archive():
+    @classmethod
+    def get_archive(cls):
         """Return the singleton `JobArchive` instance """
-        return JobArchive._archive
+        return cls._archive
 
-    @staticmethod
-    def build_archive(**kwargs):
+    @classmethod
+    def build_archive(cls, **kwargs):
         """Return the singleton `JobArchive` instance, building it if needed """
-        if JobArchive._archive is None:
-            JobArchive._archive = JobArchive(**kwargs)
-        return JobArchive._archive
+        if cls._archive is None:
+            cls._archive = cls(**kwargs)
+        return cls._archive
 
 
 def main_browse():

--- a/fermipy/jobs/scatter_gather.py
+++ b/fermipy/jobs/scatter_gather.py
@@ -220,25 +220,24 @@ class ScatterGather(Link):
         """Return the value of the no_batch flag"""
         return self._no_batch
 
-    @staticmethod
-    def _make_init_logfile_name(input_config):
+    @classmethod
+    def _make_init_logfile_name(cls, input_config):
         """ Hook to inster the name of a logfile into the input config """
-        logfile = input_config.get(
-            'logfile', ScatterGather.default_init_logfile)
+        logfile = input_config.get('logfile', cls.default_init_logfile)
         input_config['logfile'] = logfile
 
-    @staticmethod
-    def _make_scatter_logfile_name(key, job_config):
+    @classmethod
+    def _make_scatter_logfile_name(cls, key, job_config):
         """ Hook to inster the name of a logfile into the input config """
         logfile = job_config.get('logfile', "%s_%s.log" %
-                                 (ScatterGather.default_prefix_logfile, key))
+                                 (cls.default_prefix_logfile, key))
         job_config['logfile'] = logfile
 
-    @staticmethod
-    def _make_gather_logfile_name(output_config):
+    @classmethod
+    def _make_gather_logfile_name(cls, output_config):
         """ Hook to construct the name of a logfile the gatherer """
         logfile = output_config.get(
-            'logfile', ScatterGather.default_gather_logfile)
+            'logfile', cls.default_gather_logfile)
         output_config['logfile'] = logfile
 
     def check_job(self, job_details):

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -179,8 +179,8 @@ class LTCube(HpxMap):
         """
         return self._cth_center
 
-    @staticmethod
-    def create(ltfile):
+    @classmethod
+    def create(cls, ltfile):
         """Create a livetime cube from a single file or list of
         files."""
 
@@ -189,14 +189,14 @@ class LTCube(HpxMap):
         elif not isinstance(ltfile, list):
             files = glob.glob(ltfile)
 
-        ltc = LTCube.create_from_fits(files[0])
+        ltc = cls.create_from_fits(files[0])
         for f in files[1:]:
             ltc.load_ltfile(f)
 
         return ltc
 
-    @staticmethod
-    def create_from_fits(ltfile):
+    @classmethod
+    def create_from_fits(cls, ltfile):
 
         hdulist = fits.open(ltfile)
         data = hdulist['EXPOSURE'].data.field('COSBINS')
@@ -216,31 +216,31 @@ class LTCube(HpxMap):
         hpx = HPX.create_from_header(hdulist['EXPOSURE'].header, cth_edges)
         #header = dict(hdulist['EXPOSURE'].header)
         tab_gti = Table.read(ltfile, 'GTI')
-        return LTCube(data[:, ::-1].T, hpx, cth_edges,
-                      tstart=tstart, tstop=tstop,
-                      zmin=zmin, zmax=zmax, tab_gti=tab_gti,
-                      data_wt=data_wt[:, ::-1].T)
+        return cls(data[:, ::-1].T, hpx, cth_edges,
+                   tstart=tstart, tstop=tstop,
+                   zmin=zmin, zmax=zmax, tab_gti=tab_gti,
+                   data_wt=data_wt[:, ::-1].T)
 
-    @staticmethod
-    def create_empty(tstart, tstop, fill=0.0, nside=64):
+    @classmethod
+    def create_empty(cls, tstart, tstop, fill=0.0, nside=64):
         """Create an empty livetime cube."""
         cth_edges = np.linspace(0, 1.0, 41)
         domega = utils.edge_to_width(cth_edges) * 2.0 * np.pi
         hpx = HPX(nside, True, 'CEL', ebins=cth_edges)
         data = np.ones((len(cth_edges) - 1, hpx.npix)) * fill
-        return LTCube(data, hpx, cth_edges, tstart=tstart, tstop=tstop)
+        return cls(data, hpx, cth_edges, tstart=tstart, tstop=tstop)
 
-    @staticmethod
-    def create_from_obs_time(obs_time, nside=64):
+    @classmethod
+    def create_from_obs_time(cls, obs_time, nside=64):
 
         tstart = 239557417.0
         tstop = tstart + obs_time
-        ltc = LTCube.create_empty(tstart, tstop, obs_time, nside)
+        ltc = cls.create_empty(tstart, tstop, obs_time, nside)
         ltc._counts *= ltc.domega[:, np.newaxis] / (4. * np.pi)
         return ltc
 
-    @staticmethod
-    def create_from_gti(skydir, tab_sc, tab_gti, zmax, **kwargs):
+    @classmethod
+    def create_from_gti(cls, skydir, tab_sc, tab_gti, zmax, **kwargs):
 
         radius = kwargs.get('radius', 180.0)
         cth_edges = kwargs.get('cth_edges', None)
@@ -263,8 +263,7 @@ class LTCube(HpxMap):
 
         hpx2 = HPX(2**6, True, 'CEL', ebins=cth_edges)
 
-        ltc = LTCube(np.zeros((len(cth_edges) - 1, hpx2.npix)),
-                     hpx2, cth_edges)
+        ltc = cls(np.zeros((len(cth_edges) - 1, hpx2.npix)), hpx2, cth_edges)
         ltc_skydir = ltc.hpx.get_sky_dirs()
         m = skydir.separation(ltc_skydir).deg < radius
 

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -416,8 +416,8 @@ class ROIPlotter(fermipy.config.Configurable):
     def proj(self):
         return self._proj
 
-    @staticmethod
-    def create_from_fits(fitsfile, roi, **kwargs):
+    @classmethod
+    def create_from_fits(cls, fitsfile, roi, **kwargs):
 
         hdulist = fits.open(fitsfile)
         try:
@@ -439,7 +439,7 @@ class ROIPlotter(fermipy.config.Configurable):
         else:
             raise Exception("Unknown projection type %s" % projtype)
 
-        return ROIPlotter(themap, roi=roi, **kwargs)
+        return cls(themap, roi=roi, **kwargs)
 
     def plot_projection(self, iaxis, **kwargs):
 

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -917,8 +917,8 @@ class Source(Model):
     def data(self):
         return self._data
 
-    @staticmethod
-    def create_from_dict(src_dict, roi_skydir=None, rescale=False):
+    @classmethod
+    def create_from_dict(cls, src_dict, roi_skydir=None, rescale=False):
         """Create a source object from a python dictionary.
 
         Parameters
@@ -981,10 +981,10 @@ class Source(Model):
 
         radec = np.array([skydir.ra.deg, skydir.dec.deg])
 
-        return Source(name, src_dict, radec=radec)
+        return cls(name, src_dict, radec=radec)
 
-    @staticmethod
-    def create_from_xmlfile(xmlfile, extdir=None):
+    @classmethod
+    def create_from_xmlfile(cls, xmlfile, extdir=None):
         """Create a Source object from an XML file.
 
         Parameters
@@ -999,7 +999,7 @@ class Source(Model):
         srcs = root.findall('source')
         if len(srcs) == 0:
             raise Exception('No sources found.')
-        return Source.create_from_xml(srcs[0], extdir=extdir)
+        return cls.create_from_xml(srcs[0], extdir=extdir)
 
     @staticmethod
     def create_from_xml(root, extdir=None):
@@ -1635,30 +1635,29 @@ class ROIModel(fermipy.config.Configurable):
         self._diffuse_srcs = [s for s in self._diffuse_srcs if s not in srcs]
         self._build_src_index()
 
-    @staticmethod
-    def create_from_roi_data(datafile):
+    @classmethod
+    def create_from_roi_data(cls, datafile):
         """Create an ROI model."""
         data = np.load(datafile).flat[0]
 
-        roi = ROIModel()
+        roi = cls()
         roi.load_sources(data['sources'].values())
 
         return roi
 
-    @staticmethod
-    def create(selection, config, **kwargs):
+    @classmethod
+    def create(cls, selection, config, **kwargs):
         """Create an ROIModel instance."""
 
         if selection['target'] is not None:
-            return ROIModel.create_from_source(selection['target'],
-                                               config, **kwargs)
+            return cls.create_from_source(selection['target'],
+                                          config, **kwargs)
         else:
             target_skydir = wcs_utils.get_target_skydir(selection)
-            return ROIModel.create_from_position(target_skydir,
-                                                 config, **kwargs)
+            return cls.create_from_position(target_skydir, config, **kwargs)
 
-    @staticmethod
-    def create_from_position(skydir, config, **kwargs):
+    @classmethod
+    def create_from_position(cls, skydir, config, **kwargs):
         """Create an ROIModel instance centered on a sky direction.
 
         Parameters
@@ -1672,27 +1671,27 @@ class ROIModel(fermipy.config.Configurable):
         """
 
         coordsys = kwargs.pop('coordsys', 'CEL')
-        roi = ROIModel(config, skydir=skydir, coordsys=coordsys, **kwargs)
+        roi = cls(config, skydir=skydir, coordsys=coordsys, **kwargs)
         return roi
 
-    @staticmethod
-    def create_from_source(name, config, **kwargs):
+    @classmethod
+    def create_from_source(cls, name, config, **kwargs):
         """Create an ROI centered on the given source."""
 
         coordsys = kwargs.pop('coordsys', 'CEL')
 
-        roi = ROIModel(config, src_radius=None, src_roiwidth=None,
-                       srcname=name, **kwargs)
+        roi = cls(config, src_radius=None, src_roiwidth=None,
+                  srcname=name, **kwargs)
         src = roi.get_source_by_name(name)
 
-        return ROIModel.create_from_position(src.skydir, config,
-                                             coordsys=coordsys, **kwargs)
+        return cls.create_from_position(src.skydir, config,
+                                        coordsys=coordsys, **kwargs)
 
-    @staticmethod
-    def create_roi_from_ft1(ft1file, config):
+    @classmethod
+    def create_roi_from_ft1(cls, ft1file, config):
         """Create an ROI model by extracting the sources coordinates
         form an FT1 file."""
-        pass
+        raise NotImplementedError
 
     def has_source(self, name):
 

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -173,12 +173,12 @@ class Map(Map_Base):
         """Return the ROI center in pixel coordinates."""
         return self._pix_center
 
-    @staticmethod
-    def create_from_hdu(hdu, wcs):
-        return Map(hdu.data.T, wcs)
+    @classmethod
+    def create_from_hdu(cls, hdu, wcs):
+        return cls(hdu.data.T, wcs)
 
-    @staticmethod
-    def create_from_fits(fitsfile, **kwargs):
+    @classmethod
+    def create_from_fits(cls, fitsfile, **kwargs):
         hdu = kwargs.get('hdu', 0)
 
         hdulist = fits.open(fitsfile)
@@ -198,14 +198,14 @@ class Map(Map_Base):
             emax = np.array(tab['E_MAX']) / 1E3
             ebins = np.append(emin, emax[-1])
 
-        return Map(data, wcs, ebins)
+        return cls(data, wcs, ebins)
 
-    @staticmethod
-    def create(skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
+    @classmethod
+    def create(cls, skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
         crpix = np.array([n / 2. + 0.5 for n in npix])
         wcs = wcs_utils.create_wcs(skydir, coordsys, projection,
                                    cdelt, crpix)
-        return Map(np.zeros(npix).T, wcs)
+        return cls(np.zeros(npix).T, wcs)
 
     def create_image_hdu(self, name=None, **kwargs):
         return fits.ImageHDU(self.counts, header=self.wcs.to_header(),
@@ -392,8 +392,8 @@ class HpxMap(Map_Base):
     def hpx(self):
         return self._hpx
 
-    @staticmethod
-    def create_from_hdu(hdu, ebins):
+    @classmethod
+    def create_from_hdu(cls, hdu, ebins):
         """ Creates and returns an HpxMap object from a FITS HDU.
 
         hdu    : The FITS
@@ -416,10 +416,11 @@ class HpxMap(Map_Base):
             data = np.ndarray((nebin, hpx.npix))
             for i, cname in enumerate(cnames):
                 data[i, 0:] = hdu.data.field(cname)
-        return HpxMap(data, hpx)
 
-    @staticmethod
-    def create_from_hdulist(hdulist, **kwargs):
+        return cls(data, hpx)
+
+    @classmethod
+    def create_from_hdulist(cls, hdulist, **kwargs):
         """ Creates and returns an HpxMap object from a FITS HDUList
 
         extname : The name of the HDU with the map data
@@ -427,17 +428,16 @@ class HpxMap(Map_Base):
         """
         extname = kwargs.get('hdu', 'SKYMAP')
         ebins = fits_utils.find_and_read_ebins(hdulist)
-        hpxMap = HpxMap.create_from_hdu(hdulist[extname], ebins)
-        return hpxMap
+        return cls.create_from_hdu(hdulist[extname], ebins)
 
     def create_image_hdu(self, name=None, **kwargs):
         kwargs['extname'] = name
         return self.hpx.make_hdu(self.counts, **kwargs)
 
-    @staticmethod
-    def create_from_fits(fitsfile, **kwargs):
+    @classmethod
+    def create_from_fits(cls, fitsfile, **kwargs):
         hdulist = fits.open(fitsfile)
-        return HpxMap.create_from_hdulist(hdulist, **kwargs)
+        return cls.create_from_hdulist(hdulist, **kwargs)
 
     def create_image_hdu(self, name=None, **kwargs):
         kwargs['extname'] = name

--- a/fermipy/spectrum.py
+++ b/fermipy/spectrum.py
@@ -345,8 +345,8 @@ class PowerLaw(SpectralFunction):
     def _eval_dnde(x, params, scale=1.0, extra_params=None):
         return params[0] * (x / scale) ** params[1]
 
-    @classmethod
-    def eval_flux(cls, emin, emax, params, scale=1.0, extra_params=None):
+    @staticmethod
+    def eval_flux(emin, emax, params, scale=1.0, extra_params=None):
 
         phi0 = np.array(params[0], ndmin=1)
         index = np.array(params[1], ndmin=1)
@@ -374,10 +374,9 @@ class PowerLaw(SpectralFunction):
         params[1] += 1.0
         return cls.eval_flux(emin, emax, params, scale) * scale
 
-    @staticmethod
-    def eval_norm(scale, index, emin, emax, flux):
-        return flux / PowerLaw.eval_flux(emin, emax, [1.0, index],
-                                         scale=scale)
+    @classmethod
+    def eval_norm(cls, scale, index, emin, emax, flux):
+        return flux / cls.eval_flux(emin, emax, [1.0, index], scale=scale)
 
 
 class LogParabola(SpectralFunction):

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -141,8 +141,8 @@ class SourceMapCache(object):
         k0[~np.isfinite(k0)] = 0
         return k0
 
-    @staticmethod
-    def create(psf, exp, spatial_model, spatial_width, shape_out, cdelt,
+    @classmethod
+    def create(cls, psf, exp, spatial_model, spatial_width, shape_out, cdelt,
                rebin=4):
 
         npix = shape_out[1]
@@ -171,7 +171,7 @@ class SourceMapCache(object):
 
         m1 = MapInterpolator(k1, pix_ref, shape_out, rebin)
 
-        return SourceMapCache(m0, m1)
+        return cls(m0, m1)
 
 
 def make_srcmap_old(psf, spatial_model, sigma, npix=500, xpix=0.0, ypix=0.0,

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -56,13 +56,13 @@ class WCSProj(object):
     def npix(self):
         return self._npix
 
-    @staticmethod
-    def create(skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
+    @classmethod
+    def create(cls, skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
         npix = np.array(npix, ndmin=1)
         crpix = npix / 2. + 0.5
         wcs = create_wcs(skydir, coordsys, projection,
                          cdelt, crpix)
-        return WCSProj(wcs, npix)
+        return cls(wcs, npix)
 
     def distance_to_edge(self, skydir):
         """Return the angular distance from the given direction and


### PR DESCRIPTION
This pull request changes some uses of staticmethod to classmethod, for the cases where the class name is used inside the method.

It's not a huge advantage, but I think there are some small advantages:
- more friendly to sub-classing, usually one want `MySubclass.create_me` to create a `MySubclass`. This is the case with `classmethod`, but not with `staticmethod` and hardcoded class name.
- less repetition of hardcoded class name inside the class -> if one ever wants to change the class name it's easier
- Using classmethod this way is the recommended pattern as far as I can tell, in all discussions of classmethod vs staticmethod for Python that I've seen. E.g. Astropy and Gammapy uses it this way.

