### PR TITLE
Migrate to gammapy.maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS=Cython==0.26 numpy==1.13.3 astropy scipy matplotlib pytest pyyaml
+               CONDA_DEPS='Cython==0.26 numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false      
-      - PIP_DEPS='coverage pytest-cov coveralls git+http://github.com/gammapy/gammapy.git'
+      - PIP_DEPS='coverage pytest-cov coveralls'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
@@ -30,7 +30,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies
@@ -40,7 +40,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
         # Python 3.5, no Fermi ST, all other dependencies
         - os: linux
@@ -49,7 +49,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 3.6, no Fermi ST, all other dependencies
         - os: linux
@@ -67,7 +67,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, SLAC ST 11-05-03, all other dependencies
         - os: linux
@@ -77,7 +77,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-05-03-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
 
@@ -89,7 +89,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-07-00-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
         

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='Cython==0.26 numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies
@@ -40,7 +40,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
         # Python 3.5, no Fermi ST, all other dependencies
         - os: linux
@@ -49,7 +49,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 3.6, no Fermi ST, all other dependencies
         - os: linux
@@ -58,7 +58,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
@@ -67,7 +67,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, SLAC ST 11-05-03, all other dependencies
         - os: linux
@@ -77,7 +77,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-05-03-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
 
@@ -89,7 +89,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-07-00-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
         

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false      
-      - PIP_DEPS='coverage pytest-cov coveralls'
+      - PIP_DEPS='coverage pytest-cov coveralls git+http://github.com/gammapy/gammapy.git'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
       - SLAC_ST_BUILD=false      
       - PIP_DEPS='coverage pytest-cov coveralls git+http://github.com/gammapy/gammapy.git'
       - CONDA2='conda install -y -c conda-forge healpy'
-      - CONDA_DEPS='Cython==0.26'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
 
@@ -31,7 +30,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS=$CONDA_DEPS numpy==1.13.3 astropy scipy matplotlib pytest pyyaml
+               CONDA_DEPS=Cython==0.26 numpy==1.13.3 astropy scipy matplotlib pytest pyyaml
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='$CONDA_DEPS numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS=$CONDA_DEPS numpy==1.13.3 astropy scipy matplotlib pytest pyyaml
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
       - SLAC_ST_BUILD=false      
       - PIP_DEPS='coverage pytest-cov coveralls git+http://github.com/gammapy/gammapy.git'
       - CONDA2='conda install -y -c conda-forge healpy'
+      - CONDA_DEPS='Cython==0.26'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
 
@@ -30,7 +31,7 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='$CONDA_DEPS numpy==1.13.3 astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='Cython numpy astropy scipy matplotlib pytest pyyaml'
+               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -19,9 +19,8 @@ from scipy.optimize import fmin
 
 from astropy.table import Table, Column
 import astropy.units as u
+from gammapy.maps import WcsNDMap, MapAxis
 from fermipy import spectrum
-from fermipy.wcs_utils import wcs_add_energy_axis
-from fermipy.skymap import read_map_from_fits, Map
 from fermipy.sourcefind_utils import fit_error_ellipse
 from fermipy.sourcefind_utils import find_peaks
 from fermipy.spectrum import SpectralFunction, SEDFunctor
@@ -1390,17 +1389,17 @@ class TSCube(object):
 
         Parameters
         ----------
-        tsmap : `~fermipy.skymap.Map`
+        tsmap : `~gammapy.maps.WcsNDMap`
            A Map object with the TestStatistic values in each pixel
 
-        normmap : `~fermipy.skymap.Map`
+        normmap : `~gammapy.maps.WcsNDMap`
            A Map object with the normalization values in each pixel
 
-        tscube : `~fermipy.skymap.Map`
+        tscube : `~gammapy.maps.WcsNDMap`
            A Map object with the TestStatistic values in each pixel &
            energy bin
 
-        normcube : `~fermipy.skymap.Map`
+        normcube : `~gammapy.maps.WcsNDMap`
            A Map object with the normalization values in each pixel &
            energy bin
 
@@ -1430,7 +1429,7 @@ class TSCube(object):
         self._normmap = normmap
         self._tscube = tscube
         self._normcube = normcube
-        self._ts_cumul = tscube.sum_over_energy()
+        self._ts_cumul = tscube.sum_over_axes()
         self._refSpec = refSpec
         self._norm_vals = norm_vals
         self._nll_vals = nll_vals
