### PR TITLE
Improvements to Sensitivity Tools

### DIFF
--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -781,8 +781,11 @@ class HPX(object):
     def get_sky_dirs(self):
 
         lonlat = self.get_sky_coords()
-        return SkyCoord(ra=lonlat.T[0], dec=lonlat.T[1], unit='deg')
-
+        if self.coordsys == 'CEL':        
+            return SkyCoord(ra=lonlat.T[0], dec=lonlat.T[1], unit='deg', frame='icrs')
+        else:
+            return SkyCoord(l=lonlat.T[0], b=lonlat.T[1], unit='deg', frame='galactic')
+        
     def get_pixel_indices(self, lats, lons):
         """ "Return the indices in the flat array corresponding to a set of coordinates """
         theta = np.radians(90. - lats)
@@ -819,7 +822,7 @@ class HpxToWcsMapping(object):
             self._mult_val = mapping_data['mult_val']
             self._npix = mapping_data['npix']
         self._lmap = self._hpx[self._ipixs]
-        self._valid = self._lmap > 0
+        self._valid = self._lmap >= 0
 
     @property
     def hpx(self):

--- a/fermipy/scripts/flux_sensitivity.py
+++ b/fermipy/scripts/flux_sensitivity.py
@@ -16,170 +16,9 @@ from fermipy import spectrum
 from fermipy import irfs
 from fermipy import skymap
 from fermipy.ltcube import LTCube
