### PR TITLE
Add new travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
+      - CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
 matrix:
     include:
@@ -30,7 +31,6 @@ matrix:
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
                DOCKER_INSTALL=''
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # The Sphinx docs build
         # Python 3, no Fermi ST, all other dependencies
@@ -49,7 +49,6 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 3.6, no Fermi ST, all other dependencies
         - os: linux
@@ -58,7 +57,6 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, no Fermi ST, all other dependencies
         - os: linux
@@ -67,7 +65,6 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
         # Python 2, SLAC ST 11-05-03, all other dependencies
         - os: linux
@@ -77,7 +74,6 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-05-03-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
 
@@ -89,7 +85,6 @@ matrix:
                ST_INSTALL=''
                DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-07-00-python'
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
-               CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
                
@@ -108,6 +103,14 @@ matrix:
 
     allow_failures:
         - env: NAME=py2_slac-st-11-07-00-gammapy-master
+               PYTHON_VERSION=2.7
+               ST_INSTALL=''
+               DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-07-00-python'
+               CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
+               CONDA_DEPS='cython numpy astropy scipy matplotlib pytest pyyaml'
+               FERMI_DIR='/home'
+               SLAC_ST_BUILD=true
+               PIP_DEPS='coverage pytest-cov coveralls git+https://github.com/gammapy/gammapy.git'
 
 #        # Python 3, no Fermi ST, only the required dependencies
 #        # TODO: This isn't working yet, need to handle imports for opt deps more carefully
@@ -133,21 +136,6 @@ install:
         $DOCKER_INSTALL;
         docker exec fermipy-testing /bin/bash --login -c "cd /home/fermipy && python setup.py install";
     fi
-
-#docker exec fermipy-testing /bin/bash -c "cd /home/fermipy;source /home/fermipy/condainstall.sh";
-  
-#  - wget http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD -O miniconda.sh
-#  - bash miniconda.sh -b -p $HOME/miniconda
-#  - export PATH="$HOME/miniconda/bin:$PATH"
-#  - conda config --set always_yes yes --set changeps1 no
-#  - conda update -q conda
-#  - conda info -a
-#  - conda create -q -n fermi-env python=$PYTHON_VERSION pip numpy astropy pytest $CONDA_DEPS
-#  - source activate fermi-env
-#  - python -m pip install coverage pytest-cov coveralls
-#  - $CONDA2
-#  - python setup.py install
-#  - $ST_INSTALL 
 
 # Run test
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
 
-        # Python 2, SLAC ST 11-05-02, all other dependencies
+        # Python 2, SLAC ST 11-07-00, all other dependencies
         - os: linux
           sudo: required
           env: NAME=py2_slac-st-11-07-00
@@ -93,6 +93,9 @@ matrix:
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
 
+    allow_failures:
+
+        # Python 2, SLAC ST 11-07-00, gammapy master
         - os: linux
           sudo: required
           env: NAME=py2_slac-st-11-07-00-gammapy-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         # The main build:
         # Python 2, Fermi ST, all dependencies
         - os: linux
-          env: NAME=main
+          env: NAME=fssc-st-10-00-05
                PYTHON_VERSION=2.7
                CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
                ST_INSTALL='bash stinstall.sh force'
@@ -92,7 +92,18 @@ matrix:
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
-        
+
+        - os: linux
+          sudo: required
+          env: NAME=py2_slac-st-11-07-00-gammapy-master
+               PYTHON_VERSION=2.7
+               ST_INSTALL=''
+               DOCKER_INSTALL='bash dockerinstall.sh docker/centos6-11-07-00-python'
+               CONDA_DOWNLOAD=Miniconda-latest-Linux-x86_64.sh
+               CONDA_DEPS='cython numpy astropy scipy matplotlib pytest pyyaml'
+               FERMI_DIR='/home'
+               SLAC_ST_BUILD=true
+               PIP_DEPS='coverage pytest-cov coveralls git+https://github.com/gammapy/gammapy.git'
               
 #        # Python 3, no Fermi ST, only the required dependencies
 #        # TODO: This isn't working yet, need to handle imports for opt deps more carefully

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,7 @@ matrix:
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
-
-    allow_failures:
-
+               
         # Python 2, SLAC ST 11-07-00, gammapy master
         - os: linux
           sudo: required
@@ -107,7 +105,10 @@ matrix:
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
                PIP_DEPS='coverage pytest-cov coveralls git+https://github.com/gammapy/gammapy.git'
-              
+
+    allow_failures:
+        - env: NAME=py2_slac-st-11-07-00-gammapy-master
+
 #        # Python 3, no Fermi ST, only the required dependencies
 #        # TODO: This isn't working yet, need to handle imports for opt deps more carefully
 #        - os: linux

--- a/docker/centos6-11-05-03-python/Dockerfile
+++ b/docker/centos6-11-05-03-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -o miniconda.sh -L http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD && \
     /bin/bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && conda update -y conda && conda config --append channels conda-forge 
+    rm miniconda.sh && conda update -y conda && conda config --add channels conda-forge 
 RUN conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS && \
     conda install -y $CONDA_DEPS_EXTRA && \
     if [[ -n $PIP_DEPS ]]; then pip install $PIP_DEPS; fi

--- a/docker/centos6-11-05-03-python/Dockerfile
+++ b/docker/centos6-11-05-03-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -o miniconda.sh -L http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD && \
     /bin/bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && conda update -y conda && conda config --add channels conda-forge 
+    rm miniconda.sh && conda config --add channels conda-forge && conda update -y conda
 RUN conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS && \
     conda install -y $CONDA_DEPS_EXTRA && \
     if [[ -n $PIP_DEPS ]]; then pip install $PIP_DEPS; fi

--- a/docker/centos6-11-07-00-python/Dockerfile
+++ b/docker/centos6-11-07-00-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -o miniconda.sh -L http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD && \
     /bin/bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && conda update -y conda && conda config --append channels conda-forge 
+    rm miniconda.sh && conda update -y conda && conda config --add channels conda-forge 
 RUN conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS && \
     conda install -y $CONDA_DEPS_EXTRA && \
     if [[ -n $PIP_DEPS ]]; then pip install $PIP_DEPS; fi

--- a/docker/centos6-11-07-00-python/Dockerfile
+++ b/docker/centos6-11-07-00-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH /opt/conda/bin:$PATH
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -o miniconda.sh -L http://repo.continuum.io/miniconda/$CONDA_DOWNLOAD && \
     /bin/bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh && conda update -y conda && conda config --add channels conda-forge 
+    rm miniconda.sh && conda config --add channels conda-forge && conda update -y conda
 RUN conda install -y python=$PYTHON_VERSION pip pytest $CONDA_DEPS && \
     conda install -y $CONDA_DEPS_EXTRA && \
     if [[ -n $PIP_DEPS ]]; then pip install $PIP_DEPS; fi

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'scipy >= 0.14',
         'pyyaml',
         'healpy',
-        'wcsaxes',
+        'gammapy',
     ],
     extras_require=dict(
         all=[],


### PR DESCRIPTION
This PR makes a few improvements to the travis configuration:
* Minor cleanup in travis yaml file.
* Add new build against gammapy-master.  This should help us detect when/if changes in gammapy are incompatible with fermipy.  So that changes in gammapy don't block fermipy development I've marked this test as an allowed failure.
* Fixed dependency configuration in `setup.py`.  Added `gammapy` and removed `wcsaxes` (this package is no longer actively maintained since being folded into astropy).