@@ -1498,7 +1497,7 @@ class TSCube(object):
            String specifying the quantity used for the normalization
 
         """
-        tsmap = read_map_from_fits(fitsfile)
+        tsmap = WcsNDMap.read(fitsfile)
 
         tab_e = Table.read(fitsfile, 'EBOUNDS')
         tab_s = Table.read(fitsfile, 'SCANDATA')
@@ -1524,13 +1523,13 @@ class TSCube(object):
         nebins = len(tab_e)
         npred = tab_e['ref_npred']
 
-        ndim = len(tsmap.counts.shape)
+        ndim = len(tsmap.data.shape)
 
         if ndim == 2:
-            cube_shape = (tsmap.counts.shape[0],
-                          tsmap.counts.shape[1], nebins)
+            cube_shape = (tsmap.data.shape[0],
+                          tsmap.data.shape[1], nebins)
         elif ndim == 1:
-            cube_shape = (tsmap.counts.shape[0], nebins)
+            cube_shape = (tsmap.data.shape[0], nebins)
         else:
             raise RuntimeError("Counts map has dimension %i" % (ndim))
 
@@ -1538,13 +1537,16 @@ class TSCube(object):
         nll_vals = -np.array(tab_s["dloglike_scan"])
         norm_vals = np.array(tab_s["norm_scan"])
 
-        wcs_3d = wcs_add_energy_axis(tsmap.wcs, emin)
-        tscube = Map(np.rollaxis(tab_s["ts"].reshape(cube_shape), 2, 0),
-                     wcs_3d)
-        ncube = Map(np.rollaxis(tab_s["norm"].reshape(cube_shape), 2, 0),
-                    wcs_3d)
-        nmap = Map(tab_f['fit_norm'].reshape(tsmap.counts.shape),
-                   tsmap.wcs)
+        axis = MapAxis.from_edges(np.concatenate((emin, emax[-1:])),
+                                  interp='log')
+        geom_3d = tsmap.geom.to_cube([axis])
+        tscube = WcsNDMap(geom_3d,
+                          np.rollaxis(tab_s["ts"].reshape(cube_shape), 2, 0))
+
+        ncube = WcsNDMap(geom_3d,
+                         np.rollaxis(tab_s["norm"].reshape(cube_shape), 2, 0))
+        nmap = WcsNDMap(tsmap.geom,
+                        tab_f['fit_norm'].reshape(tsmap.data.shape))
 
         ref_colname = 'ref_%s' % norm_type
         norm_vals *= tab_e[ref_colname][np.newaxis, :, np.newaxis]

--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -344,7 +344,7 @@ class ExtensionFit(object):
         hdu_data.name = 'EXT_DATA'
 
         if ext.get('tsmap'):
-            hdus = [ext['tsmap'].make_hdu(extname='PRIMARY')]
+            hdus = [ext['tsmap'].make_hdu(hdu='PRIMARY')]
         else:
             hdus = [fits.PrimaryHDU()]
 

--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -337,14 +337,14 @@ class ExtensionFit(object):
         for k, v in sorted(maps.items()):
             if v is None:
                 continue
-            hdu_images += [v.create_image_hdu(k)]
+            hdu_images += [v.make_hdu(k)]
 
         tab = fits_utils.dict_to_table(ext)
         hdu_data = fits.table_to_hdu(tab)
         hdu_data.name = 'EXT_DATA'
 
         if ext.get('tsmap'):
-            hdus = [ext['tsmap'].create_primary_hdu()]
+            hdus = [ext['tsmap'].make_hdu(extname='PRIMARY')]
         else:
             hdus = [fits.PrimaryHDU()]
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -5048,9 +5048,9 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         # This is needed in case the exposure map is in HEALPix
         hpxhduname = "HPXEXPOSURES"
         try:
-            self._bexp = read_map_from_fits(self.files['bexpmap'], hpxhduname)
+            self._bexp = Map.read(self.files['bexpmap'], hdu=hpxhduname)
         except KeyError:
-            self._bexp = read_map_from_fits(self.files['bexpmap'])
+            self._bexp = Map.read(self.files['bexpmap'])
 
         # Write ROI XML
         self.roi.write_xml(self.files['srcmdl'], self.config['model'])
@@ -5544,8 +5544,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         skydir = src.skydir
         spatial_model = src['SpatialModel']
         spatial_width = src['SpatialWidth']
-        xpix, ypix = wcs_utils.skydir_to_pix(skydir, self.geom.wcs)
-        exp = self._bexp.interpolate_at_skydir(skydir)
+        xpix, ypix = self.geom.to_image().coord_to_pix(skydir)
+        exp = self._bexp.interp_by_coord((skydir,self._bexp.geom.axes[0].center))        
         rebin = min(int(np.ceil(self.binsz / 0.01)), 8)
         shape_out = (self.enumbins + 1, self.npix, self.npix)
         cache = SourceMapCache.create(self._psf, exp, spatial_model,
@@ -5561,8 +5561,8 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         skydir = src.skydir
         spatial_model = src['SpatialModel']
         spatial_width = src['SpatialWidth']
-        xpix, ypix = wcs_utils.skydir_to_pix(skydir, self.geom.wcs)
-        exp = self._bexp.interpolate_at_skydir(skydir)
+        xpix, ypix = self.geom.to_image().coord_to_pix(skydir)
+        exp = self._bexp.interp_by_coord((skydir,self._bexp.geom.axes[0].center))
         cache = self._srcmap_cache.get(name, None)
         if cache is not None:
             k = cache.create_map([ypix, xpix])

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1232,18 +1232,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         """        
         maps = [c.model_counts_map(name, exclude, use_mask=use_mask)
                 for c in self.components]
-        cmap = Map.from_geom(self.geom)
-        for m in maps:
-
-            # FIXME: This functionality could be built into the coadd method            
-            m_tmp = m
-            if isinstance(m, HpxNDMap):                
-                if m.geom.order < cmap.geom.order:
-                    factor = cmap.geom.nside//m.geom.nside
-                    m_tmp = m.upsample(factor, preserve_counts=True)
-            cmap.coadd(m_tmp)
-        
-        return cmap
+        return skymap.coadd_maps(self.geom, maps)
 
     def model_counts_spectrum(self, name, logemin=None, logemax=None,
                               summed=False, weighted=False):
@@ -3923,12 +3912,8 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
     def _coadd_maps(self, cmaps, shape, rm, wmaps):
         """
         """
-        self._ccube = Map.from_geom(self.geom)
-        for m in cmaps:
-            self._ccube.coadd(m)
-        self._wcube = Map.from_geom(self.geom)
-        for m in wmaps:
-            self._wcube.coadd(m)
+        self._ccube = skymap.coadd_maps(self.geom, cmaps)
+        self._wcube = skymap.coadd_maps(self.geom, wmaps)
         self._ccube.write(self.files['ccube'], conv='fgst-ccube')
 
         if self.projtype == "WCS":

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -1259,6 +1259,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
             cmap = WcsNDMap(self._geom)
             for m in maps:
                 cmap.coadd(m)
+            
         else:
             raise Exception(
                 "Did not recognize projection type %s", self.projtype)
@@ -3971,7 +3972,6 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
                                    axis=(1, 2), keepdims=False)
             rm['counts_wt'] += np.sum(self._ccube.data * self._wcube.data,
                                       axis=(1, 2), keepdims=False)
-
         elif self.projtype == "HPX":
             self._ccube = skymap.make_coadd_map(cmaps, self._proj, shape)
             self._wcube = skymap.make_coadd_map(
@@ -4420,7 +4420,6 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
                                         width=self.config['binning']['roiwidth'],
                                         skydir=self.roi.skydir,
                                         axes=axes)
-
             self._hpx_region = create_hpx_disk_region_string(self.roi.skydir,
                                                              self._coordsys,
                                                              0.5 * self.config['binning']['roiwidth'])

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -19,7 +19,7 @@ import numpy as np
 from scipy.stats import norm
 from scipy.stats import chi2
 from scipy import interpolate
-from gammapy.maps import WcsNDMap
+from gammapy.maps import WcsNDMap, MapCoord
 
 import fermipy
 import fermipy.config
@@ -1372,10 +1372,11 @@ class AnalysisPlotter(fermipy.config.Configurable):
         tsmap = loc['tsmap']
         fit_init = loc['fit_init']
         tsmap_renorm = copy.deepcopy(tsmap)
-        tsmap_renorm._counts -= np.max(tsmap_renorm._counts)
+        tsmap_renorm.data -= np.max(tsmap_renorm.data)
 
