### PR TITLE
Lightcurve Improvements

### DIFF
--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -157,7 +157,8 @@ gtlike = {
     'bexpmap': (None, '', str),
     'bexpmap_roi': (None, '', str),
     'srcmap_base': (None, 'Set the baseline source maps file.  This will be used to generate a scaled source map.', str),
-    'bexpmap_roi_base': (None, 'Set the basline expoure map file.  This will be used to generate a scaled source map.', str),    
+    'bexpmap_base': (None, 'Set the basline all-sky expoure map file.  This will be used to generate a scaled source map.', str),    
+    'bexpmap_roi_base': (None, 'Set the basline ROI expoure map file.  This will be used to generate a scaled source map.', str),    
     'use_external_srcmap': (False, 'Use an external precomputed source map file.', bool),
     'use_scaled_srcmap': (False, 'Generate source map by scaling an external srcmap file.', bool),
     'wmap': (None, 'Likelihood weights map.', str),
@@ -358,6 +359,10 @@ lightcurve = {
     'save_bin_data': (True, 'Save analysis directories for individual time bins.  If False then only '
                       'the analysis results table will be saved.', bool),    
     'binsz': (86400.0, 'Set the lightcurve bin size in seconds.', float),
+    'shape_ts_threshold': (16.0, 'Set the TS threshold at which shape parameters of '
+                           'sources will be freed.  If a source is detected with TS less than this '
+                           'value then its shape parameters will be fixed to values derived from the '
+                           'analysis of the full time range.', float),
     'nbins': (None, 'Set the number of lightcurve bins.  The total time range will be evenly '
               'split into this number of time bins.', int),
     'time_bins': (None, 'Set the lightcurve bin edge sequence in MET.  This option '

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -312,18 +312,19 @@ def test_gtanalysis_lightcurve(create_pg1553_analysis):
     o = gta.lightcurve('3FGL J1555.7+1111', nbins=2,
                        free_radius=3.0)
 
-    flux = np.array([2.91756869996e-08,
-                     2.36889996939e-08])
-    flux_err = np.array([1.93194096609e-09,
-                         1.82269439301e-09])
-    ts = np.array([1463.06618532,
-                   1123.16013115])
+    rtol = 0.01    
+    flux = np.array([2.917568e-08,
+                     2.359114e-08])
+    flux_err = np.array([1.931940e-09,
+                         1.822694e-09])
+    ts = np.array([1463.066,
+                   1123.160])
 
-    assert_allclose(o['flux'], flux, rtol=1E-3)
-    assert_allclose(o['flux_err'], flux_err, rtol=1E-3)
-    assert_allclose(o['ts'], ts, rtol=1E-3)
+    assert_allclose(o['flux'], flux, rtol=rtol)
+    assert_allclose(o['flux_err'], flux_err, rtol=rtol)
+    assert_allclose(o['ts'], ts, rtol=rtol)
 
     tab = Table.read(os.path.join(gta.workdir, o['file']))
-    assert_allclose(tab['flux'], flux, rtol=1E-3)
-    assert_allclose(tab['flux_err'], flux_err, rtol=1E-3)
-    assert_allclose(tab['ts'], ts, rtol=1E-3)
+    assert_allclose(tab['flux'], flux, rtol=rtol)
+    assert_allclose(tab['flux_err'], flux_err, rtol=rtol)
+    assert_allclose(tab['ts'], ts, rtol=rtol)


### PR DESCRIPTION
This PR includes some bug fixes and improvements for the lightcurve method:
* Fixes a bug in the implementation of the source map scaling.  Now uses the all-sky exposure map to derive scaling ratio for sources outside the ROI.
* Changes the logic for freeing parameters when fitting a time bin.  Shape parameters are only freed  if TS > `shape_ts_threshold`.
