### PR TITLE
Fixes for the lightcurve issue

### DIFF
--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -565,7 +565,8 @@ class PSFModel(object):
 
         exp = calc_exp(skydir, ltc, event_class, event_types,
                        energies, cth_bins)
-
+        if sum(sum(np.abs(exp))) == 0:
+            raise RuntimeError('irfs.py(569): Zero exposure!')
         return cls(dtheta, energies, cth_bins, np.squeeze(exp), np.squeeze(psf),
                    np.squeeze(wts))
 

--- a/fermipy/lightcurve.py
+++ b/fermipy/lightcurve.py
@@ -160,7 +160,7 @@ def _process_lc_bin(itime, name, config, basedir, workdir, diff_sources, const_s
         print('Analysis failed in time range %i %i' %
               (time[0], time[1]))
         print(sys.exc_info()[0])
-        return {}
+        return {'fit_success': False}
 
     gta._lck_params = lck_params
     # Recompute source map for source of interest and sources within 3 deg


### PR DESCRIPTION
Adding the changes suggested by @jeget in https://github.com/fermiPy/fermipy/issues/362#issuecomment-802537434 to fix the key error referenced in many issues (#362, #411, #446, #405).

I'd like to get some input on these from @jeget and anyone who uses the lightcurve module regularly. Are these fixes enough or were you still running into issues?