### PR TITLE
implemented phibin > 0 support for ltcube calculation

### DIFF
--- a/fermipy/defaults.py
+++ b/fermipy/defaults.py
@@ -172,6 +172,7 @@ gtlike = {
 # Options for generating livetime cubes
 ltcube = {
     'binsz': (1.0, 'Set the angular bin size for generating livetime cubes.', float),
+    'phibins': (0, 'Set the number of phi bins for generating livetime cubes.', int),
     'dcostheta': (0.025, 'Set the inclination angle binning represented as the cosine of the off-axis angle.', float),
     'use_local_ltcube': (False, 'Generate a livetime cube in the vicinity of the ROI using interpolation. '
                          'This option disables LT cube generation with gtltcube.', bool),

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4854,6 +4854,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                   outfile=self.files['ltcube'],
                   binsz=self.config['ltcube']['binsz'],
                   dcostheta=self.config['ltcube']['dcostheta'],
+                  phibins=self.config['ltcube']['phibins'],
                   zmax=self.config['selection']['zmax'])
 
         if self.config['ltcube']['use_local_ltcube']:

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -201,6 +201,18 @@ class LTCube(HpxMap):
         hdulist = fits.open(ltfile)
         data = hdulist['EXPOSURE'].data.field('COSBINS')
         data_wt = hdulist['WEIGHTED_EXPOSURE'].data.field('COSBINS')
+	if hdulist['EXPOSURE'].header['PHIBINS'] > 0:
+	    data = data[:,:hdulist['EXPOSURE'].header['NBRBINS']]
+	    # first phibin is the same as phibin = 0 or sum of phibin 1:n
+	    # data = reshape(data.shape[0],
+		     #hdulist["EXPOSURE"].header["PHIBINS"]+1,
+		     #hdulist["EXPOSURE"].header["NBRBINS"])
+	if hdulist['WEIGHTED_EXPOSURE'].header['PHIBINS'] > 0:
+	    data_wt = data[:,:hdulist['WEIGHTED_EXPOSURE'].header['NBRBINS']]
+	    # first phibin is the same as phibin = 0 or sum of phibin 1:n
+	    # data_wt = reshape(data_wt.shape[0],
+		     #hdulist["WEIGHTED_EXPOSURE"].header["PHIBINS"]+1,
+		     #hdulist["WEIGHTED_EXPOSURE"].header["NBRBINS"])
         data = data.astype(float)
         data_wt = data_wt.astype(float)
         tstart = hdulist[0].header['TSTART']
@@ -321,6 +333,7 @@ class LTCube(HpxMap):
         width = edge_to_width(bins)
         ipix = hp.ang2pix(self.hpx.nside, np.pi / 2. - np.radians(dec),
                           np.radians(ra), nest=self.hpx.nest)
+
         lt = np.histogram(self._cth_center,
                           weights=self.data[:, ipix], bins=bins)[0]
         lt = np.sum(lt.reshape(-1, npts), axis=1)

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -201,18 +201,18 @@ class LTCube(HpxMap):
         hdulist = fits.open(ltfile)
         data = hdulist['EXPOSURE'].data.field('COSBINS')
         data_wt = hdulist['WEIGHTED_EXPOSURE'].data.field('COSBINS')
-	if hdulist['EXPOSURE'].header['PHIBINS'] > 0:
-	    data = data[:,:hdulist['EXPOSURE'].header['NBRBINS']]
-	    # first phibin is the same as phibin = 0 or sum of phibin 1:n
-	    # data = reshape(data.shape[0],
-		     #hdulist["EXPOSURE"].header["PHIBINS"]+1,
-		     #hdulist["EXPOSURE"].header["NBRBINS"])
-	if hdulist['WEIGHTED_EXPOSURE'].header['PHIBINS'] > 0:
-	    data_wt = data[:,:hdulist['WEIGHTED_EXPOSURE'].header['NBRBINS']]
-	    # first phibin is the same as phibin = 0 or sum of phibin 1:n
-	    # data_wt = reshape(data_wt.shape[0],
-		     #hdulist["WEIGHTED_EXPOSURE"].header["PHIBINS"]+1,
-		     #hdulist["WEIGHTED_EXPOSURE"].header["NBRBINS"])
+        if hdulist['EXPOSURE'].header['PHIBINS'] > 0:
+            data = data[:,:hdulist['EXPOSURE'].header['NBRBINS']]
+            # first phibin is the same as phibin = 0 or sum of phibin 1:n
+            # data = reshape(data.shape[0],
+            #hdulist["EXPOSURE"].header["PHIBINS"]+1,
+            #hdulist["EXPOSURE"].header["NBRBINS"])
+        if hdulist['WEIGHTED_EXPOSURE'].header['PHIBINS'] > 0:
+            data_wt = data[:,:hdulist['WEIGHTED_EXPOSURE'].header['NBRBINS']]
+            # first phibin is the same as phibin = 0 or sum of phibin 1:n
+            # data_wt = reshape(data_wt.shape[0],
+            #hdulist["WEIGHTED_EXPOSURE"].header["PHIBINS"]+1,
+            #hdulist["WEIGHTED_EXPOSURE"].header["NBRBINS"])
         data = data.astype(float)
         data_wt = data_wt.astype(float)
         tstart = hdulist[0].header['TSTART']
@@ -333,7 +333,6 @@ class LTCube(HpxMap):
         width = edge_to_width(bins)
         ipix = hp.ang2pix(self.hpx.nside, np.pi / 2. - np.radians(dec),
                           np.radians(ra), nest=self.hpx.nest)
-
         lt = np.histogram(self._cth_center,
                           weights=self.data[:, ipix], bins=bins)[0]
         lt = np.sum(lt.reshape(-1, npts), axis=1)


### PR DESCRIPTION
For lifetime cube calculation, I added the possibility to use the option to set the number of phibins. For the defaults, I added phibins = 0. 