### PR TITLE
Enable CI tests for dev version of Gammapy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,3 +60,9 @@ jobs:
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
+    - name: Test gammapy dev version with pytest
+      shell: bash -l {0}
+      run: |
+        conda remove gammapy --force
+        python -m pip install git+https://github.com/gammapy/gammapy.git --no-deps
+        python -m pytest fermipy


### PR DESCRIPTION
This PR adds a new step in the Github action CI jobs to test `fermipy` with the development version of `gammapy`.
/cc @adonath