### PR TITLE
make sphinx an explicit requirement for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
         - os: linux
           env: NAME=docs
                PYTHON_VERSION=3.5
+               PIP_DEPS='coverage pytest-cov coveralls sphinx sphinx_rtd_theme'
                ST_INSTALL=''
                DOCKER_INSTALL=''
-               CONDA_CHANNELS='conda-forge anaconda'
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ notifications:
 env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
-      - SLAC_ST_BUILD=false      
-      - PIP_DEPS='coverage pytest-cov coveralls'
+      - SLAC_ST_BUILD=false
+      - PIP_DEPS='coverage pytest-cov coveralls sphinx'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
@@ -89,7 +89,7 @@ matrix:
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml astropy-healpix regions'
                FERMI_DIR='/home'
                SLAC_ST_BUILD=true
-               
+
         # Python 2, SLAC ST 11-07-00, gammapy master
         - os: linux
           sudo: required
@@ -132,7 +132,7 @@ matrix:
 install:
   # Download and install the ST binaries
   - if [[ $DOCKER_INSTALL == '' ]]; then
-        $ST_INSTALL; 
+        $ST_INSTALL;
         source condainstall.sh;
     else
         $DOCKER_INSTALL;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false
-      - PIP_DEPS='coverage pytest-cov coveralls sphinx'
+      - PIP_DEPS='coverage pytest-cov coveralls'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
@@ -39,6 +39,7 @@ matrix:
                PYTHON_VERSION=3.5
                ST_INSTALL=''
                DOCKER_INSTALL=''
+               CONDA_CHANNELS='conda-forge anaconda'
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false
-      - PIP_DEPS='coverage pytest-cov coveralls'
+      - PIP_DEPS='coverage pytest-cov coveralls sphinx sphinx_rtd_theme'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
-      - CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
+      - CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     global:
       - FERMI_DIR=$HOME/ScienceTools/x86_64-unknown-linux-gnu-libc2.19-10
       - SLAC_ST_BUILD=false
-      - PIP_DEPS='coverage pytest-cov coveralls sphinx sphinx_rtd_theme'
+      - PIP_DEPS='coverage pytest-cov'
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
@@ -39,6 +39,7 @@ matrix:
                PYTHON_VERSION=3.5
                ST_INSTALL=''
                DOCKER_INSTALL=''
+               PIP_DEPS='coverage pytest-cov coveralls sphinx sphinx_rtd_theme'
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh
                CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
       - CONDA2='conda install -y -c conda-forge healpy'
       - INSTALL_CMD='python setup.py install'
       - CONDA_CHANNELS=conda-forge
-      - CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml'
+      - CONDA_DEPS='gammapy numpy astropy scipy matplotlib pytest pyyaml sphinx sphinx_rtd_theme'
 
 matrix:
     include:
@@ -37,7 +37,6 @@ matrix:
         - os: linux
           env: NAME=docs
                PYTHON_VERSION=3.5
-               PIP_DEPS='coverage pytest-cov coveralls sphinx sphinx_rtd_theme'
                ST_INSTALL=''
                DOCKER_INSTALL=''
                CONDA_DOWNLOAD=Miniconda3-latest-Linux-x86_64.sh

--- a/travistests.sh
+++ b/travistests.sh
@@ -17,7 +17,7 @@ status=$?
 
 if [[ $NAME == 'docs' ]]; then
     cd docs;
-    sphinx-build -b html -d _build/doctrees . _build/html -W;
+    sphinx-build -b html -d _build/doctrees . _build/html;
     status=$[$status | $?]
 fi
 


### PR DESCRIPTION
This adds 'sphinx' as an explicit dependency that travis should pip install for all builds.