-        skydir = loc['tsmap_peak'].get_pixel_skydirs()
-
+        skydir = loc['tsmap_peak'].geom.get_coord(flat=True)#.get_pixel_skydirs()
+        skydir = MapCoord.create(skydir, coordsys=loc['tsmap_peak'].geom.coordsys).skycoord
+        
         path_effect = PathEffects.withStroke(linewidth=2.0,
                                              foreground="black")
 
@@ -1388,8 +1389,8 @@ class AnalysisPlotter(fermipy.config.Configurable):
                cmap=cmap, vmin=vmin, colors=['k'],
                interpolation='bicubic', cb_label='2$\\times\Delta\ln$L')
 
-        cdelt0 = np.abs(tsmap.wcs.wcs.cdelt[0])
-        cdelt1 = np.abs(tsmap.wcs.wcs.cdelt[1])
+        cdelt0 = np.abs(tsmap.geom.wcs.wcs.cdelt[0])
+        cdelt1 = np.abs(tsmap.geom.wcs.wcs.cdelt[1])
         cdelt = [cdelt0, cdelt1]
 
         peak_skydir = SkyCoord(fit_init['ra'], fit_init['dec'],
@@ -1397,8 +1398,8 @@ class AnalysisPlotter(fermipy.config.Configurable):
         scan_skydir = SkyCoord(loc['ra'], loc['dec'],
                                frame='icrs', unit='deg')
 
-        peak_pix = peak_skydir.to_pixel(tsmap_renorm.wcs)
-        scan_pix = scan_skydir.to_pixel(tsmap_renorm.wcs)
+        peak_pix = peak_skydir.to_pixel(tsmap_renorm.geom.wcs)
+        scan_pix = scan_skydir.to_pixel(tsmap_renorm.geom.wcs)
 
         if 'ra_preloc' in loc:
             preloc_skydir = SkyCoord(loc['ra_preloc'], loc['dec_preloc'],
@@ -1415,7 +1416,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
                      label='New Position')
 
         if skydir is not None:
-            pix = skydir.to_pixel(tsmap_renorm.wcs)
+            pix = skydir.to_pixel(tsmap_renorm.geom.wcs)
             xmin = np.min(pix[0])
             ymin = np.min(pix[1])
             xwidth = np.max(pix[0]) - xmin
@@ -1452,7 +1453,7 @@ class AnalysisPlotter(fermipy.config.Configurable):
 
         tsmap = loc['tsmap_peak']
         tsmap_renorm = copy.deepcopy(tsmap)
-        tsmap_renorm._counts -= np.max(tsmap_renorm._counts)
+        tsmap_renorm.data -= np.max(tsmap_renorm.data)
 
         p = ROIPlotter(tsmap_renorm, roi=roi)
         fig = plt.figure(figsize=figsize)
@@ -1463,10 +1464,10 @@ class AnalysisPlotter(fermipy.config.Configurable):
                cmap=cmap, vmin=vmin, colors=['k'],
                interpolation='bicubic', cb_label='2$\\times\Delta\ln$L')
 
-        cdelt0 = np.abs(tsmap.wcs.wcs.cdelt[0])
-        cdelt1 = np.abs(tsmap.wcs.wcs.cdelt[1])
+        cdelt0 = np.abs(tsmap.geom.wcs.wcs.cdelt[0])
+        cdelt1 = np.abs(tsmap.geom.wcs.wcs.cdelt[1])
         cdelt = [cdelt0, cdelt1]
-        scan_pix = scan_skydir.to_pixel(tsmap_renorm.wcs)
+        scan_pix = scan_skydir.to_pixel(tsmap_renorm.geom.wcs)
 
         if 'ra_preloc' in loc:
             preloc_skydir = SkyCoord(loc['ra_preloc'], loc['dec_preloc'],

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -292,7 +292,7 @@ class ResidMapGenerator(object):
             hdu_images += [v.make_hdu(k)]
 
         if data['projtype'] == 'WCS':
-            hdus = [data['sigma'].make_hdu(extname='PRIMARY')] + hdu_images
+            hdus = [data['sigma'].make_hdu(hdu='PRIMARY')] + hdu_images
             hdus[0].header['CONFIG'] = json.dumps(data['config'])
             hdus[1].header['CONFIG'] = json.dumps(data['config'])
         elif data['projtype'] == 'HPX':

--- a/fermipy/residmap.py
+++ b/fermipy/residmap.py
@@ -332,7 +332,7 @@ class ResidMapGenerator(object):
                       np.round((self.npix - 1.0) / 2.))
         cpix = np.array([xpix, ypix])
 
-        skywcs = self._skywcs
+        skywcs = self.geom.wcs
         skydir = wcs_utils.pix_to_skydir(cpix[0], cpix[1], skywcs)
 
         if src_dict is None:

--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -894,12 +894,12 @@ class Source(Model):
         self['offset_glon'] = offset_gal[0, 0]
         self['offset_glat'] = offset_gal[0, 1]
 
-    def set_roi_projection(self, proj):
+    def set_roi_geom(self, geom):
 
-        if proj is None:
+        if geom is None:
             return
 
-        self['offset_roi_edge'] = proj.distance_to_edge(self.skydir)
+        self['offset_roi_edge'] = float(wcs_utils.distance_to_edge(geom, self.skydir))
 
     def set_spatial_model(self, spatial_model, spatial_pars):
 
@@ -1304,7 +1304,7 @@ class ROIModel(fermipy.config.Configurable):
     def __init__(self, config=None, **kwargs):
         # Coordinate for ROI center (defaults to 0,0)
         self._skydir = kwargs.pop('skydir', SkyCoord(0.0, 0.0, unit=u.deg))
-        self._projection = kwargs.get('projection', None)
+        self._geom = kwargs.get('geom', None)
         coordsys = kwargs.pop('coordsys', 'CEL')
         srcname = kwargs.pop('srcname', None)
         super(ROIModel, self).__init__(config, **kwargs)
@@ -1366,8 +1366,8 @@ class ROIModel(fermipy.config.Configurable):
         return self._skydir
 
     @property
-    def projection(self):
-        return self._projection
+    def geom(self):
+        return self._geom
 
     @property
     def sources(self):
@@ -1390,10 +1390,10 @@ class ROIModel(fermipy.config.Configurable):
         else:
             return extdir
 
