### PR TITLE
Commit with extension modifications (width_max, width_min and width_n…

### DIFF
--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -185,12 +185,14 @@ class ExtensionFit(object):
         if kwargs['fit_position']:
             ext_fit = self._fit_extension_full(name,
                                                spatial_model=spatial_model,
-                                               optimizer=kwargs['optimizer'])
+                                               optimizer=kwargs['optimizer'], width_max=width_max,
+					       width_min=width_min, width_nstep=width_nstep)
         else:
             ext_fit = self._fit_extension(name,
                                           spatial_model=spatial_model,
                                           optimizer=kwargs['optimizer'],
-                                          psf_scale_fn=psf_scale_fn)
+                                          psf_scale_fn=psf_scale_fn, width_max=width_max,
+					  width_min=width_min, width_nstep=width_nstep)
 
         o.update(ext_fit)
 
@@ -534,6 +536,9 @@ class ExtensionFit(object):
 
         spatial_model = kwargs.get('spatial_model', 'RadialGaussian')
         optimizer = kwargs.get('optimizer', {})
+	width_min = kwargs.get('width_min', 10**-2.0)
+	width_max = kwargs.get('width_max', 10**0.5)
+        width_nstep = kwargs.get('width_nstep', 21)
         fit_position = kwargs.get('fit_position', False)
         skydir = kwargs.get('skydir', self.roi[name].skydir)
         psf_scale_fn = kwargs.get('psf_scale_fn', None)