-
-
-class SensitivityCalc(object):
-
-    def __init__(self, gdiff, iso, ltc, ebins, event_class, event_types):
-        """ 
-
-        Parameters
-        ----------
-        gdiff : `~fermipy.skymap.SkyMap`
-            Galactic diffuse map cube object.
-
-        iso : `~numpy.ndarray`
-            Array of background isotropic intensity vs. energy.
-
-        ltc : `~fermipy.ltcube.LTCube`
-
-        event_class : str
-
-        event_types : list        
-
-        """
-        self._gdiff = gdiff
-        self._iso = iso
-        self._ltc = ltc
-        self._ebins = ebins
-        self._log_ebins = np.log10(ebins)
-        self._ectr = np.exp(utils.edge_to_center(np.log(self._ebins)))
-        self._event_class = event_class
-        self._event_types = event_types
-
-        self._psf = []
-        self._exp = []
-
-        ebins = 10**np.linspace(1.0, 6.0, 5 * 8 + 1)
-        skydir = SkyCoord(0.0, 0.0, unit='deg')
-        for et in self._event_types:
-            self._psf += [irfs.PSFModel.create(skydir.icrs, self._ltc,
-                                               self._event_class, et,
-                                               ebins)]
-            self._exp += [irfs.ExposureMap.create(self._ltc,
-                                                  self._event_class, et,
-                                                  ebins)]
-
-    @property
-    def ebins(self):
-        return self._ebins
-
-    @property
-    def ectr(self):
-        return self._ectr
-
-    def compute_counts(self, skydir, fn, ebins=None):
-        """Compute signal and background counts for a point source at
-        position ``skydir`` with spectral parameterization ``fn``.
-
-        Parameters
-        ----------
-        skydir : `~astropy.coordinates.SkyCoord`
-
-        ebins : `~numpy.ndarray`
-
-        Returns
-        -------
-        sig : `~numpy.ndarray`
-            Signal counts array.  Dimensions are energy, angular
-            separation, and event type.
-
-        bkg : `~numpy.ndarray`
-            Background counts array.  Dimensions are energy, angular
-            separation, and event type.
-
-        """
-
-        if ebins is None:
-            ebins = self.ebins
-            ectr = self.ectr
-        else:
-            ectr = np.exp(utils.edge_to_center(np.log(ebins)))
-
-        skydir_cel = skydir.transform_to('icrs')
-        skydir_gal = skydir.transform_to('galactic')
-
-        sig = []
-        bkg = []
-        for psf, exp in zip(self._psf, self._exp):
-            expv = exp.interpolate(
-                skydir_cel.icrs.ra.deg, skydir_cel.icrs.dec.deg, ectr)
-            bkgv = self._gdiff.interpolate(
-                skydir_gal.l.deg, skydir_gal.b.deg, ectr)
-            isov = np.exp(np.interp(np.log(ectr), np.log(self._iso[0]),
-                                    np.log(self._iso[1])))
-            bkgv += isov
-            s, b = irfs.compute_ps_counts(ebins, expv, psf, bkgv, fn)
-            sig += [s]
-            bkg += [b]
-
-        sig = np.concatenate([np.expand_dims(t, -1) for t in sig])
-        bkg = np.concatenate([np.expand_dims(t, -1) for t in bkg])
-
-        return sig, bkg
-
-    def diff_flux_threshold(self, skydir, fn, ts_thresh, min_counts):
-        """Compute the differential flux threshold for a point source at
-        position ``skydir`` with spectral parameterization ``fn``.
-
-        """
-
-        sig, bkg = self.compute_counts(skydir, fn)
-
-        norms = irfs.compute_norm(sig, bkg, ts_thresh,
-                                  min_counts, sum_axes=[1, 2])
-        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [1, 2]))
-        norms = np.squeeze(norms)
-        flux = norms * fn.flux(self.ebins[:-1], self.ebins[1:])
-        eflux = norms * fn.eflux(self.ebins[:-1], self.ebins[1:])
-        dnde = norms * fn.dnde(self.ectr)
-        e2dnde = self.ectr**2 * dnde
-
-        return dict(e_min=self.ebins[:-1], e_max=self.ebins[1:],
-                    e_ref=self.ectr,
-                    npred=npred, flux=flux, eflux=eflux,
-                    dnde=dnde, e2dnde=e2dnde)
-
-    def int_flux_threshold(self, skydir, fn, ts_thresh, min_counts):
-        """Compute the integral flux threshold for a point source at
-        position ``skydir`` with spectral parameterization ``fn``.
-
-        """
-
-        ebins = 10**np.linspace(np.log10(self.ebins[0]),
-                                np.log10(self.ebins[-1]), 32)
-        ectr = np.sqrt(ebins[0] * ebins[-1])
-
-        sig, bkg = self.compute_counts(skydir, fn, ebins)
-
-        norms = irfs.compute_norm(sig, bkg, ts_thresh,
-                                  min_counts, sum_axes=[0, 1, 2])
-        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [0, 1, 2]))
-        norms = np.squeeze(norms)
-        flux = norms * fn.flux(ebins[0], ebins[-1])
-        eflux = norms * fn.eflux(ebins[0], ebins[-1])
-        dnde = norms * fn.dnde(ectr)
-        e2dnde = ectr**2 * dnde
-
-        o = dict(e_min=self.ebins[0], e_max=self.ebins[-1], e_ref=ectr,
-                 npred=npred, flux=flux, eflux=eflux,
-                 dnde=dnde, e2dnde=e2dnde)
-
-        sig, bkg = self.compute_counts(skydir, fn)
-        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [1, 2]))
-        flux = norms * fn.flux(self.ebins[:-1], self.ebins[1:])
-        eflux = norms * fn.eflux(self.ebins[:-1], self.ebins[1:])
-        dnde = norms * fn.dnde(self.ectr)
-        e2dnde = ectr**2 * dnde
-
-        o['bins'] = dict(npred=npred,
-                         flux=flux,
-                         eflux=eflux,
-                         dnde=dnde,
-                         e2dnde=e2dnde,
-                         e_min=self.ebins[:-1], e_max=self.ebins[1:], e_ref=self.ectr)
-
-        return o
+from fermipy.sensitivity import SensitivityCalc
+from fermipy.hpx_utils import HPX
+from fermipy.skymap import HpxMap
 
 
 def main(args=None):
@@ -194,6 +33,19 @@ def main(args=None):
     parser.add_argument('--isodiff', default=None,
                         help='Set the path to the isotropic model.  If none then the '
                         'default model will be used for the given event class.')