-    def set_projection(self, proj):
-        self._projection = proj
+    def set_geom(self, geom):
+        self._geom = geom
         for s in self._srcs:
-            s.set_roi_projection(proj)
+            s.set_roi_geom(geom)
 
     def clear(self):
         """Clear the contents of the ROI."""
@@ -1512,7 +1512,7 @@ class ROIModel(fermipy.config.Configurable):
 
         if isinstance(src, Source):
             src.set_roi_direction(self.skydir)
-            src.set_roi_projection(self.projection)
+            src.set_roi_geom(self.geom)
 
         self.load_source(src, build_index=build_index,
                          merge_sources=merge_sources)

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -10,11 +10,28 @@ from astropy.wcs import WCS
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.coordinates import Galactic, ICRS
+import gammapy
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.hpx_utils as hpx_utils
 import fermipy.fits_utils as fits_utils
 from fermipy.hpx_utils import HPX, HpxToWcsMapping
+
+
+def coadd_maps(geom, maps, preserve_counts=True):
+    """Coadd a sequence of `~gammapy.maps.Map` objects."""
+
+    # FIXME: This functionality should be built into the Map.coadd method
+    map_out = gammapy.maps.Map.from_geom(geom)
+    for m in maps:
+        m_tmp = m
+        if isinstance(m, gammapy.maps.HpxNDMap):
+            if m.geom.order < map_out.geom.order:
+                factor = map_out.geom.nside // m.geom.nside
+                m_tmp = m.upsample(factor, preserve_counts=preserve_counts)
+        map_out.coadd(m_tmp)
+
+    return map_out
 
 
 def make_coadd_map(maps, proj, shape, preserve_counts=True):
@@ -214,8 +231,8 @@ class Map(Map_Base):
             if differential:
                 nebins = len(ebins)
             else:
-                nebins = len(ebins) - 1                               
-            data = np.zeros(list(npix) + [nebins]).T            
+                nebins = len(ebins) - 1
+            data = np.zeros(list(npix) + [nebins]).T
             naxis = 3
         else:
             data = np.zeros(npix).T
@@ -422,7 +439,7 @@ class HpxMap(Map_Base):
         if hpx.conv.convname == 'FGST_SRCMAP_SPARSE':
             pixs = hdu.data.field('PIX')
             chans = hdu.data.field('CHANNEL')
-            keys = chans*hpx.npix + pixs
+            keys = chans * hpx.npix + pixs
             vals = hdu.data.field('VALUE')
             nebin = len(ebins)
             data = np.zeros((nebin, hpx.npix))
@@ -431,10 +448,10 @@ class HpxMap(Map_Base):
             for c in colnames:
                 if c.find(hpx.conv.colstring) == 0:
                     cnames.append(c)
-            nebin = len(cnames)                
+            nebin = len(cnames)
             data = np.ndarray((nebin, hpx.npix))
             for i, cname in enumerate(cnames):
-                data[i,0:] = hdu.data.field(cname)
+                data[i, 0:] = hdu.data.field(cname)
 
         return cls(data, hpx)
 
@@ -550,7 +567,7 @@ class HpxMap(Map_Base):
     def get_pixel_skydirs(self):
         """Get a list of sky coordinates for the centers of every pixel. """
         sky_coords = self._hpx.get_sky_coords()
-        if self.hpx.coordsys == 'GAL':            
+        if self.hpx.coordsys == 'GAL':
             return SkyCoord(l=sky_coords.T[0], b=sky_coords.T[1], unit='deg', frame='galactic')
         else:
             return SkyCoord(ra=sky_coords.T[0], dec=sky_coords.T[1], unit='deg', frame='icrs')
@@ -671,16 +688,16 @@ class HpxMap(Map_Base):
         """ return the full counts map """
         if self.hpx._ipix is None:
             return self.counts
-        
-        output = np.zeros((self.counts.shape[0], self.hpx._maxpix), self.counts.dtype)
+
+        output = np.zeros(
+            (self.counts.shape[0], self.hpx._maxpix), self.counts.dtype)
         for i in range(self.counts.shape[0]):
             output[i][self.hpx._ipix] = self.counts[i]
         return output
 
-
     def explicit_counts_map(self, pixels=None):
         """ return a counts map with explicit index scheme
-        
+
         Parameters
         ----------
         pixels : `np.ndarray` or None
@@ -695,7 +712,8 @@ class HpxMap(Map_Base):
                     nz = summed.nonzero()[0]
                 else:
                     nz = pixels
-                data_out = np.vstack(self.data[i].flat[nz] for i in range(self.data.shape[0]))
+                data_out = np.vstack(self.data[i].flat[nz]
+                                     for i in range(self.data.shape[0]))
             else:
                 if pixels is None:
                     nz = self.data.nonzero()[0]
@@ -707,8 +725,8 @@ class HpxMap(Map_Base):
             if pixels is None:
                 return (self.hpx._ipix, self.data)
         # FIXME, can we catch this
-        raise RuntimeError('HPX.explicit_counts_map called with pixels for a map that already has pixels')
-
+        raise RuntimeError(
+            'HPX.explicit_counts_map called with pixels for a map that already has pixels')
 
     def sparse_counts_map(self):
         """ return a counts map with sparse index scheme
@@ -716,11 +734,10 @@ class HpxMap(Map_Base):
         if self.hpx._ipix is None:
             flatarray = self.data.flattern()
         else:
-            flatarray = self.expanded_counts_map()        
+            flatarray = self.expanded_counts_map()
         nz = flatarray.nonzero()[0]
         data_out = flatarray[nz]
         return (nz, data_out)
