### PR TITLE
Bug fix for ROI plotting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
       - PIP_DEPS='coverage pytest-cov coveralls'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
+      - CONDA_CHANNELS=conda-forge
 
 matrix:
     include:
@@ -41,10 +42,19 @@ matrix:
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
-        # Python 3, no Fermi ST, all other dependencies
+        # Python 3.5, no Fermi ST, all other dependencies
         - os: linux
-          env: NAME=py3_st-no_dep-yes
+          env: NAME=py35_st-no_dep-yes
                PYTHON_VERSION=3.5
+               ST_INSTALL=''
+               DOCKER_INSTALL=''
+               CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
+               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml'
+
+        # Python 3.6, no Fermi ST, all other dependencies
+        - os: linux
+          env: NAME=py36_st-no_dep-yes
+               PYTHON_VERSION=3.6
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh

--- a/condainstall.sh
+++ b/condainstall.sh
@@ -44,7 +44,7 @@ fi
 export PATH="$CONDA_PATH/bin:$PATH"
 
 conda update -q conda -y
-conda config --append channels conda-forge
+conda config --add channels conda-forge
 conda info -a
 conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS
 

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -84,7 +84,7 @@ def row_to_dict(row):
     o = {}
     for colname in row.colnames:
 
-        if row[colname].dtype.kind in ['S', 'U']:
+        if isinstance(row[colname], np.string_) and row[colname].dtype.kind in ['S', 'U']:
             o[colname] = str(row[colname])
         else:
             o[colname] = row[colname]

--- a/fermipy/diffuse/catalog_src_manager.py
+++ b/fermipy/diffuse/catalog_src_manager.py
@@ -223,7 +223,7 @@ class CatalogSourceManager(object):
 
                 try:
                     all_sources = [x.strip() for x in full_cat_info.catalog_table[
-                            'Source_Name'].tolist()]
+                            'Source_Name'].astype(str).tolist()]
                 except KeyError:
                     print(full_cat_info.catalog_table.colnames)
                 used_sources = []

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -1261,7 +1261,6 @@ class AnalysisPlotter(fermipy.config.Configurable):
         if p.projtype == "WCS":
             model_data = mcube_map.counts.T
             diffuse_data = mcube_diffuse.counts.T
-            weight_data = wmap.counts.T
             xmin = -1
             xmax = 1
         elif p.projtype == "HPX":

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -371,7 +371,6 @@ class Map(Map_Base):
         else:
             if egy is None:
                 egy = self._ectr
-            print ('xx', lat, lon, egy, self.npix)
             pixcrd = self.wcs.wcs_world2pix(lon, lat, egy, 0)
             pixcrd[2] = np.array(utils.val_to_pix(np.log(self._ectr),
                                                   np.log(egy)), ndmin=1)

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -85,7 +85,7 @@ def test_print_params(create_draco_analysis):
 
 def test_gtanalysis_write_roi(create_draco_analysis):
     gta = create_draco_analysis
-    gta.write_roi('test')
+    gta.write_roi('test', make_plots=True)
 
 
 def test_gtanalysis_load_roi(create_draco_analysis):

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -232,8 +232,8 @@ def find_rows_by_string(tab, names, colnames=['assoc']):
             continue
 
         col = tab[[colname]].copy()
-        col[colname] = defchararray.replace(defchararray.lower(col[colname]),
-                                            ' ', '')
+        col[colname] = defchararray.replace(defchararray.lower(col[colname]).astype(str),
+                                        ' ', '')
         for name in names:
             mask |= col[colname] == name
     return mask


### PR DESCRIPTION
This PR resolves #189.  The ROI plotting method was referencing a weights map variable that was undefined when weighting was disabled.  Also enabled `make_plots=True` for testing `write_roi`.