### PR TITLE
Extended Source Sensitivity

### DIFF
--- a/docs/advanced/sensitivity.rst
+++ b/docs/advanced/sensitivity.rst
@@ -3,28 +3,84 @@
 Sensitivity Tools
 -----------------
 
-The ``fermipy-flux-sensitivity`` script can be used to calculate the
-LAT detection threshold versus energy.  Inputs are the galactic
-diffuse model and the livetime cube of the observation epoch.  The
-``obs_time_yr`` option can be used to rescale the livetime cube to a
-shorter or longer observation time.
+The ``fermipy-flux-sensitivity`` script calculates the LAT flux
+threshold for a gamma-ray source in bins of energy (differential
+sensitivity) and integrated over the full LAT energy range (integral
+sensitivity).  The source flux threshold is the flux at which the
+median TS of a source (twice the likelihood ratio of the best-fit model with and
+without the source) equals a certain value.  Primary inputs to this script
+are the livetime cube (output of ``gtltcube``) and the model cube for the galactic diffuse
+background.  The ``obs_time_yr`` option can be used to rescale the
+livetime cube to a shorter or longer observation time.
 
 .. code-block:: bash
 
-   $ fermipy-flux-sensitivity --glon=30 --glat=30 --output=flux.fits \
-   --ltcube=ltcube.fits --galdiff=gll_iem_v06.fits --event_class=P8R2_SOURCE_V6
+   $ fermipy-flux-sensitivity --glon=30 --glat=30 --output=lat_sensitivity.fits \
+   --ltcube=ltcube.fits --galdiff=gll_iem_v06.fits --event_class=P8R2_SOURCE_V6 \
+   --ts_thresh=25.0 --min_counts=10.0
 
 If no livetime cube is provided then the sensitivity will be computed
 assuming an "ideal" survey-mode operation with uniform exposure over
 the whole sky and no Earth obscuration or deadtime.  By default the
 flux sensitivity will be calculated for a TS threshold of 25 and at
 least 3 counts.
-   
-The output FITS file contains a table with the flux threshold in each
-energy bin.
-   
+
+A map of sensitivity with WCS or HEALPix pixelization can be generated
+by setting the ``map_type`` argument to either ``wcs`` or ``hpx``:
+
+.. code-block:: bash
+
+   # Generate a WCS sensitivity map of 50 x 50 deg centered at (glon,glat) = (30,30) 
+   $ fermipy-flux-sensitivity  --glon=30 --glat=30 --output=lat_sensitivity_map.fits \
+   --ltcube=ltcube.fits --galdiff=gll_iem_v06.fits --event_class=P8R2_SOURCE_V6 \
+   --map_type=wcs --wcs_npix=100 --wcs_cdelt=0.5 --wcs_proj=AIT
+
+   # Generate a HPX sensitivity map of nside=16
+   $ fermipy-flux-sensitivity  --output=lat_sensitivity_map.fits \
+   --ltcube=ltcube.fits --galdiff=gll_iem_v06.fits --event_class=P8R2_SOURCE_V6 \
+   --map_type=hpx --hpx_nside=16
+
+The integral and differential sensitivity maps will be written to the
+``MAP_INT_FLUX`` and ``MAP_DIFF_FLUX`` extensions respectively.
+
+By default the flux sensitivity will be computed for a point-source
+morphology.  The assumed source morphology can be changed with the
+``spatial_model`` and ``spatial_size`` parameters:
+
+.. code-block:: bash
+
+   # Generate the sensitivity to a source with a 2D gaussian morphology
+   # and a 68% containment radiu of 1 deg  
+   $ fermipy-flux-sensitivity --output=lat_sensitivity_map.fits \
+   --ltcube=ltcube.fits --galdiff=gll_iem_v06.fits --event_class=P8R2_SOURCE_V6 \
+   --spatial_model=RadialGaussian --spatial_size=1.0
+
+The output FITS file set with the ``output`` option contains the
+following tables.  Note that ``MAP`` tables are only generated when
+the ``map_type`` argument is set.
+
+* ``DIFF_FLUX`` : Differential flux sensitivity for a gamma-ray source
+  at sky positition set by ``glon`` and ``glat``.
+* ``INT_FLUX`` : Integral flux sensitivity evaluated for PowerLaw
+  sources with spectral indices between 1.0 and 5.0 at sky positition
+  set by ``glon`` and ``glat``.  Columns starting with ``ebin`` contain the source amplitude vs. energy bin.
+* ``MAP_DIFF_FLUX`` : Sky cube with differential flux threshold
+  vs. sky position and energy.  
+* ``MAP_DIFF_NPRED`` : Sky cube with counts amplitude
+  (NPred) of a source at the detection threshold vs. position and energy. 
+* ``MAP_INT_FLUX`` : Sky map with integral flux threshold vs. sky
+  position.  Integral sensitivity will be computed for a PowerLaw
+  source with index equal to the ``index`` parameter.
+* ``MAP_INT_NPRED`` : Sky map with counts amplitude (NPred)
+  of a source at the detection threshold vs. sky position.
+  
+The output file can be read using the `~astropy.table.Table` module:
+  
 .. code-block:: python
 
    from astropy.table import Table
