### PR TITLE
Change PLEC to PLSuperExpCutoff4 in curvature test

### DIFF
--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -3901,14 +3901,14 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         pars2 = {
             'Prefactor': copy.deepcopy(prefactor),
             'Index1': copy.deepcopy(index),
-            'Cutoff': {'value': 1000.0, 'scale': 1E3,
-                       'min': 10.0, 'max': 1E4, 'free': True},
-            'Index2': {'value': 1.0, 'scale': 1.0,
-                       'min': 1.0, 'max': 1.0, 'free': False},
+            'Expfactor_S': {'value': 0.1, 'scale': 1.0,
+                       'min': 0.0, 'max': 10.0, 'free': True},
+            'Index2': {'value': 0.6667, 'scale': 1.0,
+                       'min': 0.1, 'max': 1.0, 'free': True},
             'Scale': copy.deepcopy(scale)
         }
 
-        self.set_source_spectrum(str(name), 'PLSuperExpCutoff',
+        self.set_source_spectrum(str(name), 'PLSuperExpCutoff4',
                                  spectrum_pars=pars2,
                                  update_source=False)
 
@@ -3933,7 +3933,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         self.logger.info('LogLike_PL: %12.3f LogLike_LP: %12.3f LogLike_PLE: %12.3f',
                          o.loglike_pl, o.loglike_lp, o.loglike_ple)
         self.logger.info('TS_curv:        %.3f (LP)', o.lp_ts_curv)
-        self.logger.info('TS_curv:        %.3f (PLE)', o.ple_ts_curv)
+        self.logger.info('TS_curv:        %.3f (PLSE)', o.ple_ts_curv)
         return o
 
     def bowtie(self, name, fd=None, loge=None):

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -3900,8 +3900,8 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
 
         pars2 = {
             'Prefactor': copy.deepcopy(prefactor),
-            'Index1': copy.deepcopy(index),
-            'Expfactor_S': {'value': 0.1, 'scale': 1.0,
+            'IndexS': copy.deepcopy(index),
+            'ExpfactorS': {'value': 0.1, 'scale': 1.0,
                        'min': 0.0, 'max': 10.0, 'free': True},
             'Index2': {'value': 0.6667, 'scale': 1.0,
                        'min': 0.1, 'max': 1.0, 'free': True},

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -3930,7 +3930,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
                               loglike_lp=fit_lp['loglike'],
                               loglike_ple=fit_ple['loglike'])
 
-        self.logger.info('LogLike_PL: %12.3f LogLike_LP: %12.3f LogLike_PLE: %12.3f',
+        self.logger.info('LogLike_PL: %12.3f LogLike_LP: %12.3f LogLike_PLSE: %12.3f',
                          o.loglike_pl, o.loglike_lp, o.loglike_ple)
         self.logger.info('TS_curv:        %.3f (LP)', o.lp_ts_curv)
         self.logger.info('TS_curv:        %.3f (PLSE)', o.ple_ts_curv)


### PR DESCRIPTION
As far as I understand, the old `PLEC` is not used anymore in 4FGL-DR3. I changed it to `PLSuperExpCutoff4` which is the new parametrization of the (super-exponential) cutoff PL. It contains the logParabola shape as an edge case (setting the parameter `b` (4FGL-DR3 paper) aka `PLEC_Exp_Index` (4FGL) aka `Index2` (fermipy) to 0.

I'd like to get some feedback on the implementation here. In [4FGL-DR3](https://arxiv.org/pdf/2201.11184.pdf), most of the sources fit with this function were pulsars. The authors chose to **fit** the aforementioned parameter `b` for pulsars with TS>1e4, and **fix** it to the value 2/3 for pulsars with TS<1e4. Additionally, "3C 454.3 and the five other AGN with TS > 80,000 were modeled with PLEC and **free** `b` as well" [4FGL-DR3]. 

In the `curvature` function, I kept the logParabola fit, and added a `PLSuperExpCutoff4` fit with all parameters free (including the aforementioned `b`). I picked 2/3 as the starting value for `b` since it's the default for pulsars.

Any thoughts or opinions? Should we make this more  customizable, e.g. allow the user to fix `b` for the curvature test? I'm worried that the fit may be unstable for weaker sources. 

I'm playing around with an example, but I've run into another issue - the PL fit inside the curvature test doesn't converge to the same values as my external PL fit. Maybe due to different starting values? In any case, starting from a `PLSuperExpCutoff4`, my curvature test **overestimates** the curvature because the PL fit doesn't find the global minimum 🤔 