+
+    parser.add_argument('--galdiff_fit', default=None,
+                        help='Set the path to the galactic diffuse model used for fitting. '
+                        'This can be used to assess the impact of IEM systematics  '
+                        'from fitting with the wrong model.  If none '
+                        'then the same model will be used for data and fit.')
+    
+    parser.add_argument('--isodiff_fit', default=None,
+                        help='Set the path to the isotropic model used for fitting.  '
+                        'This can be used to assess the impact of IEM systematics  '
+                        'from fitting with the wrong model.  If none '
+                        'then the same model will be used for data and fit.')
+    
     parser.add_argument('--ts_thresh', default=25.0, type=float,
                         help='Set the detection threshold.')
     parser.add_argument('--min_counts', default=3.0, type=float,
@@ -212,6 +64,10 @@ def main(args=None):
                         help='Maximum energy in MeV.')
     parser.add_argument('--nbin', default=18, type=int,
                         help='Number of energy bins for differential flux calculation.')
+    parser.add_argument('--nside', default=None, type=int,
+                        help='Set the NSIDE parameter of the all-sky sensivity map.  If None then no sensitivity maps '
+                        'will be computed.  WARNING: Running with a large nside parameter is very '
+                        'computationally and memory intensive.')
     parser.add_argument('--output', default='output.fits', type=str,
                         help='Output filename.')
     parser.add_argument('--obs_time_yr', default=None, type=float,
@@ -233,10 +89,14 @@ def run_flux_sensitivity(**kwargs):
     ltcube_filepath = kwargs.get('ltcube', None)
     galdiff_filepath = kwargs.get('galdiff', None)
     isodiff_filepath = kwargs.get('isodiff', None)
+    galdiff_fit_filepath = kwargs.get('galdiff_fit', None)
+    isodiff_fit_filepath = kwargs.get('isodiff_fit', None)
+    
     obs_time_yr = kwargs.get('obs_time_yr', None)
     event_class = kwargs.get('event_class', 'P8R2_SOURCE_V6')
     min_counts = kwargs.get('min_counts', 3.0)
     ts_thresh = kwargs.get('ts_thresh', 25.0)
+    nside = kwargs.get('nside', None)
     output = kwargs.get('output', None)
 
     event_types = [['FRONT', 'BACK']]
@@ -262,7 +122,10 @@ def run_flux_sensitivity(**kwargs):
                 24 * 3600. / (ltc.tstop - ltc.tstart)
 
     gdiff = skymap.Map.create_from_fits(galdiff_filepath)
-
+    gdiff_fit = None
+    if galdiff_fit_filepath is not None:
+        gdiff_fit = skymap.Map.create_from_fits(galdiff_fit_filepath)
+        
     if isodiff_filepath is None:
         isodiff = utils.resolve_file_path('iso_%s_v06.txt' % event_class,
                                           search_dirs=[os.path.join('$FERMIPY_ROOT', 'data'),
@@ -271,13 +134,44 @@ def run_flux_sensitivity(**kwargs):
     else:
         isodiff = isodiff_filepath
 
+
     iso = np.loadtxt(isodiff, unpack=True)
-
+    iso_fit = None
+    if isodiff_fit_filepath is not None:
+        iso_fit = np.loadtxt(isodiff_fit_filepath, unpack=True)
+    
     scalc = SensitivityCalc(gdiff, iso, ltc, ebins,
-                            event_class, event_types)
+                            event_class, event_types, gdiff_fit=gdiff_fit,
+                            iso_fit=iso_fit)
 
+    # Compute Maps
+    map_diff_flux = None
+    map_diff_npred = None
+    map_int_flux = None
+    map_int_npred = None
+    
+    if nside is not None:
+
+        hpx = HPX(nside, True, 'GAL', ebins=ebins)
+        map_diff_flux = HpxMap(np.zeros((nbin,hpx.npix)),hpx)
+        map_diff_npred = HpxMap(np.zeros((nbin,hpx.npix)),hpx)
+        map_skydir = map_diff_flux.hpx.get_sky_dirs()
+
+        o = scalc.diff_flux_threshold(map_skydir, fn, ts_thresh, min_counts)
+        map_diff_flux.data[...] = o['flux'].T
+        map_diff_npred.data[...] = o['npred'].T
+
+        hpx = HPX(nside, True, 'GAL')
+        map_int_flux = HpxMap(np.zeros((hpx.npix)),hpx)
+        map_int_npred = HpxMap(np.zeros((hpx.npix)),hpx)
+        map_skydir = map_int_flux.hpx.get_sky_dirs()
+
+        o = scalc.int_flux_threshold(map_skydir, fn, ts_thresh, min_counts)
+        map_int_flux.data[...] = o['flux']
+        map_int_npred.data[...] = o['npred']
+        
     o = scalc.diff_flux_threshold(c, fn, ts_thresh, min_counts)
-
+        
     cols = [Column(name='e_min', dtype='f8', data=scalc.ebins[:-1], unit='MeV'),
             Column(name='e_ref', dtype='f8', data=o['e_ref'], unit='MeV'),
             Column(name='e_max', dtype='f8', data=scalc.ebins[1:], unit='MeV'),
@@ -352,6 +246,21 @@ def run_flux_sensitivity(**kwargs):
     hdulist[2].name = 'INT_FLUX'
     hdulist[3].name = 'INT_FLUX_EBIN'
 
+    if nside is not None:
+        hdu = map_diff_flux.create_image_hdu()
+        hdu.name = 'MAP_DIFF_FLUX'
+        hdulist.append(hdu)
+        hdu = map_diff_npred.create_image_hdu()
+        hdu.name = 'MAP_DIFF_NPRED'
+        hdulist.append(hdu)
+
+        hdu = map_int_flux.create_image_hdu()
+        hdu.name = 'MAP_INT_FLUX'
+        hdulist.append(hdu)
+        hdu = map_int_npred.create_image_hdu()
+        hdu.name = 'MAP_INT_NPRED'
+        hdulist.append(hdu)
+        
     hdulist.writeto(output, clobber=True)
 
 if __name__ == "__main__":

--- a/fermipy/sensitivity.py
+++ b/fermipy/sensitivity.py
@@ -1,0 +1,256 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function
+
+import pyLikelihood as pyLike
+
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.table import Table, Column
+from astropy.io import fits
+
+from fermipy import utils
+from fermipy import spectrum
+from fermipy import irfs
+from fermipy import skymap
+from fermipy.ltcube import LTCube
+
+
+class SensitivityCalc(object):
+    """Class for evaluating LAT source flux sensitivity.  
+
+    Parameters
+    ----------
+    gdiff : `~fermipy.skymap.SkyMap`
+        Galactic diffuse map cube object.
+
+    iso : `~numpy.ndarray`
+        Array of background isotropic intensity vs. energy.
+
+    ltc : `~fermipy.ltcube.LTCube`
+
+    ebins : `~numpy.ndarray`
+        Energy bin edges in MeV used for differential sensitivity.
+
+    event_class : str
+        Name of the IRF/event class (e.g. P8R2_SOURCE_V6).
+
+    event_types : list
+        List of lists of event type strings defining the event type
+        selection to be used.  Each event type list will be combined.
+        A selection for a combined FRONT/BACK analysis is defined with
+        [['FRONT','BACK']].  A selection for joint FRONT/BACK analysis
+        is defined with [['FRONT'],['BACK']].
+
+    """
+
+    def __init__(self, gdiff, iso, ltc, ebins, event_class, event_types=None,
+                 gdiff_fit=None, iso_fit=None):
+
+        self._gdiff = gdiff
+        self._gdiff_fit = gdiff_fit
+        self._iso = iso
+        self._iso_fit = iso_fit
+        self._ltc = ltc
+        self._ebins = ebins
+        self._log_ebins = np.log10(ebins)
+        self._ectr = np.exp(utils.edge_to_center(np.log(self._ebins)))
+        self._event_class = event_class
+        if event_types is None:
+            self._event_types = [['FRONT'],['BACK']]
+        else:
+            self._event_types = event_types
+
+        self._psf = []
+        self._exp = []
+
+        ebins = 10**np.linspace(1.0, 6.0, 5 * 8 + 1)
+        skydir = SkyCoord(0.0, 0.0, unit='deg')
+        for et in self._event_types:
+            self._psf += [irfs.PSFModel.create(skydir.icrs, self._ltc,
+                                               self._event_class, et,
+                                               ebins)]
+            self._exp += [irfs.ExposureMap.create(self._ltc,
+                                                  self._event_class, et,
+                                                  ebins)]
+
+    @property
+    def ebins(self):
+        return self._ebins
+
+    @property
+    def ectr(self):
+        return self._ectr
+
+    def compute_counts(self, skydir, fn, ebins=None):
+        """Compute signal and background counts for a point source at
+        position ``skydir`` with spectral parameterization ``fn``.
+
+        Parameters
+        ----------
+        skydir : `~astropy.coordinates.SkyCoord`
+
+        ebins : `~numpy.ndarray`
+
+        Returns
+        -------
+        sig : `~numpy.ndarray`
+            Signal counts array.  Dimensions are energy, angular
+            separation, and event type.
+
+        bkg : `~numpy.ndarray`
+            Background counts array.  Dimensions are energy, angular
+            separation, and event type.
+
+        """
+
+        if ebins is None:
+            ebins = self.ebins
+            ectr = self.ectr
+        else:
+            ectr = np.exp(utils.edge_to_center(np.log(ebins)))
+
+        skydir_cel = skydir.transform_to('icrs')
+        skydir_gal = skydir.transform_to('galactic')
+
+        sig = []
+        bkg = []
+        bkg_fit = None
+        if self._gdiff_fit is not None:
+            bkg_fit = []
+
+        for psf, exp in zip(self._psf, self._exp):
+
+            coords0 = np.meshgrid(*[skydir_cel.ra.deg, ectr], indexing='ij')
+            coords1 = np.meshgrid(*[skydir_cel.dec.deg, ectr], indexing='ij')
+
+            # expv = exp.interpolate(skydir_cel.icrs.ra.deg,
+            #                       skydir_cel.icrs.dec.deg,
+            #                       ectr)
+
+            expv = exp.interpolate(coords0[0], coords1[0], coords0[1])
+
+            coords0 = np.meshgrid(*[skydir_gal.l.deg, ectr], indexing='ij')
+            coords1 = np.meshgrid(*[skydir_gal.b.deg, ectr], indexing='ij')
+
+            bkgv = self._gdiff.interpolate(np.ravel(coords0[0]),
+                                           np.ravel(coords1[0]),
+                                           np.ravel(coords0[1]))
+            bkgv = bkgv.reshape(expv.shape)
+
+            # bkgv = self._gdiff.interpolate(
+            #    skydir_gal.l.deg, skydir_gal.b.deg, ectr)
+
+            isov = np.exp(np.interp(np.log(ectr), np.log(self._iso[0]),
+                                    np.log(self._iso[1])))
+            bkgv += isov
+            s, b = irfs.compute_ps_counts(
+                ebins, expv, psf, bkgv, fn, egy_dim=1)
+
+            sig += [s]
+            bkg += [b]
+
+            if self._iso_fit is not None:
+                isov_fit = np.exp(np.interp(np.log(ectr), np.log(self._iso_fit[0]),
+                                            np.log(self._iso_fit[1])))
+            else:
+                isov_fit = isov
+
+            if self._gdiff_fit is not None:
+                bkgv_fit = self._gdiff_fit.interpolate(np.ravel(coords0[0]),
+                                                       np.ravel(coords1[0]),
+                                                       np.ravel(coords0[1]))
+                bkgv_fit = bkgv_fit.reshape(expv.shape)
+                bkgv_fit += isov_fit
+                s, b = irfs.compute_ps_counts(ebins, expv, psf,
+                                              bkgv_fit, fn, egy_dim=1)
+                bkg_fit += [b]
+
+        sig = np.concatenate([np.expand_dims(t, -1) for t in sig])
+        bkg = np.concatenate([np.expand_dims(t, -1) for t in bkg])
+        if self._gdiff_fit is not None:
+            bkg_fit = np.concatenate([np.expand_dims(t, -1) for t in bkg_fit])
+
+        return sig, bkg, bkg_fit
+
+    def diff_flux_threshold(self, skydir, fn, ts_thresh, min_counts):
+        """Compute the differential flux threshold for a point source at
+        position ``skydir`` with spectral parameterization ``fn``.
+
+        Parameters
+        ----------
+        skydir : `~astropy.coordinates.SkyCoord`
+            Sky coordinates at which the sensitivity will be evaluated.
+
+        fn : `~fermipy.spectrum.SpectralFunction`
+
+        ts_thresh : float
+            Threshold on the detection test statistic (TS).
+
+        min_counts : float
+            Threshold on the minimum number of counts.
+
+        """
+
+        sig, bkg, bkg_fit = self.compute_counts(skydir, fn)
+        norms = irfs.compute_norm(sig, bkg, ts_thresh,
+                                  min_counts, sum_axes=[2, 3],
+                                  rebin_axes=[10, 1],
+                                  bkg_fit=bkg_fit)
+
+        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [2, 3]))
+        norms = np.squeeze(norms)
+        flux = norms * fn.flux(self.ebins[:-1], self.ebins[1:])
+        eflux = norms * fn.eflux(self.ebins[:-1], self.ebins[1:])
+        dnde = norms * fn.dnde(self.ectr)
+        e2dnde = self.ectr**2 * dnde
+
+        return dict(e_min=self.ebins[:-1], e_max=self.ebins[1:],
+                    e_ref=self.ectr,
+                    npred=npred, flux=flux, eflux=eflux,
+                    dnde=dnde, e2dnde=e2dnde)
+
+    def int_flux_threshold(self, skydir, fn, ts_thresh, min_counts):
+        """Compute the integral flux threshold for a point source at
+        position ``skydir`` with spectral parameterization ``fn``.
+
+        """
+
+        ebins = 10**np.linspace(np.log10(self.ebins[0]),
+                                np.log10(self.ebins[-1]), 33)
+        ectr = np.sqrt(ebins[0] * ebins[-1])
+
+        sig, bkg, bkg_fit = self.compute_counts(skydir, fn, ebins)
+
+        norms = irfs.compute_norm(sig, bkg, ts_thresh,
+                                  min_counts, sum_axes=[1, 2, 3], bkg_fit=bkg_fit,
+                                  rebin_axes=[4, 10, 1])
+        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [1, 2, 3]))
+        npred = np.array(npred, ndmin=1)
+        norms = np.array(np.squeeze(norms), ndmin=1)
+        flux = norms * fn.flux(ebins[0], ebins[-1])
+        eflux = norms * fn.eflux(ebins[0], ebins[-1])
+        dnde = norms * fn.dnde(ectr)
+        e2dnde = ectr**2 * dnde
+
+        o = dict(e_min=self.ebins[0], e_max=self.ebins[-1], e_ref=ectr,
+                 npred=npred, flux=flux, eflux=eflux,
+                 dnde=dnde, e2dnde=e2dnde)
+
+        sig, bkg, bkg_fit = self.compute_counts(skydir, fn)
+        npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig, [2, 3]))
+        flux = np.squeeze(norms[:, None] *
+                          fn.flux(self.ebins[:-1], self.ebins[1:]))
+        eflux = np.squeeze(norms[:, None] *
+                           fn.eflux(self.ebins[:-1], self.ebins[1:]))
+        dnde = np.squeeze(norms[:, None] * fn.dnde(self.ectr))
+        e2dnde = ectr**2 * dnde
+
+        o['bins'] = dict(npred=npred,
+                         flux=flux,
+                         eflux=eflux,
+                         dnde=dnde,
+                         e2dnde=e2dnde,
+                         e_min=self.ebins[:-1], e_max=self.ebins[1:],
+                         e_ref=self.ectr)
+
+        return o