-
 
     def ud_grade(self, order, preserve_counts=False):
         """

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -343,7 +343,7 @@ class SourceFind(object):
 
         src = self.roi.copy_source(name)
         skydir = src.skydir
-        skywcs = self._skywcs
+        skywcs = self.geom.wcs
         src_pix = skydir.to_pixel(skywcs)
 
         fit0 = self._fit_position_tsmap(name, prefix=prefix,
@@ -549,7 +549,7 @@ class SourceFind(object):
                                        zmin=max(zmin, -ts_value * 0.5))
 
         o.update(posfit)
-        pix = posfit['skydir'].to_pixel(self._skywcs)
+        pix = posfit['skydir'].to_pixel(self.geom.wcs)
         o['xpix'] = float(pix[0])
         o['ypix'] = float(pix[1])
         o['skydir'] = posfit['skydir'].transform_to('icrs')
@@ -567,7 +567,7 @@ class SourceFind(object):
         ts_value = np.max(tsmap.counts)
         posfit = fit_error_ellipse(tsmap, dpix=2,
                                    zmin=max(zmin, -ts_value * 0.5))
-        pix = posfit['skydir'].to_pixel(self._skywcs)
+        pix = posfit['skydir'].to_pixel(self.geom.wcs)
 
         o = {}
         o.update(posfit)
@@ -601,7 +601,7 @@ class SourceFind(object):
         self.free_norm(name, loglevel=logging.DEBUG)
 
         lnlmap = Map.create(skydir, scan_cdelt, (nstep, nstep),
-                            coordsys=wcs_utils.get_coordsys(self._skywcs))
+                            coordsys=wcs_utils.get_coordsys(self.geom.wcs))
 
         src = self.roi.copy_source(name)
 
@@ -642,7 +642,7 @@ class SourceFind(object):
 
         loglike = []
         skydir = src.skydir
-        skywcs = self._skywcs
+        skywcs = self.geom.wcs
         src_pix = skydir.to_pixel(skywcs)
 
         c = skydir.transform_to('icrs')
@@ -657,7 +657,7 @@ class SourceFind(object):
 
             t0 = time.time()
 
-            c = SkyCoord.from_pixel(params[0], params[1], self._skywcs)
+            c = SkyCoord.from_pixel(params[0], params[1], self.geom.wcs)
             c = c.transform_to('icrs')
             src.set_radec(c.ra.deg, c.dec.deg)
 

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -609,7 +609,8 @@ class SourceFind(object):
         if use_cache and not use_pylike:
             self._create_srcmap_cache(src.name, src)
 
-        scan_skydir = lnlmap.get_pixel_skydirs().transform_to('icrs')
+        scan_skydir = wcs_utils.get_map_skydirs(lnlmap).transform_to('icrs')
+        #scan_skydir = lnlmap.get_pixel_skydirs().transform_to('icrs')
         loglike = []
         for ra, dec in zip(scan_skydir.ra.deg, scan_skydir.dec.deg):
 

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -306,8 +306,8 @@ class SourceFind(object):
         hdu_data = fits.table_to_hdu(tab)
         hdu_data.name = 'LOC_DATA'
 
-        hdus = [loc['tsmap_peak'].make_hdu(extname='PRIMARY'),
-                loc['tsmap'].make_hdu(extname='TSMAP'),
+        hdus = [loc['tsmap_peak'].make_hdu(hdu='PRIMARY'),
+                loc['tsmap'].make_hdu(hdu='TSMAP'),
                 hdu_data]
 
         hdus[0].header['CONFIG'] = json.dumps(loc['config'])

--- a/fermipy/sourcefind.py
+++ b/fermipy/sourcefind.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, Column
+from gammapy.maps import WcsNDMap
 import fermipy.config
 from fermipy import utils
 from fermipy import defaults
@@ -116,7 +117,7 @@ class SourceFind(object):
             src_dict = copy.deepcopy(src_dict_template)
             norm_par = get_function_norm_par_name(
                 src_dict_template['SpectrumType'])
-            src_dict.update({norm_par: amp.counts[p['iy'], p['ix']],
+            src_dict.update({norm_par: amp.data[p['iy'], p['ix']],
                              'ra': skydir.icrs.ra.deg,
                              'dec': skydir.icrs.dec.deg})
 
@@ -305,8 +306,8 @@ class SourceFind(object):
         hdu_data = fits.table_to_hdu(tab)
         hdu_data.name = 'LOC_DATA'
 
-        hdus = [loc['tsmap_peak'].create_primary_hdu(),
-                loc['tsmap'].create_image_hdu('TSMAP'),
+        hdus = [loc['tsmap_peak'].make_hdu(extname='PRIMARY'),
+                loc['tsmap'].make_hdu(extname='TSMAP'),
                 hdu_data]
 
         hdus[0].header['CONFIG'] = json.dumps(loc['config'])
@@ -535,7 +536,7 @@ class SourceFind(object):
         o = {}
         for p in sorted(peaks, key=lambda t: t['amp'], reverse=True):
             xy = p['ix'], p['iy']
-            ts_value = tsmap['ts'].counts[xy[1], xy[0]]
+            ts_value = tsmap['ts'].data[xy[1], xy[0]]
             posfit = fit_error_ellipse(tsmap['ts'], xy=xy, dpix=2,
                                        zmin=max(zmin, -ts_value * 0.5))
             offset = posfit['skydir'].separation(self.roi[name].skydir).deg
@@ -544,7 +545,7 @@ class SourceFind(object):
                 break
 
         if peak_best is None:
-            ts_value = np.max(tsmap['ts'].counts)
+            ts_value = np.max(tsmap['ts'].data)
             posfit = fit_error_ellipse(tsmap['ts'], dpix=2,
                                        zmin=max(zmin, -ts_value * 0.5))
 
@@ -564,7 +565,7 @@ class SourceFind(object):
 
         zmin = kwargs.get('zmin', -9.0)
         tsmap, loglike = self._scan_position(name, **kwargs)
-        ts_value = np.max(tsmap.counts)
+        ts_value = np.max(tsmap.data)
         posfit = fit_error_ellipse(tsmap, dpix=2,
                                    zmin=max(zmin, -ts_value * 0.5))
         pix = posfit['skydir'].to_pixel(self.geom.wcs)
@@ -600,8 +601,8 @@ class SourceFind(object):
         saved_state.restore()
         self.free_norm(name, loglevel=logging.DEBUG)
 
-        lnlmap = Map.create(skydir, scan_cdelt, (nstep, nstep),
-                            coordsys=wcs_utils.get_coordsys(self.geom.wcs))
+        lnlmap = WcsNDMap.create(skydir=skydir, binsz=scan_cdelt, npix=(nstep, nstep),
+                                 coordsys=wcs_utils.get_coordsys(self.geom.wcs))
 
         src = self.roi.copy_source(name)
 
@@ -626,7 +627,7 @@ class SourceFind(object):
 
         lnlmap.data = np.array(loglike).reshape((nstep, nstep)).T
         lnlmap.data -= fit_output_nosrc['loglike']
-        tsmap = Map(2.0 * lnlmap.data, lnlmap.wcs)
+        tsmap = WcsNDMap(lnlmap.geom, 2.0 * lnlmap.data)
 
         self._clear_srcmap_cache()
         return tsmap, fit_output_nosrc['loglike']

--- a/fermipy/sourcefind_utils.py
+++ b/fermipy/sourcefind_utils.py
@@ -18,7 +18,7 @@ def fit_error_ellipse(tsmap, xy=None, dpix=3, zmin=None):
 
     Parameters
     ----------
-    tsmap : `~fermipy.skymap.Map`
+    tsmap : `~gammapy.maps.WcsMap`
 
     xy : tuple
 
@@ -33,20 +33,20 @@ def fit_error_ellipse(tsmap, xy=None, dpix=3, zmin=None):
     """
 
     if xy is None:
