### PR TITLE
Replace deprecated method in scipy.stats

### DIFF
--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -941,7 +941,7 @@ class CastroData_Base(object):
         ts_spec = self.TS_spectrum(spec_vals)
         chi2_vals = self.chi2_vals(spec_vals)
         chi2_spec = np.sum(chi2_vals)
-        pval_spec = stats.chisqprob(chi2_spec, len(spec_vals))
+        pval_spec = stats.distributions.chi2.sf(chi2_spec, len(spec_vals))
         return dict(params=out_pars, spec_vals=spec_vals,
                     spec_npred=spec_npred,
                     ts_spec=ts_spec, chi2_spec=chi2_spec,


### PR DESCRIPTION
The recent update to scipy 1.0.0 in the conda defaults channel is triggering test failures due to the use of a deprecated function `scipy.stats.chisqprob` in `fermipy.castro`.  This PR replaces the deprecated function with the equivalent function from `scipy.stats.distributions`.