### PR TITLE
Fix bug in parsing multi-component diffuse model configuration

### DIFF
--- a/fermipy/roi_model.py
+++ b/fermipy/roi_model.py
@@ -1415,14 +1415,15 @@ class ROIModel(fermipy.config.Configurable):
                 os.path.expandvars('$FERMI_DIR/refdata/fermi/galdiffuse')
 
         search_dirs = []
-        search_dirs += self.config['diffuse_dir']
+        if config.get('diffuse_dir', []):
+            search_dirs += config.get('diffuse_dir', [])
         search_dirs += [self.config['fileio']['outdir'],
                         os.path.join('$FERMIPY_ROOT', 'data'),
                         '$FERMI_DIFFUSE_DIR']
 
         srcs = []
-        if self.config[name] is not None:
-            srcs = self.config[name]
+        if config[name] is not None:
+            srcs = config[name]
 
         srcs_out = []
         for i, t in enumerate(srcs):


### PR DESCRIPTION
This PR fixes a bug in how the model configuration for multi-component analyses was being parsed.  Specifically when setting different diffuse template files for multiple components the template of the first component was assigned to all components.  This was due to a small typo in `ROIModel._create_diffuse_src`.