### PR TITLE
Small updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,8 +22,9 @@ jobs:
       with:
         activate-environment: fermipy
         environment-file: environment.yml
-        python-version: ${{ matrix.python-versino}}
+        python-version: ${{ matrix.python-version }}
         auto-activate-base: false
+        mamba-version: "*"
     - name: Install
       shell: bash -l {0}
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - astropy-healpix
   - gammapy>=0.18
   - fermitools
+  - clhep=2.4.4.1

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -800,7 +800,7 @@ def create_wtd_psf(skydir, ltc, event_class, event_types, dtheta,
     """
     #npts = int(np.ceil(32. / bins_per_dec(egy_bins)))
     egy_bins = np.exp(utils.split_bin_edges(np.log(egy_bins), npts))
-    etrue_bins = 10**np.linspace(1.0, 6.5, np.int(np.ceil(nbin * 5.5 + 1)))
+    etrue_bins = 10**np.linspace(1.0, 6.5, int(np.ceil(nbin * 5.5 + 1)))
     etrue = 10**utils.edge_to_center(np.log10(etrue_bins))
 
     psf = create_avg_psf(skydir, ltc, event_class, event_types, dtheta,
@@ -832,7 +832,7 @@ def calc_drm(skydir, ltc, event_class, event_types,
     npts = int(np.ceil(128. / bins_per_dec(egy_bins)))
     egy_bins = np.exp(utils.split_bin_edges(np.log(egy_bins), npts))
 
-    etrue_bins = 10**np.linspace(1.0, 6.5, np.int(np.ceil(nbin * 5.5 + 1)))
+    etrue_bins = 10**np.linspace(1.0, 6.5, int(np.ceil(nbin * 5.5 + 1)))
     egy = 10**utils.edge_to_center(np.log10(egy_bins))
     egy_width = utils.edge_to_width(egy_bins)
     etrue = 10**utils.edge_to_center(np.log10(etrue_bins))
@@ -901,7 +901,7 @@ def calc_counts_edisp(skydir, ltc, event_class, event_types,
 
     # Split energy bins
     egy_bins = np.exp(utils.split_bin_edges(np.log(egy_bins), npts))
-    etrue_bins = 10**np.linspace(1.0, 6.5, np.int(np.ceil(nbin * 5.5 + 1)))
+    etrue_bins = 10**np.linspace(1.0, 6.5, int(np.ceil(nbin * 5.5 + 1)))
     drm = calc_drm(skydir, ltc, event_class, event_types,
                    egy_bins, cth_bins, nbin=nbin)
     cnts_etrue = calc_counts(skydir, ltc, event_class, event_types,

--- a/fermipy/plotting.py
+++ b/fermipy/plotting.py
@@ -282,8 +282,7 @@ class ImagePlotter(object):
                           'linewidths': 1.0}
 
         kwargs_imshow = {'interpolation': 'nearest',
-                         'origin': 'lower', 'norm': None,
-                         'vmin': None, 'vmax': None}
+                         'origin': 'lower', 'norm': None}
 
         zscale = kwargs.get('zscale', 'lin')
         gamma = kwargs.get('gamma', 0.5)
@@ -699,8 +698,9 @@ class SEDPlotter(object):
         else:
             fmin, fmax = np.log10(ylim)
 
-        fluxM = np.arange(fmin, fmax, 0.01)
-        fbins = len(fluxM)
+        fluxEdges = np.arange(fmin, fmax, 0.01)
+        fluxCenters = 0.5*(fluxEdges[1:] + fluxEdges[:-1])
+        fbins = len(fluxCenters)
         llhMatrix = np.zeros((len(sed['e_ctr']), fbins))
 
         # loop over energy bins
@@ -712,9 +712,9 @@ class SEDPlotter(object):
             logl -= np.max(logl)
             try:
                 fn = interpolate.interp1d(flux, logl, fill_value='extrapolate')
-                logli = fn(fluxM)
+                logli = fn(fluxCenters)
             except:
-                logli = np.interp(fluxM, flux, logl)
+                logli = np.interp(fluxCenters, flux, logl)
             llhMatrix[i, :] = logli
 
         cmap = copy.deepcopy(plt.cm.get_cmap(cmap))
@@ -724,7 +724,7 @@ class SEDPlotter(object):
             cmap = truncate_colormap(cmap, cmap_trunc_lo, cmap_trunc_hi, 1024)
 
         xedge = 10**np.insert(sed['loge_max'], 0, sed['loge_min'][0])
-        yedge = np.logspace(fmin, fmax, fbins)
+        yedge = 10**fluxEdges
         xedge, yedge = np.meshgrid(xedge, yedge)
         im = ax.pcolormesh(xedge, yedge, llhMatrix.T,
                            vmin=llhcut, vmax=0, cmap=cmap,

--- a/fermipy/tests/test_gtanalysis.py
+++ b/fermipy/tests/test_gtanalysis.py
@@ -9,10 +9,10 @@ from fermipy.tests.utils import requires_dependency,\
     requires_st_version, requires_git_version, create_diffuse_dir
 from fermipy import spectrum
 
-try:
-    from fermipy import gtanalysis
-except ImportError:
-    pass
+#try:
+from fermipy import gtanalysis
+#except ImportError:
+#    pass
 
 # Skip tests in this file if Fermi ST aren't available
 pytestmark = requires_st_version('02-00-00')


### PR DESCRIPTION
Some small updates to silence numpy warnings and incorporate changes to the matplotlib interface.

Fixed an inconsistency in the SED likelihood profile plot, where previously we provided the bin *edges* of the energy bins (X axis) but the bin *centers* of the flux bins (Y axis) to `pcolormesh`. Older versions of matplotlib would silently drop a column, but newer versions are more strict.

Now using mamba to install the environment in the CI tests (speedup).

Pinned the version of CLHEP as fermitools 2.0.8 are incompatible with newer versions. This will be removed for the next release of fermitools.

Some of the tests still fail due to incompatibility of some dependencies with astropy 3. Upgrading astropy fixes those, but creates multiple new issues as fermitools 2.0.8 need astropy 3. Unfortunately, there is no way to resolve this except for downgrading and pinning multiple dependencies - for example, we currently require gammapy>0.18 in the master branch, which needs astropy 4 etc. I suggest waiting for the next release of fermitools :/ 