-   tab = Table.read('flux.fits')
+   
+   tab = Table.read('lat_sensitivity.fits','DIFF_FLUX')
    print(tab['e_min'], tab['e_max'], tab['flux'])
+   tab = Table.read('lat_sensitivity.fits','INT_FLUX')
+   print(tab['index'], tab['flux'])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,28 @@ Changelog
 This page is a changelog for releases of Fermipy.  You can also browse
 releases on `Github <https://github.com/fermiPy/fermipy/releases>`_.
 
+0.15.0 (09/05/2017)
+-------------------
+
+* Bug fix related to restoring analysis state for phased analysis
+  (scaled exposure).
+* Many improvements and feature additions to senstivity tools (see e.g. `#148
+  <https://github.com/fermiPy/fermipy/pull/148>`_, `#149
+  <https://github.com/fermiPy/fermipy/pull/149>`_, and `#152
+  <https://github.com/fermiPy/fermipy/pull/152>`_).
+* Various updates to support DM pipeline package (`#146
+  <https://github.com/fermiPy/fermipy/pull/146>`_).
+* Improve robustness of algorithms for extracting peak and
+  uncertainty ellipse from 2D likelihood surface.
+* Added `~fermipy.gtanalysis.GTAnalysis.curvature` method for testing a
+  source for spectral curvature.
+* Added ``fix_shape`` option to
+  `~fermipy.gtanalysis.GTAnalysis.extension` and
+  `~fermipy.gtanalysis.GTAnalysis.localize` to fix spectral shape
+  parameters.  Spectral shape parameters of the source of interest are
+  now free by default when localizing or fitting extension.
+  
+
 0.14.0 (03/28/2017)
 -------------------
 * Refactoring and improvements in

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -46,8 +46,8 @@ as a dictionary containing *name* and *file* fields:
    
    model:
      galdiff  : 
-       - { 'name' : 'component0' : 'file' : '$FERMI_DIFFUSE_DIR/diffuse_component0.fits' }
-       - { 'name' : 'component1' : 'file' : '$FERMI_DIFFUSE_DIR/diffuse_component1.fits' }
+       - { 'name' : 'component0', 'file' : '$FERMI_DIFFUSE_DIR/diffuse_component0.fits' }
+       - { 'name' : 'component1', 'file' : '$FERMI_DIFFUSE_DIR/diffuse_component1.fits' }
 
 Configuring Source Components
 -----------------------------

--- a/fermipy/scripts/flux_sensitivity.py
+++ b/fermipy/scripts/flux_sensitivity.py
@@ -82,6 +82,10 @@ def main(args=None):
                         help='Set the pixel size in deg of the WCS sensitivity map.')
     parser.add_argument('--wcs_proj', default='AIT', type=str,
                         help='Set the projection of the WCS sensitivity map.')