-        ix, iy = np.unravel_index(np.argmax(tsmap.counts.T),
-                                  tsmap.counts.T.shape)
+        ix, iy = np.unravel_index(np.argmax(tsmap.data.T),
+                                  tsmap.data.T.shape)
     else:
         ix, iy = xy
 
-    pbfit0 = utils.fit_parabola(tsmap.counts.T, ix, iy, dpix=1.5)
-    pbfit1 = utils.fit_parabola(tsmap.counts.T, ix, iy, dpix=dpix,
+    pbfit0 = utils.fit_parabola(tsmap.data.T, ix, iy, dpix=1.5)
+    pbfit1 = utils.fit_parabola(tsmap.data.T, ix, iy, dpix=dpix,
                                 zmin=zmin)
 
-    wcs = tsmap.wcs
-    cdelt0 = tsmap.wcs.wcs.cdelt[0]
-    cdelt1 = tsmap.wcs.wcs.cdelt[1]
-    npix0 = tsmap.counts.T.shape[0]
-    npix1 = tsmap.counts.T.shape[1]
+    wcs = tsmap.geom.wcs
+    cdelt0 = tsmap.geom.wcs.wcs.cdelt[0]
+    cdelt1 = tsmap.geom.wcs.wcs.cdelt[1]
+    npix0 = tsmap.data.T.shape[0]
+    npix1 = tsmap.data.T.shape[1]
 
     o = {}
     o['fit_success'] = pbfit0['fit_success']
@@ -59,7 +59,7 @@ def fit_error_ellipse(tsmap, xy=None, dpix=3, zmin=None):
     else:
         o['xpix'] = float(ix)
         o['ypix'] = float(iy)
-        o['zoffset'] = tsmap.counts.T[ix, iy]
+        o['zoffset'] = tsmap.data.T[ix, iy]
 
     if pbfit1['fit_success']:
         sigmax = 2.0**0.5 * pbfit1['sigmax'] * np.abs(cdelt0)
@@ -121,7 +121,7 @@ def fit_error_ellipse(tsmap, xy=None, dpix=3, zmin=None):
     o['pos_ecc2'] = np.sqrt(a**2 / b**2 - 1)
     o['skydir'] = skydir
 
-    if wcs_utils.get_coordsys(tsmap.wcs) == 'GAL':
+    if tsmap.geom.coordsys == 'GAL':
         gal_cov = utils.ellipse_to_cov(o['pos_err_semimajor'],
                                        o['pos_err_semiminor'],
                                        o['theta'])
@@ -158,7 +158,7 @@ def find_peaks(input_map, threshold, min_separation=0.5):
 
     Parameters
     ----------
-    input_map : `~fermipy.utils.Map`
+    input_map : `~gammapy.maps.WcsMap`
 
     threshold : float
 
@@ -173,16 +173,16 @@ def find_peaks(input_map, threshold, min_separation=0.5):
        each peak.
     """
 
-    data = input_map.counts
+    data = input_map.data
 
-    cdelt = max(input_map.wcs.wcs.cdelt)
+    cdelt = max(input_map.geom.wcs.wcs.cdelt)
     min_separation = max(min_separation, 2 * cdelt)
 
     region_size_pix = int(min_separation / cdelt)
     region_size_pix = max(3, region_size_pix)
 
     deltaxy = utils.make_pixel_distance(region_size_pix * 2 + 3)
-    deltaxy *= max(input_map.wcs.wcs.cdelt)
+    deltaxy *= max(input_map.geom.wcs.wcs.cdelt)
     region = deltaxy < min_separation
 
     local_max = maximum_filter(data, footprint=region) == data
@@ -194,7 +194,7 @@ def find_peaks(input_map, threshold, min_separation=0.5):
     peaks = []
     for s in slices:
         skydir = SkyCoord.from_pixel(s[1].start, s[0].start,
-                                     input_map.wcs)
+                                     input_map.geom.wcs)
         peaks.append({'ix': s[1].start,
                       'iy': s[0].start,
                       'skydir': skydir,

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -735,13 +735,13 @@ class TSMapGenerator(object):
         for k, v in sorted(maps.items()):
             if v is None:
                 continue
-            hdu_images += [v.make_hdu(extname=k)]
+            hdu_images += [v.make_hdu(hdu=k)]
 
         tab = fits_utils.dict_to_table(data)
         hdu_data = fits.table_to_hdu(tab)
         hdu_data.name = 'TSMAP_DATA'
 
-        hdus = [data['ts'].make_hdu(extname='PRIMARY'),
+        hdus = [data['ts'].make_hdu(hdu='PRIMARY'),
                 hdu_data] + hdu_images
 
         data['config'].pop('map_skydir', None)

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -23,7 +23,6 @@ import fermipy.wcs_utils as wcs_utils
 import fermipy.fits_utils as fits_utils
 import fermipy.plotting as plotting
 import fermipy.castro as castro
-from fermipy.skymap import Map
 from fermipy.roi_model import Source
 from fermipy.spectrum import PowerLaw
 from fermipy.config import ConfigSchema
@@ -1106,12 +1105,12 @@ class TSCubeGenerator(object):
         ts_map = tscube.tsmap
         norm_map = tscube.normmap
         npred_map = copy.deepcopy(norm_map)
-        npred_map._counts *= tscube.refSpec.ref_npred.sum()
+        npred_map.data *= tscube.refSpec.ref_npred.sum()
         amp_map = copy.deepcopy(norm_map)
-        amp_map._counts *= src_dict['Prefactor']
+        amp_map.data *= src_dict['Prefactor']
 
         sqrt_ts_map = copy.deepcopy(ts_map)
-        sqrt_ts_map._counts = np.abs(sqrt_ts_map._counts)**0.5
+        sqrt_ts_map.data[...] = np.abs(sqrt_ts_map.data)**0.5
 
         o = {'name': utils.join_strings([prefix, modelname]),
              'src_dict': copy.deepcopy(src_dict),

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -14,7 +14,10 @@ from scipy.optimize import brentq
 import astropy
 from astropy.io import fits
 from astropy.table import Table
+from astropy.coordinates import SkyCoord
 import astropy.wcs as pywcs
+from gammapy.maps.geom import coordsys_to_frame
+from gammapy.maps import WcsNDMap, WcsGeom
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils
 import fermipy.fits_utils as fits_utils
@@ -732,15 +735,16 @@ class TSMapGenerator(object):
         for k, v in sorted(maps.items()):
             if v is None:
                 continue
-            hdu_images += [v.create_image_hdu(k)]
+            hdu_images += [v.make_hdu(extname=k)]
 
         tab = fits_utils.dict_to_table(data)
         hdu_data = fits.table_to_hdu(tab)
         hdu_data.name = 'TSMAP_DATA'
 
-        hdus = [data['ts'].create_primary_hdu(),
+        hdus = [data['ts'].make_hdu(extname='PRIMARY'),
                 hdu_data] + hdu_images
 
+        data['config'].pop('map_skydir', None)
         hdus[0].header['CONFIG'] = json.dumps(data['config'])
         hdus[1].header['CONFIG'] = json.dumps(data['config'])
         fits_utils.write_hdus(hdus, filename)
@@ -788,8 +792,11 @@ class TSMapGenerator(object):
                       np.round((self.npix - 1.0) / 2.))
         cpix = np.array([xpix, ypix])
 
-        skywcs = self._skywcs
-        skydir = wcs_utils.pix_to_skydir(cpix[0], cpix[1], skywcs)
+        map_geom = self._geom.to_image()
+        frame = coordsys_to_frame(map_geom.coordsys)
+        skydir = SkyCoord(*map_geom.pix_to_coord((cpix[0], cpix[1])),
+                          frame=frame, unit='deg')
+        skydir = skydir.transform_to('icrs')
 
         src_dict['ra'] = skydir.ra.deg
         src_dict['dec'] = skydir.dec.deg
@@ -811,9 +818,9 @@ class TSMapGenerator(object):
             imax = utils.val_to_edge(c.log_energies, loge_bounds[1])[0]
 
             eslice = slice(imin, imax)
-            bm = c.model_counts_map(exclude=kwargs['exclude']).counts.astype('float')[
+            bm = c.model_counts_map(exclude=kwargs['exclude']).data.astype('float')[
                 eslice, ...]
-            cm = c.counts_map().counts.astype('float')[eslice, ...]
+            cm = c.counts_map().data.astype('float')[eslice, ...]
 
             bkg += [bm]
             counts += [cm]
@@ -829,7 +836,7 @@ class TSMapGenerator(object):
         # self.logger.info(str(src_dict))
         modelname = utils.create_model_name(src)
         for c, eslice in zip(self.components, eslices):
-            mm = c.model_counts_map('tsmap_testsource').counts.astype('float')[
+            mm = c.model_counts_map('tsmap_testsource').data.astype('float')[
                 eslice, ...]
             model_npred += np.sum(mm)
             model += [mm]
@@ -865,8 +872,10 @@ class TSMapGenerator(object):
                                  C_0_map=c0_map)
 
         if kwargs['map_skydir'] is not None:
+
             map_offset = wcs_utils.skydir_to_pix(kwargs['map_skydir'],
-                                                 self._skywcs)
+                                                 map_geom.wcs)
+
             map_delta = 0.5 * kwargs['map_size'] / self.components[0].binsz
             xmin = max(int(np.ceil(map_offset[1] - map_delta)), 0)
             xmax = min(int(np.floor(map_offset[1] + map_delta)) + 1, self.npix)
@@ -877,13 +886,16 @@ class TSMapGenerator(object):
             yslice = slice(ymin, ymax)
             xyrange = [range(xmin, xmax), range(ymin, ymax)]
 
-            map_wcs = skywcs.deepcopy()
-            map_wcs.wcs.crpix[0] -= ymin
-            map_wcs.wcs.crpix[1] -= xmin
+            wcs = map_geom.wcs.deepcopy()
+            npix = (ymax - ymin, xmax - xmin)
+            crpix = (map_geom._crpix[0] - ymin, map_geom._crpix[1] - xmin)
+            wcs.wcs.crpix[0] -= ymin
+            wcs.wcs.crpix[1] -= ymax
+
+            # FIXME: We should implement this with a proper cutout method
+            map_geom = WcsGeom(wcs, npix, crpix=crpix)
         else:
             xyrange = [range(self.npix), range(self.npix)]
-            map_wcs = skywcs
-
             xslice = slice(0, self.npix)
             yslice = slice(0, self.npix)
 
@@ -910,10 +922,10 @@ class TSMapGenerator(object):
         ts_values = ts_values[xslice, yslice]
         amp_values = amp_values[xslice, yslice]
 
-        ts_map = Map(ts_values, map_wcs)
-        sqrt_ts_map = Map(ts_values**0.5, map_wcs)
-        npred_map = Map(amp_values * model_npred, map_wcs)
-        amp_map = Map(amp_values * src.get_norm(), map_wcs)
+        ts_map = WcsNDMap(map_geom, ts_values)
+        sqrt_ts_map = WcsNDMap(map_geom, ts_values**0.5)
+        npred_map = WcsNDMap(map_geom, amp_values * model_npred)
+        amp_map = WcsNDMap(map_geom, amp_values * src.get_norm())
 
         o = {'name': utils.join_strings([prefix, modelname]),
              'src_dict': copy.deepcopy(src_dict),
@@ -927,76 +939,6 @@ class TSMapGenerator(object):
              }
 
         return o
-
-    def _tsmap_pylike(self, prefix, **kwargs):
-        """Evaluate the TS for an additional source component at each point
-        in the ROI.  This is the brute force implementation of TS map
-        generation that runs a full pyLikelihood fit
-        at each point in the ROI."""
-
-        logLike0 = -self.like()
-        self.logger.info('LogLike: %f' % logLike0)
-
-        saved_state = LikelihoodState(self.like)
-
-        # Get the ROI geometry
-
-        # Loop over pixels
-        w = copy.deepcopy(self._skywcs)
-        #        w = create_wcs(self._roi.skydir,cdelt=self._binsz,crpix=50.5)
-
-        data = np.zeros((self.npix, self.npix))
-        #        self.free_sources(free=False)
-
-        xpix = (np.linspace(0, self.npix - 1, self.npix)[:, np.newaxis] *
-                np.ones(data.shape))
-        ypix = (np.linspace(0, self.npix - 1, self.npix)[np.newaxis, :] *
-                np.ones(data.shape))
-
-        radec = wcs_utils.pix_to_skydir(xpix, ypix, w)
-        radec = (np.ravel(radec.ra.deg), np.ravel(radec.dec.deg))
-
-        testsource_dict = {
-            'ra': radec[0][0],
-            'dec': radec[1][0],
-            'SpectrumType': 'PowerLaw',
-            'Index': 2.0,
-            'Scale': 1000,
-            'Prefactor': {'value': 0.0, 'scale': 1e-13},
-            'SpatialModel': 'PSFSource',
-        }
-
-        #        src = self.roi.get_source_by_name('tsmap_testsource')
-
-        for i, (ra, dec) in enumerate(zip(radec[0], radec[1])):
-            testsource_dict['ra'] = ra
-            testsource_dict['dec'] = dec
-            #                        src.set_position([ra,dec])
-            self.add_source('tsmap_testsource', testsource_dict, free=True,
-                            init_source=False, save_source_maps=False)
-
-            #            for c in self.components:
-            #                c.update_srcmap_file([src],True)
-
-            self.set_parameter('tsmap_testsource', 'Prefactor', 0.0,
-                               update_source=False)
-            self.fit(loglevel=logging.DEBUG, update=False)
-
-            logLike1 = -self.like()
-            ts = max(0, 2 * (logLike1 - logLike0))
-
-            data.flat[i] = ts
-
-            #            print(i, ra, dec, ts)
-            #            print(self.like())
-            # print(self.components[0].like.model['tsmap_testsource'])
-
-            self.delete_source('tsmap_testsource')
-
-        saved_state.restore()
-
-        outfile = os.path.join(self.config['fileio']['workdir'], 'tsmap.fits')
-        fits_utils.write_fits_image(data, w, outfile)
 
 
 class TSCubeGenerator(object):
@@ -1084,7 +1026,7 @@ class TSCubeGenerator(object):
 
     def _make_ts_cube(self, prefix, **kwargs):
 
-        skywcs = kwargs.get('wcs', self._skywcs)
+        skywcs = kwargs.get('wcs', self.geom.wcs)
         npix = kwargs.get('npix', self.npix)
 
         galactic = wcs_utils.is_galactic(skywcs)

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -890,7 +890,7 @@ class TSMapGenerator(object):
             npix = (ymax - ymin, xmax - xmin)
             crpix = (map_geom._crpix[0] - ymin, map_geom._crpix[1] - xmin)
             wcs.wcs.crpix[0] -= ymin
-            wcs.wcs.crpix[1] -= ymax
+            wcs.wcs.crpix[1] -= xmin
 
             # FIXME: We should implement this with a proper cutout method
             map_geom = WcsGeom(wcs, npix, crpix=crpix)

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -375,12 +375,6 @@ def get_map_skydir(filename, maphdu=0):
     return wcs_to_skydir(wcs)
 
 
-def get_map_skydirs(m):
-    coords = m.geom.get_coords()
-    frame = coordsys_to_frame(m.geom.coordsys)
-    return SkyCoord(coords[0], coords[1], frame=frame, unit='deg')
-
-
 def get_cel_to_gal_angle(skydir):
     """Calculate the rotation angle in radians between the longitude
     axes of a local projection in celestial and galactic coordinates.

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.extern import six
+from gammapy.maps.geom import coordsys_to_frame
 
 
 class WCSProj(object):
@@ -372,6 +373,12 @@ def get_map_skydir(filename, maphdu=0):
     hdulist = fits.open(filename)
     wcs = WCS(hdulist[maphdu].header)
     return wcs_to_skydir(wcs)
+
+
+def get_map_skydirs(m):
+    coords = m.geom.get_coords()
+    frame = coordsys_to_frame(m.geom.coordsys)
+    return SkyCoord(coords[0], coords[1], frame=frame, unit='deg')
 
 
 def get_cel_to_gal_angle(skydir):

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -91,6 +91,35 @@ class WCSProj(object):
         return delta
 
 
+def distance_to_edge(geom, skydir):
+    """Return the angular distance from the given direction and
+    the edge of the projection."""
+
+    # FIXME: We should add a pixel_size property in gammapy.maps
+    # FIXME: We should make this into a MapGeom method 
+    
+    xpix, ypix = skydir.to_pixel(geom.wcs, origin=0)
+    deltax = np.array((xpix - geom.center_pix[0]) * geom._cdelt[0],
+                      ndmin=1)
+    deltay = np.array((ypix - geom.center_pix[1]) * geom._cdelt[1],
+                      ndmin=1)
+
+    deltax = np.abs(deltax) - 0.5 * geom.width[0]
+    deltay = np.abs(deltay) - 0.5 * geom.width[1]
+
+    m0 = (deltax < 0) & (deltay < 0)
+    m1 = (deltax > 0) & (deltay < 0)
+    m2 = (deltax < 0) & (deltay > 0)
+    m3 = (deltax > 0) & (deltay > 0)
+    mx = np.abs(deltax) <= np.abs(deltay)
+    my = np.abs(deltay) < np.abs(deltax)
+
+    delta = np.zeros(len(deltax))
+    delta[(m0 & mx) | (m3 & my) | m1] = deltax[(m0 & mx) | (m3 & my) | m1]
+    delta[(m0 & my) | (m3 & mx) | m2] = deltay[(m0 & my) | (m3 & mx) | m2]
+    return delta
+
+    
 def create_wcs(skydir, coordsys='CEL', projection='AIT',
                cdelt=1.0, crpix=1., naxis=2, energies=None):
     """Create a WCS object.


### PR DESCRIPTION
This PR replaces WCS and HPX map classes in `fermipy.skymap` with their equivalents from `gammapy.maps` and adds `gammapy` as a dependency.  

Note that I've left the fermipy maps modules in place for now as there are still some places where we're using the fermipy classes (e.g. in the code for LT cubes and flux sensitivity).  I'll try to make a follow-up PR to fix these as well as remove the modules with the fermipy maps code (`skymap`, `wcs_utils`, and `hpx_utils`).

Finally the HPX-related functionality will probably require some additional tweaking.  I tried to to verify that I didn't break anything with the all-sky test case analysis that @eacharles gave me but it's likely I missed something.  At some point it would be good to add a test-case for HPX-based analysis so that we can catch these issues in an automated way.