### PR TITLE
Improve Parameter Sampling for Likelihood Scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+               CONDA_DEPS='numpy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
         # Python 3, no Fermi ST, all other dependencies
         - os: linux
@@ -48,7 +48,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false      
       - PIP_DEPS='coverage pytest-cov coveralls'
-      - CONDA2='conda install -y -c conda-forge healpy wcsaxes'
+      - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies
@@ -39,7 +39,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
         # Python 3, no Fermi ST, all other dependencies
         - os: linux
@@ -48,7 +48,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
@@ -57,7 +57,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
 
         # Python 2, SLAC ST 11-05-02, all other dependencies
         - os: linux
@@ -67,7 +67,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-05-02-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
         

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies
@@ -39,7 +39,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
         # Python 3, no Fermi ST, all other dependencies
         - os: linux
@@ -48,7 +48,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
@@ -57,7 +57,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, SLAC ST 11-05-02, all other dependencies
         - os: linux
@@ -67,7 +67,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-05-02-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
         

--- a/condainstall.sh
+++ b/condainstall.sh
@@ -15,7 +15,7 @@ if [[ -z $CONDA_DOWNLOAD ]]; then
 fi
 
 if [[ -z $CONDA_DEPS ]]; then
-    CONDA_DEPS='scipy matplotlib pyyaml ipython'
+    CONDA_DEPS='scipy matplotlib pyyaml ipython numpy==1.13.3'
 fi
 
 if [[ -z $CONDA2 ]]; then

--- a/condainstall.sh
+++ b/condainstall.sh
@@ -15,7 +15,7 @@ if [[ -z $CONDA_DOWNLOAD ]]; then
 fi
 
 if [[ -z $CONDA_DEPS ]]; then
-    CONDA_DEPS='scipy matplotlib pyyaml ipython numpy==1.13.3'
+    CONDA_DEPS='scipy matplotlib pyyaml ipython numpy'
 fi
 
 if [[ -z $CONDA2 ]]; then

--- a/condainstall.sh
+++ b/condainstall.sh
@@ -15,7 +15,7 @@ if [[ -z $CONDA_DOWNLOAD ]]; then
 fi
 
 if [[ -z $CONDA_DEPS ]]; then
-    CONDA_DEPS='scipy matplotlib pyyaml ipython numpy'
+    CONDA_DEPS='scipy matplotlib pyyaml ipython numpy astropy'
 fi
 
 if [[ -z $CONDA2 ]]; then
@@ -46,7 +46,7 @@ export PATH="$CONDA_PATH/bin:$PATH"
 conda update -q conda -y
 conda config --append channels conda-forge
 conda info -a
-conda install -y python=$PYTHON_VERSION pip numpy astropy pytest $CONDA_DEPS
+conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS
 
 if [[ -n $CONDA2 ]]; then
     $CONDA2

--- a/docker/centos6-11-05-02-python/Dockerfile
+++ b/docker/centos6-11-05-02-python/Dockerfile
@@ -2,15 +2,15 @@ FROM fermipy/fermist:11-05-02
 MAINTAINER Matthew Wood <mdwood@slac.stanford.edu>
 ARG PYTHON_VERSION=2.7
 ARG CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-ARG CONDA_DEPS="scipy matplotlib pyyaml ipython jupyter pandas"
-ARG CONDA_DEPS_EXTRA="wcsaxes healpy subprocess32"
+ARG CONDA_DEPS="numpy astropy scipy matplotlib pyyaml ipython jupyter pandas"
+ARG CONDA_DEPS_EXTRA="healpy subprocess32"
 ARG PIP_DEPS=""
 ENV PATH /opt/conda/bin:$PATH
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -o miniconda.sh -L http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD && \
     /bin/bash miniconda.sh -b -p /opt/conda && \
     rm miniconda.sh && conda update -y conda && conda config --append channels conda-forge 
-RUN conda install -y python=$PYTHON_VERSION pip numpy astropy pytest $CONDA_DEPS && \
+RUN conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS && \
     conda install -y $CONDA_DEPS_EXTRA && \
     if [[ -n $PIP_DEPS ]]; then pip install $PIP_DEPS; fi
 RUN conda install -y fermipy

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -669,8 +669,8 @@ class SEDPlotter(object):
     @staticmethod
     def get_ylims(sed):
 
-        fmin = np.log10(np.min(sed['e2dnde_ul95'])) - 0.5
-        fmax = np.log10(np.max(sed['e2dnde_ul95'])) + 0.5
+        fmin = np.log10(np.nanmin(sed['e2dnde_ul95'])) - 0.5
+        fmax = np.log10(np.nanmax(sed['e2dnde_ul95'])) + 0.5
         fdelta = fmax - fmin
         if fdelta < 2.0:
             fmin -= 0.5 * (2.0 - fdelta)


### PR DESCRIPTION
This PR makes some small improvements to the logic for generating parameter sequences for likelihood scans.  Now explicitly evaluates differences in log-likelihood values against the largest value obtained in the scan.  Avoids errors that were occurring when the initial parameter value was not at the peak of the likelihood function (e.g. due to fit convergence issues).  Also pinned numpy version to 1.13.3 to resolve python 2 test errors.