--- a/fermipy/tests/test_sensitivity.py
+++ b/fermipy/tests/test_sensitivity.py
@@ -13,6 +13,7 @@ from fermipy.skymap import Map
 
 try:
     from fermipy.scripts import flux_sensitivity
+    from fermipy.sensitivity import SensitivityCalc
 except ImportError:
     pass
     
@@ -33,8 +34,8 @@ def test_calc_diff_flux_sensitivity():
     gdiff = Map.create_from_fits(galdiff_path)
     iso = np.loadtxt(os.path.expandvars('$FERMIPY_ROOT/data/iso_P8R2_SOURCE_V6_v06.txt'),
                      unpack=True)
-    scalc = flux_sensitivity.SensitivityCalc(gdiff, iso, ltc, ebins,
-                                             'P8R2_SOURCE_V6', [['FRONT', 'BACK']])
+    scalc = SensitivityCalc(gdiff, iso, ltc, ebins,
+                            'P8R2_SOURCE_V6', [['FRONT', 'BACK']])
 
     fn = spectrum.PowerLaw([1E-13, -2.0], scale=1E3)
     o = scalc.diff_flux_threshold(c, fn, 25.0, 3.0)
@@ -47,7 +48,7 @@ def test_calc_diff_flux_sensitivity():
                               2.05372045e-07,   2.14355673e-07,   2.29584275e-07,
                               2.53220397e-07,   2.80878974e-07,   3.19989251e-07,
                               3.74686765e-07,   4.49321103e-07,   5.48865583e-07]),