+    parser.add_argument('--spatial_model', default='PointSource', type=str,
+                        help='Set the spatial morphology of the signal (PointSource, RadialDisk, RadialGaussian).')
+    parser.add_argument('--spatial_size', default=1.0, type=float,
+                        help='Set the intrinsic 68% containment radius in degrees for extended spatial models (RadialDisk, RadialGaussian).')
     parser.add_argument('--output', default='output.fits', type=str,
                         help='Output filename.')
     parser.add_argument('--obs_time_yr', default=None, type=float,
@@ -109,6 +113,8 @@ def run_flux_sensitivity(**kwargs):
     wcs_cdelt = kwargs.get('wcs_cdelt', 0.5)
     wcs_proj = kwargs.get('wcs_proj', 'AIT')
     map_type = kwargs.get('map_type', None)
+    spatial_model = kwargs.get('spatial_model', 'PointSource')
+    spatial_size = kwargs.get('spatial_size', 1E-2)
 
     obs_time_yr = kwargs.get('obs_time_yr', None)
     event_class = kwargs.get('event_class', 'P8R2_SOURCE_V6')
@@ -159,7 +165,8 @@ def run_flux_sensitivity(**kwargs):
 
     scalc = SensitivityCalc(gdiff, iso, ltc, ebins,
                             event_class, event_types, gdiff_fit=gdiff_fit,
-                            iso_fit=iso_fit)
+                            iso_fit=iso_fit, spatial_model=spatial_model,
+                            spatial_size=spatial_size)
 
     # Compute Maps
     map_diff_flux = None
@@ -328,6 +335,7 @@ def run_flux_sensitivity(**kwargs):
         hdulist.append(hdu)
 
     hdulist.writeto(output, clobber=True)
+
 
 if __name__ == "__main__":
     main()

--- a/fermipy/sensitivity.py
+++ b/fermipy/sensitivity.py
@@ -44,7 +44,8 @@ class SensitivityCalc(object):
     """
 
     def __init__(self, gdiff, iso, ltc, ebins, event_class, event_types=None,
-                 gdiff_fit=None, iso_fit=None):
+                 gdiff_fit=None, iso_fit=None, spatial_model='PointSource',
+                 spatial_size=None):
 
         self._gdiff = gdiff
         self._gdiff_fit = gdiff_fit
@@ -55,6 +56,8 @@ class SensitivityCalc(object):
         self._log_ebins = np.log10(ebins)
         self._ectr = np.exp(utils.edge_to_center(np.log(self._ebins)))
         self._event_class = event_class
+        self._spatial_model = spatial_model
+        self._spatial_size = spatial_size
         if event_types is None:
             self._event_types = [['FRONT'], ['BACK']]
         else:
@@ -80,6 +83,14 @@ class SensitivityCalc(object):
     @property
     def ectr(self):
         return self._ectr
+
+    @property
+    def spatial_model(self):
+        return self._spatial_model
+
+    @property
+    def spatial_size(self):
+        return self._spatial_size
 
     def compute_counts(self, skydir, fn, ebins=None):
         """Compute signal and background counts for a point source at
@@ -143,11 +154,13 @@ class SensitivityCalc(object):
             isov = np.exp(np.interp(np.log(ectr), np.log(self._iso[0]),
                                     np.log(self._iso[1])))
             bkgv += isov
-            s, b = irfs.compute_ps_counts(
-                ebins, expv, psf, bkgv, fn, egy_dim=1)
+            s0, b0 = irfs.compute_ps_counts(ebins, expv, psf, bkgv, fn,
+                                            egy_dim=1,
+                                            spatial_model=self.spatial_model,
+                                            spatial_size=self.spatial_size)
 
