### PR TITLE
Add 4FGL-DR2 to SourceFactory as well

### DIFF
--- a/fermipy/diffuse/source_factory.py
+++ b/fermipy/diffuse/source_factory.py
@@ -187,6 +187,8 @@ class SourceFactory(object):
             return catalog.Catalog4FGLP(fitsfile=catalog_file, extdir=catalog_extdir)
         elif catalog_type == '4FGL':
             return catalog.Catalog4FGL(fitsfile=catalog_file, extdir=catalog_extdir)
+        elif catalog_type == '4FGL-DR2':
+            return catalog.Catalog4FGLDR2(fitsfile=catalog_file, extdir=catalog_extdir)
         elif catalog_type == 'FL8Y':
             return catalog.CatalogFL8Y(fitsfile=catalog_file, extdir=catalog_extdir)
         else:


### PR DESCRIPTION
I think I should have added 4FGL-DR2 also to the fermipy.diffuse `SourceFactory` class. 