### PR TITLE
Update interface to matplotlib

### DIFF
--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -728,7 +728,7 @@ class SEDPlotter(object):
         xedge, yedge = np.meshgrid(xedge, yedge)
         im = ax.pcolormesh(xedge, yedge, llhMatrix.T,
                            vmin=llhcut, vmax=0, cmap=cmap,
-                           linewidth=0, shading='auto')
+                           linewidth=0, shading='auto') 
         cb = plt.colorbar(im)
         cb.set_label('Delta LogLikelihood')
 

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -143,8 +143,14 @@ def load_ds9_cmap():
                  [1.0, 1.0, 1.0]]
     }
 
-    plt.register_cmap(name='ds9_b', data=ds9_b)
-    plt.cm.ds9_b = plt.cm.get_cmap('ds9_b')
+    try:
+        plt.cm.ds9_b = plt.cm.get_cmap('ds9_b')
+
+    except ValueError:
+        ds9_cmap=LinearSegmentedColormap(name = 'ds9_b', segmentdata = ds9_b )
+        plt.register_cmap(cmap = ds9_cmap)
+        plt.cm.ds9_b = plt.cm.get_cmap('ds9_b')
+
     return plt.cm.ds9_b
 
 
@@ -161,8 +167,14 @@ def load_bluered_cmap():
                         (1.0, 0.0, 0.0))
                }
 
-    plt.register_cmap(name='bluered', data=bluered)
-    plt.cm.bluered = plt.cm.get_cmap('bluered')
+    try:
+        plt.cm.bluered = plt.cm.get_cmap('bluered')
+
+    except ValueError:
+        bluered_cmap=LinearSegmentedColormap(name = 'bluered', segmentdata = bluered )
+        plt.register_cmap(cmap = bluered_cmap)
+        plt.cm.bluered = plt.cm.get_cmap('bluered')
+    
     return plt.cm.bluered
 
 
@@ -294,9 +306,9 @@ class ImagePlotter(object):
 
         load_ds9_cmap()
         try:
-            colormap = plt.get_cmap(cmap)
+            colormap = plt.cm.get_cmap(cmap).copy()
         except:
-            colormap = plt.get_cmap('ds9_b')
+            colormap = plt.cm.get_cmap('ds9_b').copy()
 
         colormap.set_under(colormap(0))
 
@@ -716,7 +728,7 @@ class SEDPlotter(object):
         xedge, yedge = np.meshgrid(xedge, yedge)
         im = ax.pcolormesh(xedge, yedge, llhMatrix.T,
                            vmin=llhcut, vmax=0, cmap=cmap,
-                           linewidth=0)
+                           linewidth=0, shading='auto')
         cb = plt.colorbar(im)
         cb.set_label('Delta LogLikelihood')
 


### PR DESCRIPTION
Fix #399 

Fix #397 

Fix some more matplotlib related warnings (see below).

These should be gone now:

```
/Users/ich/hawc_software/miniconda3/envs/test_fermipy/lib/python3.7/site-packages/fermipy/plotting.py:148: UserWarning: Trying to register the cmap ‘ds9_b’ which already exists.
 plt.register_cmap(cmap = ds9_cmap)

/Users/ich/hawc_software/miniconda3/envs/test_fermipy/lib/python3.7/site-packages/fermipy/plotting.py:304: MatplotlibDeprecationWarning: You are modifying the state of a globally registered colormap. This has been deprecated since 3.3 and in 3.6, you will not be able to modify a registered colormap in-place. To remove this warning, you can make a copy of the colormap first. cmap = mpl.cm.get_cmap(“magma”).copy()
 colormap.set_under(colormap(0))

/Users/ich/hawc_software/miniconda3/envs/test_fermipy/lib/python3.7/site-packages/fermipy/plotting.py:731: MatplotlibDeprecationWarning: shading=‘flat’ when X and Y have the same dimensions as C is deprecated since 3.3. Either specify the corners of the quadrilaterals with X and Y, or pass shading=‘auto’, ‘nearest’ or ‘gouraud’, or set rcParams[‘pcolor.shading’]. This will become an error two minor releases later.
 linewidth=0)
```