-            sig += [s]
-            bkg += [b]
+            sig += [s0]
+            bkg += [b0]
 
             if self._iso_fit is not None:
                 isov_fit = np.exp(np.interp(np.log(ectr), np.log(self._iso_fit[0]),
@@ -161,9 +174,11 @@ class SensitivityCalc(object):
                                                        np.ravel(coords0[1]))
                 bkgv_fit = bkgv_fit.reshape(expv.shape)
                 bkgv_fit += isov_fit
-                s, b = irfs.compute_ps_counts(ebins, expv, psf,
-                                              bkgv_fit, fn, egy_dim=1)
-                bkg_fit += [b]
+                s0, b0 = irfs.compute_ps_counts(ebins, expv, psf,
+                                                bkgv_fit, fn, egy_dim=1,
+                                                spatial_model=self.spatial_model,
+                                                spatial_size=self.spatial_size)
+                bkg_fit += [b0]
 
         sig = np.concatenate([np.expand_dims(t, -1) for t in sig])
         bkg = np.concatenate([np.expand_dims(t, -1) for t in bkg])
@@ -240,11 +255,12 @@ class SensitivityCalc(object):
 
         npred = np.squeeze(np.apply_over_axes(np.sum, norms * sig,
                                               [2, 3]))
-        flux = np.squeeze(np.squeeze(norms,axis=(1,2,3))[:, None] *
+        flux = np.squeeze(np.squeeze(norms, axis=(1, 2, 3))[:, None] *
                           fn.flux(self.ebins[:-1], self.ebins[1:]))
-        eflux = np.squeeze(np.squeeze(norms,axis=(1,2,3))[:, None] *
+        eflux = np.squeeze(np.squeeze(norms, axis=(1, 2, 3))[:, None] *
                            fn.eflux(self.ebins[:-1], self.ebins[1:]))
-        dnde = np.squeeze(np.squeeze(norms,axis=(1,2,3))[:, None] * fn.dnde(self.ectr))
+        dnde = np.squeeze(np.squeeze(norms, axis=(1, 2, 3))
+                          [:, None] * fn.dnde(self.ectr))
         e2dnde = ectr**2 * dnde
 
         o['bins'] = dict(npred=npred,

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -1415,15 +1415,13 @@ def convolve2d_disk(fn, r, sig, nstep=200):
     rmin[rmin < 0] = 0
     delta = (rmax - rmin) / nstep
 
-    redge = rmin[:, np.newaxis] + \
-        delta[:, np.newaxis] * np.linspace(0, nstep, nstep + 1)[np.newaxis, :]
-    rp = 0.5 * (redge[:, 1:] + redge[:, :-1])
-    dr = redge[:, 1:] - redge[:, :-1]
+    redge = rmin[..., np.newaxis] + \
+        delta[..., np.newaxis] * np.linspace(0, nstep, nstep + 1)
+    rp = 0.5 * (redge[..., 1:] + redge[..., :-1])
+    dr = redge[..., 1:] - redge[..., :-1]
     fnv = fn(rp)
 
     r = r.reshape(r.shape + (1,))
-    saxis = 1
-
     cphi = -np.ones(dr.shape)
     m = ((rp + r) / sig < 1) | (r == 0)
 
@@ -1432,7 +1430,7 @@ def convolve2d_disk(fn, r, sig, nstep=200):
     cphi[~m] = sx[~m] / (2 * rrp[~m])
     dphi = 2 * np.arccos(cphi)
     v = rp * fnv * dphi * dr / (np.pi * sig * sig)
-    s = np.sum(v, axis=saxis)
+    s = np.sum(v, axis=-1)
 
     return s
 
@@ -1468,17 +1466,15 @@ def convolve2d_gauss(fn, r, sig, nstep=200):
     rmin[rmin < 0] = 0
     delta = (rmax - rmin) / nstep
 
-    redge = (rmin[:, np.newaxis] +
-             delta[:, np.newaxis] *
-             np.linspace(0, nstep, nstep + 1)[np.newaxis, :])
+    redge = (rmin[..., np.newaxis] +
+             delta[..., np.newaxis] *
+             np.linspace(0, nstep, nstep + 1))
 
-    rp = 0.5 * (redge[:, 1:] + redge[:, :-1])
-    dr = redge[:, 1:] - redge[:, :-1]
+    rp = 0.5 * (redge[..., 1:] + redge[..., :-1])
+    dr = redge[..., 1:] - redge[..., :-1]
     fnv = fn(rp)
 
     r = r.reshape(r.shape + (1,))
-    saxis = 1
-
     sig2 = sig * sig
     x = r * rp / (sig2)
 
@@ -1489,10 +1485,10 @@ def convolve2d_gauss(fn, r, sig, nstep=200):
         convolve2d_gauss.je_fn = UnivariateSpline(t, je, k=2, s=0)
 
     je = convolve2d_gauss.je_fn(x.flat).reshape(x.shape)
-    #    je2 = special.ive(0,x)
+    #je2 = special.ive(0,x)
     v = (rp * fnv / (sig2) * je * np.exp(x - (r * r + rp * rp) /
                                          (2 * sig2)) * dr)
-    s = np.sum(v, axis=saxis)
+    s = np.sum(v, axis=-1)
 
     return s
 


### PR DESCRIPTION
This PR implements support in the `fermipy-flux-sensitivity` script for calculating flux thresholds for extended sources (Disk or Gaussian).  Size and spatial morphology are set with the `spatial_size` and `spatial_model` parameters.  The calculation will still be performed for a PointSource morphology by default.