### PR TITLE
Lightcurve Development

### DIFF
--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -44,6 +44,9 @@ ENERGY_FLUX_UNIT = ':math:`\mathrm{MeV}~\mathrm{cm}^{-2}~\mathrm{s}^{-1}`'
 
 # Options that are common to several sections
 common = {
+    'multithread': (False, 'Split the calculation across number of processes set by nthread option.', bool),
+    'nthread': (None, 'Number of processes to create when multithread is True.  If None then one process '
+                 'will be created for each available core.', int),    
     'model': (None, 'Dictionary defining the spatial/spectral properties of the test source. '
               'If model is None the test source will be a PointSource with an Index 2 power-law spectrum.', dict),
     'free_background': (False, 'Leave background parameters free when performing the fit. If True then any '
@@ -215,6 +218,7 @@ fileio = {
 }
 
 logging = {
+    'prefix': ('', 'Prefix that will be appended to the logger name.', str),
     'chatter': (3, 'Set the chatter parameter of the STs.', int),
     'verbosity': (3, '', int)
 }
@@ -291,7 +295,8 @@ tsmap = {
     'model': common['model'],
     'exclude': (None, 'List of sources that will be removed from the model when '
                 'computing the TS map.', list),
-    'multithread': (False, 'Split the calculation across all available cores.', bool),
+    'multithread': common['multithread'],
+    'nthread': common['nthread'],
     'max_kernel_radius': (3.0, 'Set the maximum radius of the test source kernel.  Using a '
                           'smaller value will speed up the TS calculation at the loss of '
                           'accuracy.', float),
@@ -340,7 +345,8 @@ sourcefind = {
                          'iteration.', int),
     'tsmap_fitter': ('tsmap', 'Set the method for generating the TS map.  Valid options are tsmap or tscube.', str),
     'free_params': (None, '', list),
-    'multithread': (False, 'Split the calculation across all available cores.', bool),
+    'multithread': common['multithread'],
+    'nthread': common['nthread'],
 }
 
 # Options for lightcurve analysis
@@ -365,7 +371,8 @@ lightcurve = {
     'make_plots': common['make_plots'],
     'write_fits': common['write_fits'],
     'write_npy': common['write_npy'],
-    'multithread': (False, 'Split the calculation across all available cores.', bool),
+    'multithread': common['multithread'],
+    'nthread': common['nthread'],
     'systematic': (0.02, 'Systematic correction factor for TS:subscript:`var`. See Sect. 3.6 in 2FGL for details.', float),
 }
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -277,7 +277,9 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             self.config['fileio']['logfile'] = os.path.join(self.outdir,
                                                             'fermipy.log')
 
-        Logger.configure(self.__class__.__name__,
+        self._logger_name = self.config['logging']['prefix'] + \
+            self.__class__.__name__
+        Logger.configure(self._logger_name,
                          self.config['fileio']['logfile'],
                          log_level(self.config['logging']['verbosity']))
 
@@ -422,7 +424,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
     @property
     def logger(self):
         """Return the default loglevel."""
-        return logging.getLogger(self.__class__.__name__)
+        return logging.getLogger(self._logger_name)
 
     @property
     def loglevel(self):
@@ -4001,9 +4003,10 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         super(GTBinnedAnalysis, self).__init__(config, **kwargs)
 
         self._projtype = self.config['binning']['projtype']
+        self._logger_name = self.config['logging']['prefix'] + \
+            self.__class__.__name__
 
-        Logger.configure(self.__class__.__name__,
-                         self.config['fileio']['logfile'],
+        Logger.configure(self._logger_name, self.config['fileio']['logfile'],
                          log_level(self.config['logging']['verbosity']))
 
         self._roi = roi
@@ -4184,7 +4187,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
     @property
     def logger(self):
         """Return the default loglevel."""
-        return logging.getLogger(self.__class__.__name__)
+        return logging.getLogger(self._logger_name)
 
     @property
     def loglevel(self):
@@ -5045,7 +5048,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
             hdu.header['EXPSCALE'] = (scale,
                                       'Exposure correction applied to this map')
 
-        srcmap.writeto(self.files['srcmap'], clobber=True)
+        srcmap.writeto(self.files['srcmap'], overwrite=True)
         srcmap.close()
 
         # Force reloading the map from disk

--- a/fermipy/lightcurve.py
+++ b/fermipy/lightcurve.py
@@ -140,10 +140,11 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
         return {}
 
     # Recompute source map for source of interest and sources within 3 deg
-    names = [s.name for s in
-             gta.roi.get_sources(distance=3.0, skydir=gta.roi[name].skydir)
-             if not s.diffuse]
-    gta.reload_sources(names)
+    if gta.config['gtlike']['use_scaled_srcmap']:
+        names = [s.name for s in
+                 gta.roi.get_sources(distance=3.0, skydir=gta.roi[name].skydir)
+                 if not s.diffuse]
+        gta.reload_sources(names)
 
     # Write the current model
     gta.write_xml(xmlfile)

--- a/fermipy/lightcurve.py
+++ b/fermipy/lightcurve.py
@@ -115,6 +115,9 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
     # create output directories labeled in MET vals
     outdir = basedir + 'lightcurve_%.0f_%.0f' % (time[0], time[1])
     config['fileio']['outdir'] = os.path.join(workdir, outdir)
+    config['logging']['prefix'] = 'lightcurve_%.0f_%.0f ' % (time[0], time[1])
+    config['fileio']['logfile'] = os.path.join(config['fileio']['outdir'],
+                                               'fermipy.log')
     utils.mkdir(config['fileio']['outdir'])
 
     yaml.dump(utils.tolist(config),
@@ -135,6 +138,12 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
         print(sys.exc_info()[0])
         raise
         return {}
+
+    # Recompute source map for source of interest and sources within 3 deg
+    names = [s.name for s in
+             gta.roi.get_sources(distance=3.0, skydir=gta.roi[name].skydir)
+             if not s.diffuse]
+    gta.reload_sources(names)
 
     # Write the current model
     gta.write_xml(xmlfile)
@@ -158,6 +167,8 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
     o = {'flux_const': const_srcmodel['flux'],
          'loglike_const': const_fit_results['loglike'],
          'fit_success': fit_results['fit_success'],
+         'fit_quality': fit_results['fit_quality'],
+         'fit_status': fit_results['fit_status'],
          'config': config}
 
     if fit_results['fit_success'] == 1:
@@ -167,7 +178,6 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
             o[k] = srcmodel[k]
 
     gta.logger.info('Finished time range %i %i' % (time[0], time[1]))
-
     return o
 
 
@@ -279,6 +289,9 @@ class LightCurve(object):
         o['tmin_mjd'] = utils.met_to_mjd(o['tmin'])
         o['tmax_mjd'] = utils.met_to_mjd(o['tmax'])
         o['loglike_const'] = np.nan * np.ones(o['tmin'].shape)
+        o['fit_success'] = np.zeros(o['tmin'].shape, dtype=bool)
+        o['fit_status'] = np.zeros(o['tmin'].shape, dtype=int)
+        o['fit_quality'] = np.zeros(o['tmin'].shape, dtype=int)
 
         for k, v in defaults.source_flux_output.items():
 
@@ -330,6 +343,7 @@ class LightCurve(object):
         config['ltcube']['use_local_ltcube'] = kwargs['use_local_ltcube']
         config['gtlike']['use_scaled_srcmap'] = kwargs['use_scaled_srcmap']
         config['model']['diffuse_dir'] = [self.workdir]
+        config['selection']['filter'] = None
         if config['components'] is None:
             config['components'] = []
         for j, c in enumerate(self.components):
@@ -350,15 +364,17 @@ class LightCurve(object):
                                  {'data': data_cfg, 'gtlike': gtlike_cfg},
                                  add_new_keys=True)
 
+            config.setdefault('selection', {})
+            config['selection']['filter'] = None
+
         outdir = kwargs.get('outdir', None)
         basedir = outdir + '/' if outdir is not None else ''
-        mt = kwargs.get('multithread', False)
         wrap = partial(_process_lc_bin, name=name, config=config,
                        basedir=basedir, workdir=self.workdir, diff_sources=diff_sources,
                        const_spectrum=const_spectrum, roi=self.roi, **kwargs)
         itimes = enumerate(zip(times[:-1], times[1:]))
-        if mt:
-            p = Pool()
+        if kwargs.get('multithread', False):
+            p = Pool(processes=kwargs.get('nthread', None))
             mapo = p.map(wrap, itimes)
             p.close()
         else:

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -216,6 +216,8 @@ class LTCube(HpxMap):
         hpx = HPX.create_from_header(hdulist['EXPOSURE'].header, cth_edges)
         #header = dict(hdulist['EXPOSURE'].header)
         tab_gti = Table.read(ltfile, 'GTI')
+        hdulist.close()
+
         return cls(data[:, ::-1].T, hpx, cth_edges,
                    tstart=tstart, tstop=tstop,
                    zmin=zmin, zmax=zmax, tab_gti=tab_gti,
@@ -279,9 +281,9 @@ class LTCube(HpxMap):
 
         ltc = LTCube.create_from_fits(ltfile)
         self.load(ltc)
-        
+
     def load(self, ltc):
-        
+
         self._counts += ltc.data
 
         if self._tstart is not None:
@@ -293,7 +295,7 @@ class LTCube(HpxMap):
             self._tstop = max(self.tstop, ltc.tstop)
         else:
             self._tstop = ltc.tstop
-            
+
     def get_skydir_lthist(self, skydir, cth_bins):
         """Get the livetime distribution (observing profile) for a given sky
         direction with binning in incidence angle defined by
@@ -417,5 +419,5 @@ class LTCube(HpxMap):
             hdu.header['TSTART'] = self.tstart
             hdu.header['TSTOP'] = self.tstop
 
-        hdulist = fits.HDUList(hdus)
-        hdulist.writeto(outfile, clobber=True)
+        with fits.HDUList(hdus) as hdulist:
+            hdulist.writeto(outfile, overwrite=True)

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.ndimage import map_coordinates
 from scipy.ndimage.interpolation import spline_filter
 from scipy.ndimage.interpolation import shift
-import astropy.io.fits as pyfits
+from astropy.io import fits
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 
@@ -297,18 +297,18 @@ def make_cgauss_mapcube(skydir, psf, sigma, outfile, npix=500, cdelt=0.01,
     w.wcs.cdelt[2] = energies[1] - energies[0]
     w.wcs.ctype[2] = 'Energy'
 
-    ecol = pyfits.Column(name='Energy', format='D', array=10 ** energies)
-    hdu_energies = pyfits.BinTableHDU.from_columns([ecol], name='ENERGIES')
+    ecol = fits.Column(name='Energy', format='D', array=10 ** energies)
+    hdu_energies = fits.BinTableHDU.from_columns([ecol], name='ENERGIES')
 
-    hdu_image = pyfits.PrimaryHDU(np.zeros((nebin, npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((nebin, npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[...] = k
 
     hdu_image.header['CUNIT3'] = 'MeV'
 
-    hdulist = pyfits.HDUList([hdu_image, hdu_energies])
-    hdulist.writeto(outfile, clobber=True)
+    with fits.HDUList([hdu_image, hdu_energies]) as hdulist:
+        hdulist.writeto(outfile, overwrite=True)
 
 
 def make_psf_mapcube(skydir, psf, outfile, npix=500, cdelt=0.01, rebin=1):
@@ -327,18 +327,18 @@ def make_psf_mapcube(skydir, psf, outfile, npix=500, cdelt=0.01, rebin=1):
     w.wcs.cdelt[2] = energies[1] - energies[0]
     w.wcs.ctype[2] = 'Energy'
 
-    ecol = pyfits.Column(name='Energy', format='D', array=10 ** energies)
-    hdu_energies = pyfits.BinTableHDU.from_columns([ecol], name='ENERGIES')
+    ecol = fits.Column(name='Energy', format='D', array=10 ** energies)
+    hdu_energies = fits.BinTableHDU.from_columns([ecol], name='ENERGIES')
 
-    hdu_image = pyfits.PrimaryHDU(np.zeros((nebin, npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((nebin, npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[...] = k
 
     hdu_image.header['CUNIT3'] = 'MeV'
 
-    hdulist = pyfits.HDUList([hdu_image, hdu_energies])
-    hdulist.writeto(outfile, clobber=True)
+    with fits.HDUList([hdu_image, hdu_energies]) as hdulist:
+        hdulist.writeto(outfile, overwrite=True)
 
 
 def make_gaussian_spatial_map(skydir, sigma, outfile, cdelt=None, npix=None):
@@ -350,13 +350,13 @@ def make_gaussian_spatial_map(skydir, sigma, outfile, cdelt=None, npix=None):
         npix = int(np.ceil((6.0 * (sigma + cdelt)) / cdelt))
 
     w = wcs_utils.create_wcs(skydir, cdelt=cdelt, crpix=npix / 2. + 0.5)
-    hdu_image = pyfits.PrimaryHDU(np.zeros((npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[:, :] = utils.make_gaussian_kernel(sigma, npix=npix,
                                                       cdelt=cdelt)
-    hdulist = pyfits.HDUList([hdu_image])
-    hdulist.writeto(outfile, clobber=True)
+    with fits.HDUList([hdu_image]) as hdulist:
+        hdulist.writeto(outfile, overwrite=True)
 
 
 def make_disk_spatial_map(skydir, radius, outfile, cdelt=None, npix=None):
@@ -368,13 +368,13 @@ def make_disk_spatial_map(skydir, radius, outfile, cdelt=None, npix=None):
         npix = int(np.ceil((2.0 * (radius + cdelt)) / cdelt))
 
     w = wcs_utils.create_wcs(skydir, cdelt=cdelt, crpix=npix / 2. + 0.5)
-    hdu_image = pyfits.PrimaryHDU(np.zeros((npix, npix)),
-                                  header=w.to_header())
+    hdu_image = fits.PrimaryHDU(np.zeros((npix, npix)),
+                                header=w.to_header())
 
     hdu_image.data[:, :] = utils.make_disk_kernel(radius, npix=npix,
                                                   cdelt=cdelt)
-    hdulist = pyfits.HDUList([hdu_image])
-    hdulist.writeto(outfile, clobber=True)
+    with fits.HDUList([hdu_image]) as hdulist:
+        hdulist.writeto(outfile, overwrite=True)
 
 
 def delete_source_map(srcmap_file, names, logger=None):
@@ -389,39 +389,40 @@ def delete_source_map(srcmap_file, names, logger=None):
        List of HDU keys of source maps to be deleted.
 
     """
-    hdulist = pyfits.open(srcmap_file)
-    hdunames = [hdu.name.upper() for hdu in hdulist]
+    with fits.open(srcmap_file) as hdulist:
+        hdunames = [hdu.name.upper() for hdu in hdulist]
 
-    if not isinstance(names, list):
-        names = [names]
+        if not isinstance(names, list):
+            names = [names]
 
-    for name in names:
-        if not name.upper() in hdunames:
-            continue
-        del hdulist[name.upper()]
+        for name in names:
+            if not name.upper() in hdunames:
+                continue
+            del hdulist[name.upper()]
 
-    hdulist.writeto(srcmap_file, clobber=True)
+        hdulist.writeto(srcmap_file, overwrite=True)
 
 
 def update_source_maps(srcmap_file, srcmaps, logger=None):
-    hdulist = pyfits.open(srcmap_file)
-    hdunames = [hdu.name.upper() for hdu in hdulist]
 
-    for name, data in srcmaps.items():
+    with fits.open(srcmap_file) as hdulist:
+        hdunames = [hdu.name.upper() for hdu in hdulist]
 
-        if not name.upper() in hdunames:
+        for name, data in srcmaps.items():
 
-            for hdu in hdulist[1:]:
-                if hdu.header['XTENSION'] == 'IMAGE':
-                    break
+            if not name.upper() in hdunames:
 
-            newhdu = pyfits.ImageHDU(data, hdu.header, name=name)
-            newhdu.header['EXTNAME'] = name
-            hdulist.append(newhdu)
+                for hdu in hdulist[1:]:
+                    if hdu.header['XTENSION'] == 'IMAGE':
+                        break
 
-        if logger is not None:
-            logger.debug('Updating source map for %s' % name)
+                newhdu = fits.ImageHDU(data, hdu.header, name=name)
+                newhdu.header['EXTNAME'] = name
+                hdulist.append(newhdu)
 
-        hdulist[name].data[...] = data
+            if logger is not None:
+                logger.debug('Updating source map for %s' % name)
 
-    hdulist.writeto(srcmap_file, clobber=True)
+            hdulist[name].data[...] = data
+
+        hdulist.writeto(srcmap_file, overwrite=True)


### PR DESCRIPTION
This PR makes a few improvements to the lightcurve method:
- Forces recalculation of source maps for all sources within a given distance of the source of interest.  This should help improve accuracy when running with `use_scaled_srcmap=True`.
- Adds an `nthread` option which can be used to set the number of processes created when running with `multithread=True`.
- Adds columns to lightcurve output file for fit status/quality.
- Redirects logging output to separate files for each lightcurve bin.