-                    rtol=1E-3)
+                    rtol=3E-3)
 
     assert_allclose(o['flux'],
                     np.array([8.22850449e-09,   5.33257909e-09,   3.46076145e-09,
@@ -58,7 +59,7 @@ def test_calc_diff_flux_sensitivity():
                               2.37979404e-11,   1.86265760e-11,   1.49602959e-11,
                               1.23736187e-11,   1.02924147e-11,   8.79292634e-12,
                               7.72087281e-12,   6.94312304e-12,   6.36010146e-12]),
-                    rtol=1E-3)
+                    rtol=3E-3)
 
 
 @requires_file(galdiff_path)
@@ -71,17 +72,17 @@ def test_calc_int_flux_sensitivity():
     gdiff = Map.create_from_fits(galdiff_path)
     iso = np.loadtxt(os.path.expandvars('$FERMIPY_ROOT/data/iso_P8R2_SOURCE_V6_v06.txt'),
                      unpack=True)
-    scalc = flux_sensitivity.SensitivityCalc(gdiff, iso, ltc, ebins,
-                                             'P8R2_SOURCE_V6', [['FRONT', 'BACK']])
+    scalc = SensitivityCalc(gdiff, iso, ltc, ebins,
+                            'P8R2_SOURCE_V6', [['FRONT', 'BACK']])
 
     fn = spectrum.PowerLaw([1E-13, -2.0], scale=1E3)
     o = scalc.int_flux_threshold(c, fn, 25.0, 3.0)
 
