### PR TITLE
Python 3 print fixes

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -284,7 +284,7 @@ was written to *fit_model.npy* in the Mkn421 analysis example:
    >>> # Load analysis dictionary from a npy file
    >>> import np
    >>> c = np.load('fit_model.npy').flat[0]
-   >>> print(c.keys())
+   >>> list(c.keys())
    ['roi', 'config', 'sources', 'version']
 
 The output dictionary contains the following top-level elements:
@@ -301,16 +301,16 @@ the analysis.
 
 .. code-block:: python
    
-   >>> print c['sources'].keys()
+   >>> list(c['sources'].keys())
    ['3FGL J1032.7+3735',
    '3FGL J1033.2+4116',
    ...
    '3FGL J1145.8+4425',
    'galdiff',
    'isodiff']
-   >>> print c['sources']['3FGL J1104.4+3812']['ts']
+   >>> c['sources']['3FGL J1104.4+3812']['ts']
    87455.9709683
-   >>> print c['sources']['3FGL J1104.4+3812']['npred']
+   >>> c['sources']['3FGL J1104.4+3812']['npred']
    31583.7166495
     
 Information about individual sources in the ROI is also saved to a
@@ -323,7 +323,7 @@ This file can be loaded with the `astropy.io.fits` or
    >>> # Load the source catalog file
    >>> from astropy.table import Table
    >>> tab = Table.read('fit_model.fits')
-   >>> print(tab[['name','class','ts','npred','flux']])
+   >>> tab[['name','class','ts','npred','flux']]
        name       class       ts           npred                    flux [2]               
                                                                   1 / (cm2 s)              
    ----------------- ----- -------------- ------------- --------------------------------------
@@ -339,7 +339,7 @@ the source dictionary.  Spectral fit parameters are contained in the
 
 .. code-block:: python
                 