@@ -545,9 +550,9 @@ class ExtensionFit(object):
         # parts centered on the best-fit value -- this ensures better
         # fit stability
         if (src['SpatialModel'] in ['RadialGaussian', 'RadialDisk'] and
-                src['SpatialWidth'] > 0.1):
-            width_lo = np.logspace(-2.0, np.log10(src['SpatialWidth']), 11)
-            width_hi = np.logspace(np.log10(src['SpatialWidth']), 0.5, 11)
+                src['SpatialWidth'] > width_min):
+            width_lo = np.logspace(np.log10(width_min), np.log10(src['SpatialWidth']), width_nstep // 2 + (width_nstep % 2 > 0))
+            width_hi = np.logspace(np.log10(src['SpatialWidth']), np.log10(width_max), width_nstep // 2 + 1)
             loglike_lo = self._scan_extension(name, spatial_model=spatial_model,
                                               width=width_lo[::-1],
                                               optimizer=optimizer,
@@ -563,7 +568,7 @@ class ExtensionFit(object):
             width = np.concatenate((width_lo, width_hi[1:]))
             loglike = np.concatenate((loglike_lo, loglike_hi[1:]))
         else:
-            width = np.logspace(-2.0, 0.5, 21)
+            width = np.logspace(np.log10(width_min), np.log10(width_max), width_nstep)
             width = np.concatenate(([0.0], width))
             loglike = self._scan_extension(name, spatial_model=spatial_model,
                                            width=width, optimizer=optimizer,
@@ -572,7 +577,7 @@ class ExtensionFit(object):
                                            reoptimize=reoptimize)
 
         ul_data = utils.get_parameter_limits(width, loglike,
-                                             bounds=[10**-3.0, 10**0.5])
+                                             bounds=[10**-3.0, width_max])
 
         if not np.isfinite(ul_data['err']):
             ul_data['x0'] = width[np.argmax(loglike)]
@@ -589,7 +594,7 @@ class ExtensionFit(object):
         else:
             hilim = ul_data['x0'] + 2.0 * err
 
-        nstep = max(11, int((hilim - lolim) / err))
+        nstep = max(width_nstep, int((hilim - lolim) / err))
         width2 = np.linspace(lolim, hilim, nstep)
 
         loglike2 = self._scan_extension(name, spatial_model=spatial_model,
@@ -598,7 +603,7 @@ class ExtensionFit(object):
                                         psf_scale_fn=psf_scale_fn,
                                         reoptimize=reoptimize)
         ul_data2 = utils.get_parameter_limits(width2, loglike2,
-                                              bounds=[10**-3.0, 10**0.5])
+                                              bounds=[10**-3.0, width_max])
 
         self.logger.debug('width: %s', width)
         self.logger.debug('loglike: %s', loglike - np.max(loglike))

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -893,8 +893,8 @@ class TSMapGenerator(object):
             xyrange = [range(xmin, xmax), range(ymin, ymax)]
 
             wcs = map_geom.wcs.deepcopy()
-            npix = (ymax - ymin,xmax - xmin)
-            crpix = ( map_geom._crpix[1] - xmin, map_geom._crpix[0] - ymin)
+            npix = (xmax - xmin, ymax - ymin)
+            crpix = ( map_geom._crpix[0] - xmin, map_geom._crpix[1] - ymin)
             wcs.wcs.crpix[1] -= ymin
             wcs.wcs.crpix[0] -= xmin
 


### PR DESCRIPTION
Hi everyone,
,
I have spotted an potential mistake in the tsmap method of fermipy. In these lines (895-899)
```
            wcs = map_geom.wcs.deepcopy()
            npix = (ymax - ymin,xmax - xmin)
            crpix = ( map_geom._crpix[1] - xmin, map_geom._crpix[0] - ymin)
            wcs.wcs.crpix[1] -= ymin
            wcs.wcs.crpix[0] -= xmin
```

I think that the x and y axis seem inversed, so I proposed the correction below:

```
            wcs = map_geom.wcs.deepcopy()
            npix = (xmax - xmin, ymax - ymin)
            crpix = ( map_geom._crpix[0] - xmin, map_geom._crpix[1] - ymin)
            wcs.wcs.crpix[1] -= ymin
            wcs.wcs.crpix[0] -= xmin
```

To test this modification, I added a test script for rectangular ROI on the same model of "test_gtanalysis.py" named "test_gtanalysis_rectangular.py". This test is based on the analysis of Draco and PG1553 modified in order to have a rectangular ROI.

The second modifications is in the script extension.py. Luigi and I have noticed that the method "_fit_extension" do not take into account the parameters width_min, width_max and width_nstep given by the user. This can be a problem when trying to fit the extension of a source larger than 10**0.5 (the default value, hard coded):

`    def _fit_extension(self, name, **kwargs):


        spatial_model = kwargs.get('spatial_model', 'RadialGaussian')
        optimizer = kwargs.get('optimizer', {})
        fit_position = kwargs.get('fit_position', False)
        skydir = kwargs.get('skydir', self.roi[name].skydir)
        psf_scale_fn = kwargs.get('psf_scale_fn', None)
        reoptimize = kwargs.get('reoptimize', True)


        src = self.roi.copy_source(name)


        # If the source is extended split the likelihood scan into two
        # parts centered on the best-fit value -- this ensures better
        # fit stability
        if (src['SpatialModel'] in ['RadialGaussian', 'RadialDisk'] and
                src['SpatialWidth'] > 0.1):
            width_lo = np.logspace(-2.0, np.log10(src['SpatialWidth']), 11)
            width_hi = np.logspace(np.log10(src['SpatialWidth']), 0.5, 11)
            loglike_lo = self._scan_extension(name, spatial_model=spatial_model,
                                              width=width_lo[::-1],
                                              optimizer=optimizer,
                                              skydir=skydir,
                                              psf_scale_fn=psf_scale_fn,
                                              reoptimize=reoptimize)[::-1]
            loglike_hi = self._scan_extension(name, spatial_model=spatial_model,
                                              width=width_hi,
                                              optimizer=optimizer,
                                              skydir=skydir,
                                              psf_scale_fn=psf_scale_fn,
                                              reoptimize=reoptimize)
            width = np.concatenate((width_lo, width_hi[1:]))
            loglike = np.concatenate((loglike_lo, loglike_hi[1:]))
        else:
            width = np.logspace(-2.0, 0.5, 21)
            width = np.concatenate(([0.0], width))
            loglike = self._scan_extension(name, spatial_model=spatial_model,
                                           width=width, optimizer=optimizer,
                                           skydir=skydir,
                                           psf_scale_fn=psf_scale_fn,
                                           reoptimize=reoptimize)


        ul_data = utils.get_parameter_limits(width, loglike,
                                             bounds=[10**-3.0, 10**0.5])


        if not np.isfinite(ul_data['err']):
            ul_data['x0'] = width[np.argmax(loglike)]
            ul_data['err'] = ul_data['x0']
            ul_data['err_lo'] = ul_data['x0']
            ul_data['err_hi'] = ul_data['x0']


        imax = np.argmax(loglike)
        err = max(10**-2.0, ul_data['err'])
        lolim = max(min(ul_data['x0'], width[imax]) - 2.0 * err, 0)


        if np.isfinite(ul_data['ul']):
            hilim = 1.5 * ul_data['ul']
        else:
            hilim = ul_data['x0'] + 2.0 * err


        nstep = max(11, int((hilim - lolim) / err))
        width2 = np.linspace(lolim, hilim, nstep)


        loglike2 = self._scan_extension(name, spatial_model=spatial_model,
                                        width=width2, optimizer=optimizer,
                                        skydir=skydir,
                                        psf_scale_fn=psf_scale_fn,
                                        reoptimize=reoptimize)
        ul_data2 = utils.get_parameter_limits(width2, loglike2,
                                              bounds=[10**-3.0, 10**0.5])


        self.logger.debug('width: %s', width)
        self.logger.debug('loglike: %s', loglike - np.max(loglike))
        self.logger.debug('ul_data:\n %s', pprint.pformat(ul_data))
        self.logger.debug('width2: %s', width2)
        self.logger.debug('loglike2: %s', loglike2 - np.max(loglike2))
        self.logger.debug('ul_data2:\n %s', pprint.pformat(ul_data2))


        return MutableNamedTuple(
            ext=max(ul_data2['x0'], 10**-2.5),
            ext_ul95=ul_data2['ul'],
            ext_err_lo=ul_data2['err_lo'],
            ext_err_hi=ul_data2['err_hi'],
            ext_err=ul_data2['err'],
            loglike_ext=ul_data2['lnlmax'],
            ra=skydir.ra.deg,
            dec=skydir.dec.deg,
            glon=skydir.galactic.l.deg,
            glat=skydir.galactic.b.deg,
            pos_offset=0.0)`

Here, width_min, width_max and width_nstep have arbitrary values of 10**-2.0, 10**0.5 and 21.
I suggest the modifications below:
`    def _fit_extension(self, name, **kwargs):


        spatial_model = kwargs.get('spatial_model', 'RadialGaussian')
        optimizer = kwargs.get('optimizer', {})
	width_min = kwargs.get('width_min', 10**-2.0)
	width_max = kwargs.get('width_max', 10**0.5)
        width_nstep = kwargs.get('width_nstep', 21)
        fit_position = kwargs.get('fit_position', False)
        skydir = kwargs.get('skydir', self.roi[name].skydir)
        psf_scale_fn = kwargs.get('psf_scale_fn', None)
        reoptimize = kwargs.get('reoptimize', True)


        src = self.roi.copy_source(name)


        # If the source is extended split the likelihood scan into two
        # parts centered on the best-fit value -- this ensures better
        # fit stability
        if (src['SpatialModel'] in ['RadialGaussian', 'RadialDisk'] and
                src['SpatialWidth'] > width_min):
            width_lo = np.logspace(np.log10(width_min), np.log10(src['SpatialWidth']), width_nstep // 2 + (width_nstep % 2 > 0))
            width_hi = np.logspace(np.log10(src['SpatialWidth']), np.log10(width_max), width_nstep // 2 + 1)
            loglike_lo = self._scan_extension(name, spatial_model=spatial_model,
                                              width=width_lo[::-1],
                                              optimizer=optimizer,
                                              skydir=skydir,
                                              psf_scale_fn=psf_scale_fn,
                                              reoptimize=reoptimize)[::-1]
            loglike_hi = self._scan_extension(name, spatial_model=spatial_model,
                                              width=width_hi,
                                              optimizer=optimizer,
                                              skydir=skydir,
                                              psf_scale_fn=psf_scale_fn,
                                              reoptimize=reoptimize)
            width = np.concatenate((width_lo, width_hi[1:]))
            loglike = np.concatenate((loglike_lo, loglike_hi[1:]))
        else:
            width = np.logspace(np.log10(width_min), np.log10(width_max), width_nstep)
            width = np.concatenate(([0.0], width))
            loglike = self._scan_extension(name, spatial_model=spatial_model,
                                           width=width, optimizer=optimizer,
                                           skydir=skydir,
                                           psf_scale_fn=psf_scale_fn,
                                           reoptimize=reoptimize)


        ul_data = utils.get_parameter_limits(width, loglike,
                                             bounds=[10**-3.0, width_max])


        if not np.isfinite(ul_data['err']):
            ul_data['x0'] = width[np.argmax(loglike)]
            ul_data['err'] = ul_data['x0']
            ul_data['err_lo'] = ul_data['x0']
            ul_data['err_hi'] = ul_data['x0']


        imax = np.argmax(loglike)
        err = max(10**-2.0, ul_data['err'])
        lolim = max(min(ul_data['x0'], width[imax]) - 2.0 * err, 0)


        if np.isfinite(ul_data['ul']):
            hilim = 1.5 * ul_data['ul']
        else:
            hilim = ul_data['x0'] + 2.0 * err


        nstep = max(width_nstep, int((hilim - lolim) / err))
        width2 = np.linspace(lolim, hilim, nstep)


        loglike2 = self._scan_extension(name, spatial_model=spatial_model,
                                        width=width2, optimizer=optimizer,
                                        skydir=skydir,
                                        psf_scale_fn=psf_scale_fn,
                                        reoptimize=reoptimize)
        ul_data2 = utils.get_parameter_limits(width2, loglike2,
                                              bounds=[10**-3.0, width_max])


        self.logger.debug('width: %s', width)
        self.logger.debug('loglike: %s', loglike - np.max(loglike))
        self.logger.debug('ul_data:\n %s', pprint.pformat(ul_data))
        self.logger.debug('width2: %s', width2)
        self.logger.debug('loglike2: %s', loglike2 - np.max(loglike2))
        self.logger.debug('ul_data2:\n %s', pprint.pformat(ul_data2))


        return MutableNamedTuple(
            ext=max(ul_data2['x0'], 10**-2.5),
            ext_ul95=ul_data2['ul'],
            ext_err_lo=ul_data2['err_lo'],
            ext_err_hi=ul_data2['err_hi'],
            ext_err=ul_data2['err'],
            loglike_ext=ul_data2['lnlmax'],
            ra=skydir.ra.deg,
            dec=skydir.dec.deg,
            glon=skydir.galactic.l.deg,
            glat=skydir.galactic.b.deg,
            pos_offset=0.0)`

In my example, I am trying to fit the extension of the cocoon in the Cygnus X region. But the cocoon has an extension of approximately 3.2 degrees and the arbitrary limit of 3.162 degrees in the _fit_extension method can make the fit converge to a point like source. Here is the output of extension method for the cocoon before the modifications:
![4fgl_j2028 6+4110e_test_extension](https://user-images.githubusercontent.com/49984348/80970261-2ab53000-8e1b-11ea-9f37-ef8ce7fd017c.png)

And here is the output of extension method after the modifications:
![4fgl_j2028 6+4110e_extension](https://user-images.githubusercontent.com/49984348/80970307-3bfe3c80-8e1b-11ea-87f0-199c457cb1a8.png)
