### PR TITLE
fixed _fit_extension_ebin call

### DIFF
--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -224,7 +224,12 @@ class ExtensionFit(object):
         o.loglike_ext = fit_output['loglike']
 
         if kwargs['fit_ebin']:
-            self._fit_extension_ebin(name, o, **kwargs)
+            self._fit_extension_ebin(name, o, 
+                                    spatial_model=spatial_model,
+                                    optimizer=kwargs['optimizer'],
+                                    psf_scale_fn=psf_scale_fn,
+                                    reoptimize=kwargs.get('reoptimize', True)
+                                    )
 
         if kwargs['save_model_map']:
             o.ext_tot_map = self.model_counts_map()


### PR DESCRIPTION
This pull request fixes an issue in the extension module when the extension fit in the energy bins is enabled with PSF scaling. Before, the `_fit_extension_ebin` call was done with `**kwargs` which broke the code since the `kwargs['psf_scale_fn']` is still the array for interpolation, but the function expects it to be a callable. Therefore, I removed the `**kwargs` from the function call and replaced it with setting the available kwargs explicitly. 