-   >>> print(tab[['param_names','param_values','param_errors']][0])
+   >>> tab[['param_names','param_values','param_errors']][0]
    <Row 0 of table
     values=(['Prefactor', 'Index', 'Scale', '', '', ''],
             [2.1301351784512767e-11, -1.7716399431228638, 1187.1300048828125, nan, nan, nan],

--- a/fermipy/diffuse/catalog_src_manager.py
+++ b/fermipy/diffuse/catalog_src_manager.py
@@ -222,7 +222,7 @@ class CatalogSourceManager(object):
                     all_sources = [x.strip() for x in full_cat_info.catalog_table[
                             'Source_Name'].tolist()]
                 except KeyError:
-                    print (full_cat_info.catalog_table.colnames)
+                    print(full_cat_info.catalog_table.colnames)
                 used_sources = []
                 rules_dict = source_dict['rules_dict']
                 split_dict = {}

--- a/fermipy/diffuse/gt_assemble_model.py
+++ b/fermipy/diffuse/gt_assemble_model.py
@@ -185,7 +185,7 @@ class GtAssembleModel(object):
                 try:
                     hpxmap = HpxMap.create_from_hdulist(hdulist_in, hdu=source_name)
                 except IndexError:
-                    print ("  Index error on source %s in file %s" % (source_name, srcmap_file))
+                    print("  Index error on source %s in file %s" % (source_name, srcmap_file))
                     continue
                 hpxmap_out = hpxmap.ud_grade(hpx_order, preserve_counts=True)
                 hdulist.append(hpxmap_out.create_image_hdu(name=source_name))

--- a/fermipy/diffuse/gt_merge_srcmaps.py
+++ b/fermipy/diffuse/gt_merge_srcmaps.py
@@ -88,7 +88,7 @@ class GtMergeSourceMaps(object):
 
         like.logLike.set_use_single_fixed_map(False)
 
-        print ("Reading xml model from %s" % args.srcmdl)
+        print("Reading xml model from %s" % args.srcmdl)
         source_factory = pyLike.SourceFactory(obs.observation)
         source_factory.readXml(args.srcmdl, BinnedAnalysis._funcFactory, False, True, True)
         strv = pyLike.StringVector()
@@ -108,16 +108,16 @@ class GtMergeSourceMaps(object):
         comp = like.mergeSources(args.merged, source_names, 'ConstantValue')
         like.logLike.getSourceMap(comp.getName())
 
-        print ("Merged %i sources into %s"%(len(srcs_to_merge), comp.getName()))
+        print("Merged %i sources into %s"%(len(srcs_to_merge), comp.getName()))
         if len(missing_sources) > 0:
-            print ("Missed sources: ", missing_sources)
+            print("Missed sources: ", missing_sources)
 
-        print ("Writing output source map file %s" % args.outfile)
+        print("Writing output source map file %s" % args.outfile)
         like.logLike.saveSourceMaps(args.outfile, False, False)
         if args.gzip:
             os.system("gzip -9 %s" % args.outfile)
 
-        print ("Writing output xml file %s" % args.outxml)
+        print("Writing output xml file %s" % args.outxml)
         like.writeXml(args.outxml)
 
 
@@ -156,7 +156,7 @@ class ConfigMaker_MergeSrcmaps(ConfigMaker):
         for split_ver, split_dict in comp_info_dict.items():
             for source_key, source_dict in split_dict.items():
 
-                print (split_ver, source_key, source_dict.model_type)
+                print(split_ver, source_key, source_dict.model_type)
                 full_key = "%s_%s"%(split_ver, source_key)
                 if source_dict.model_type != 'CompositeSource':
                     continue

--- a/fermipy/diffuse/gt_srcmap_partial.py
+++ b/fermipy/diffuse/gt_srcmap_partial.py
@@ -160,12 +160,12 @@ class ConfigMaker_SrcmapPartial(ConfigMaker):
             fullkey = "%s_%s" % (sourcekey, comp_dict.comp_key)
         srcdict = make_sources(fullkey, comp_dict)
         if comp_dict.model_type == 'IsoSource':
-            print ("Writing xml for %s to %s: %s %s" % (fullkey,
+            print("Writing xml for %s to %s: %s %s" % (fullkey,
                                                         comp_dict.srcmdl_name,
                                                         comp_dict.model_type,
                                                         comp_dict.Spectral_Filename))
         elif comp_dict.model_type == 'MapCubeSource':
-            print ("Writing xml for %s to %s: %s %s" % (fullkey,
+            print("Writing xml for %s to %s: %s %s" % (fullkey,
                                                         comp_dict.srcmdl_name,
                                                         comp_dict.model_type,
                                                         comp_dict.Spatial_Filename))

--- a/fermipy/diffuse/job_library.py
+++ b/fermipy/diffuse/job_library.py
@@ -177,12 +177,12 @@ class ConfigMaker_SrcmapsCatalog(ConfigMaker):
         """Make all the xml file for individual components
         """
         for val in catalog_info_dict.values():
-            print ("%s : %06i" % (val.srcmdl_name, len(val.roi_model.sources)))
+            print("%s : %06i" % (val.srcmdl_name, len(val.roi_model.sources)))
             val.roi_model.write_xml(val.srcmdl_name)
 
         for val in comp_info_dict.values():
             for val2 in val.values():
-                print ("%s : %06i" % (val2.srcmdl_name, len(val2.roi_model.sources)))
+                print("%s : %06i" % (val2.srcmdl_name, len(val2.roi_model.sources)))
                 val2.roi_model.write_xml(val2.srcmdl_name)
 
     def build_job_configs(self, args):

--- a/fermipy/diffuse/model_manager.py
+++ b/fermipy/diffuse/model_manager.py
@@ -121,7 +121,7 @@ class ModelInfo(object):
         master_roi = SourceFactory.make_roi(master_roi_source_info)
         master_xml_mdl = name_factory.master_srcmdl_xml(
             modelkey=self.model_name)
-        print ("Writing master ROI model to %s" % master_xml_mdl)
+        print("Writing master ROI model to %s" % master_xml_mdl)
         master_roi.write_xml(master_xml_mdl)
         ret_dict['master'] = master_roi
 
@@ -149,7 +149,7 @@ class ModelInfo(object):
             comp_roi = SourceFactory.make_roi(comp_roi_source_info)
             comp_xml_mdl = name_factory.comp_srcmdl_xml(modelkey=self.model_name,
                                                         component=compkey)
-            print ("Writing component ROI model to %s" % comp_xml_mdl)
+            print("Writing component ROI model to %s" % comp_xml_mdl)
             comp_roi.write_xml(comp_xml_mdl)
             ret_dict[compkey] = comp_roi
 
@@ -400,7 +400,7 @@ class ModelManager(object):
             fermipy_dict['components'].append(sub_dict)
 
         outfile = os.path.join(model_dir, 'config.yaml')
-        print ("Writing fermipy config file %s"%outfile)
+        print("Writing fermipy config file %s"%outfile)
         utils.write_yaml(fermipy_dict, outfile)
         return fermipy_dict
 

--- a/fermipy/diffuse/residual_cr.py
+++ b/fermipy/diffuse/residual_cr.py
@@ -197,7 +197,7 @@ class ResidualCRAnalysis(object):
             mean_bright_pixel = bright_pixels_intensity.mean()
             aeff_corrections[i] = 1. / mean_bright_pixel
 
-        print ("Aeff correction: ", aeff_corrections)
+        print("Aeff correction: ", aeff_corrections)
         return aeff_corrections
 
     @staticmethod

--- a/fermipy/diffuse/source_factory.py
+++ b/fermipy/diffuse/source_factory.py
@@ -163,7 +163,7 @@ class SourceFactory(object):
         catalog_extdir : str
             Path to directory with extended source templates
         """
-        print (catalog_file, catalog_extdir)
+        print(catalog_file, catalog_extdir)
         if catalog_type == '2FHL':
             return catalog.Catalog2FHL(fitsfile=catalog_file, extdir=catalog_extdir)
         elif catalog_type == '3FGL':

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4805,9 +4805,9 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         self._like = BinnedAnalysis(binnedData=self._obs,
                                     **utils.unicode_to_str(kw))
 
-#        print self.like.logLike.use_single_fixed_map()
+#        print(self.like.logLike.use_single_fixed_map())
 #        self.like.logLike.set_use_single_fixed_map(False)
-#        print self.like.logLike.use_single_fixed_map()
+#        print(self.like.logLike.use_single_fixed_map())
 
         if self.config['gtlike']['edisp']:
             self.logger.debug('Enabling energy dispersion')

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -536,7 +536,7 @@ class HPX(object):
         if self.conv.convname == 'FGST_SRCMAP_SPARSE':
             nonzero = data.nonzero()
             nfilled = len(nonzero[0])
-            print ('Nfilled ', nfilled)
+            print('Nfilled ', nfilled)
             if len(shape) == 1:
                 nonzero = nonzero[0]
                 cols.append(fits.Column("KEY", "%iJ" %

--- a/fermipy/jobs/chain.py
+++ b/fermipy/jobs/chain.py
@@ -627,14 +627,14 @@ class Link(object):
 
     def stage_input_files(self, file_mapping, dry_run=True):
         """Stage the input files to the scratch area and adjust the arguments accordingly"""
-        print ("Staging input ", file_mapping)
+        print("Staging input ", file_mapping)
         if self._file_stage is None:
             return
         self._file_stage.copy_to_scratch(file_mapping, dry_run)
 
     def stage_output_files(self, file_mapping, dry_run=True):
         """Stage the input files to the scratch area and adjust the arguments accordingly"""
-        print ("Staging output ", file_mapping)
+        print("Staging output ", file_mapping)
         if self._file_stage is None:
             return
         self._file_stage.copy_from_scratch(file_mapping, dry_run)
@@ -643,12 +643,12 @@ class Link(object):
         """Remove / compress files as requested """
         for rmfile in self.files.temp_files:
             if dry_run:
-                print ("remove %s" % rmfile)
+                print("remove %s" % rmfile)
             else:
                 os.remove(rmfile)
         for gzfile in self.files.gzip_files:
             if dry_run:
-                print ("gzip %s" % gzfile)
+                print("gzip %s" % gzfile)
             else:
                 os.system('gzip -9 %s' % gzfile)
 
@@ -840,7 +840,7 @@ class Chain(Link):
                 self.stage_input_files(input_file_mapping, dry_run)
 
         for link in self._links.values():
-            print ("Running link ", link.linkname)
+            print("Running link ", link.linkname)
             link.run_link(stream=stream, dry_run=dry_run, stage_files=False)
 
         if self._file_stage is not None and stage_files:

--- a/fermipy/jobs/file_archive.py
+++ b/fermipy/jobs/file_archive.py
@@ -374,7 +374,7 @@ class FileStageManager(object):
             scratch_dirs[scratch_dirname] = True
         for scratch_dirname in scratch_dirs.keys():
             if dry_run:
-                print ("mkdir -f %s" % (scratch_dirname))
+                print("mkdir -f %s" % (scratch_dirname))
             else:
                 try:
                     os.makedirs(scratch_dirname)
@@ -388,7 +388,7 @@ class FileStageManager(object):
             if not os.path.exists(key):
                 continue
             if dry_run:
-                print ("cp %s %s" % (key, value))
+                print("cp %s %s" % (key, value))
             else:
                 os.system("cp %s %s" % (key, value))
         return file_mapping
@@ -398,7 +398,7 @@ class FileStageManager(object):
         """Copy output files from scratch area """
         for key, value in file_mapping.items():
             if dry_run:
-                print ("cp %s %s" % (value, key))
+                print("cp %s %s" % (value, key))
             else:
                 try:
                     outdir = os.path.dirname(key)
@@ -486,7 +486,7 @@ class FileHandle(object):
         try:
             return FileHandle(**kwargs)
         except KeyError:
-            print (kwargs)
+            print(kwargs)
 
     def check_status(self, basepath=None):
         """Check on the status of this particular file"""
@@ -656,7 +656,7 @@ class FileArchive(object):
             # Make sure the file really exists
             fullpath = self._get_fullpath(filepath)
             if not os.path.exists(fullpath):
-                print ("register_file called on called on mising file %s" % fullpath)
+                print("register_file called on called on mising file %s" % fullpath)
                 status = FileStatus.missing
                 timestamp = 0
             else:
@@ -756,7 +756,7 @@ class FileArchive(object):
         try:
             path_array = self._table[id_list - 1]['path']
         except IndexError:
-            print ("IndexError ", len(self._table), id_list)
+            print("IndexError ", len(self._table), id_list)
             path_array = []
         return [path for path in path_array]
 
@@ -776,7 +776,7 @@ class FileArchive(object):
         """Update the status of all the files in the archive"""
         nfiles = len(self.cache.keys())
         status_vect = np.zeros((6), int)
-        print ("Updating status of %i files: "%nfiles)
+        print("Updating status of %i files: "%nfiles)
         for i, key in enumerate(self.cache.keys()):
             if i % 200 == 0:
                 sys.stdout.write('.')

--- a/fermipy/jobs/gtlink.py
+++ b/fermipy/jobs/gtlink.py
@@ -108,14 +108,14 @@ def run_gtapp(gtapp, stream, dry_run, **kwargs):
     pfiles_orig = os.environ['PFILES']
     if pfiles:
         if dry_run:
-            print ("mkdir %s" % pfiles)
+            print("mkdir %s" % pfiles)
         else:
             try:
                 os.makedirs(pfiles)
             except OSError:
                 pass
         pfiles = "%s:%s" % (pfiles, pfiles_orig)
-        print ("Setting PFILES=%s" % pfiles)
+        print("Setting PFILES=%s" % pfiles)
 
         os.environ['PFILES'] = pfiles
 

--- a/fermipy/jobs/job_archive.py
+++ b/fermipy/jobs/job_archive.py
@@ -514,7 +514,7 @@ class JobArchive(object):
         """Update the status of all the jobs in the archive"""
         njobs = len(self.cache.keys())
         status_vect = np.zeros((5), int)
-        print ("Updating status of %i jobs: "%njobs)
+        print("Updating status of %i jobs: "%njobs)
         for i, key in enumerate(self.cache.keys()):
             if i % 200 == 0:
                 sys.stdout.write('.')

--- a/fermipy/jobs/scatter_gather.py
+++ b/fermipy/jobs/scatter_gather.py
@@ -348,7 +348,7 @@ class ScatterGather(Link):
             elif self.args['dry_run']:
                 break
             else:
-                print ("Sleeping %.0f seconds between status checks" %
+                print("Sleeping %.0f seconds between status checks" %
                        self.args['job_check_sleep'])
                 time.sleep(self.args['job_check_sleep'])
 
@@ -453,13 +453,13 @@ class ScatterGather(Link):
         running = True            
         while running:
             if self.args['dry_run']:
-                print ("Dry run break")
+                print("Dry run break")
                 break
             running, failed = self._check_link_completion(self._initialize_link)
             if failed:
                 return JobStatus.failed
-            print ("Sleeping %.0f seconds between status checks" %
-                   self.args['job_check_sleep'])
+            print("Sleeping %.0f seconds between status checks" %
+                  self.args['job_check_sleep'])
             time.sleep(self.args['job_check_sleep'])
 
         return job_details.status
@@ -519,7 +519,7 @@ class ScatterGather(Link):
         try:
             job_details = link.jobs[key]
         except KeyError:
-            print (key, link.jobs)
+            print(key, link.jobs)
         job_config = job_details.job_config
         link.update_args(job_config)
         logfile = job_config['logfile']

--- a/fermipy/logger.py
+++ b/fermipy/logger.py
@@ -56,7 +56,7 @@ class Logger(object):
 #        logger = logging.getLogger()
 #        for h in logger.handlers:
 #            if 'file_handler' in h.name:
-#                print h.name
+#                print(h.name)
 
     @staticmethod
     def get(name, logfile, loglevel=logging.DEBUG):

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -699,10 +699,10 @@ class Source(Model):
     object can be accessed with the bracket operator:
 
     # Return the TS of this source
-    >>> print src['ts']
+    >>> src['ts']
 
     # Get a skycoord representation of the source position
-    >>> print src.skydir
+    >>> src.skydir
     """
 
     def __init__(self, name, data, radec=None):

--- a/fermipy/scripts/preprocess_data.py
+++ b/fermipy/scripts/preprocess_data.py
@@ -171,10 +171,10 @@ workdir=$(mktemp -d -p /scratch/$USER);\n
 
     lstfile = "%s_%s_%s_z%g_r%g_ft1.lst" % (
         args.evclass, min(tstarts), max(tstops), args.zmax, args.rock)
-    print "Writing ft1 file list: %s\n" % lstfile
+    print("Writing ft1 file list: %s\n" % lstfile)
     np.savetxt(lstfile, sorted(lst), fmt="%s")
 
-    print "Done."
+    print("Done.")
 
 if __name__ == "__main__":
     main()

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -680,7 +680,7 @@ class SourceFind(object):
                                     method='SLSQP',
                                     tol=1e-6)
 
-        print ('fit 2')
+        print('fit 2')
 
         o = scipy.optimize.minimize(fit_fn, o.x,
                                     bounds=[(0.0, 39.0),

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -979,9 +979,9 @@ class TSMapGenerator(object):
 
             data.flat[i] = ts
 
-            #            print i, ra, dec, ts
-            #            print self.like()
-            # print self.components[0].like.model['tsmap_testsource']
+            #            print(i, ra, dec, ts)
+            #            print(self.like())
+            # print(self.components[0].like.model['tsmap_testsource'])
 
             self.delete_source('tsmap_testsource')
 

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -705,7 +705,7 @@ def get_parameter_limits(xval, loglike, ul_confidence=0.95, tol=1E-3):
     try:
         spline = UnivariateSpline(xval, loglike, k=2, s=tol)
     except:
-        print ("Failed to create spline: ", xval, loglike)
+        print("Failed to create spline: ", xval, loglike)
         return {'x0': np.nan, 'ul': np.nan, 'll': np.nan,
                 'err_lo': np.nan, 'err_hi': np.nan, 'err': np.nan,
                 'lnlmax': np.nan}


### PR DESCRIPTION
This PR contains a few Python 3 and PEP8 print fixes. (I did a search and replace from "print " to "print", i.e. remove the space, and added `()` where necessary.)

---

Side comment: using `print` doesn't give users of Fermipy much control and IMO using logging is better (even if it's an extra two lines of boilerplate at the top). In Gammapy we never print, but always emit log messages like this: http://docs.gammapy.org/en/latest/development/howto.html#generating-log-messages