-    assert_allclose(o['eflux'], 1.0719847971553671e-06, rtol=1E-3)
-    assert_allclose(o['flux'], 1.550305083355546e-09, rtol=1E-3)
-    assert_allclose(o['npred'], 511.16725330021416, rtol=1E-3)
-    assert_allclose(o['dnde'], 1.5518569402958423e-14, rtol=1E-3)
-    assert_allclose(o['e2dnde'], 1.5518569402958427e-07, rtol=1E-3)
+    assert_allclose(o['eflux'], 1.0719847971553671e-06, rtol=3E-3)
+    assert_allclose(o['flux'], 1.550305083355546e-09, rtol=3E-3)
+    assert_allclose(o['npred'], 511.16725330021416, rtol=3E-3)
+    assert_allclose(o['dnde'], 1.5518569402958423e-14, rtol=3E-3)
+    assert_allclose(o['e2dnde'], 1.5518569402958427e-07, rtol=3E-3)
 
     assert_allclose(o['bins']['flux'],
                     np.array([3.88128407e-10,   2.91055245e-10,   2.18260643e-10,
@@ -119,4 +120,4 @@ def test_flux_sensitivity_script(tmpdir):
                               2.37979404e-11,   1.86265760e-11,   1.49602959e-11,
                               1.23736187e-11,   1.02924147e-11,   8.79292634e-12,
                               7.72087281e-12,   6.94312304e-12,   6.36010146e-12]),
-                    rtol=1E-3)
+                    rtol=3E-3)


### PR DESCRIPTION
This PR makes a number of improvements to the flux sensitivity tools:

* Vectorizes integral/differential flux methods with respect to sky position.  This makes it significantly more efficient to compute sensitivity over a grid of sky positions.
* Adds sensitivity map output to `fermipy-flux-sensitivity`.  This will write HEALPix maps to the output FITS file with NSIDE set by the `nside` command-line parameter.  Maps are only computed if the `nside` parameter is defined on the command line.
* Adds support for setting independent background models for the data and model inputs to the sensitivity calculation.  By default data and model will be assumed to be equal.  The `iso_fit` and `gdiff_fit` parameters can be used to set the fit model independently.
* Various improvements to the efficiency of the sensitivity calculation. 