### PR TITLE
modified met_to_mjd to correct issue 460

### DIFF
--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -16,6 +16,7 @@ from scipy.optimize import brentq
 from scipy.ndimage.measurements import label
 import scipy.special as special
 from numpy.core import defchararray
+from astropy.time import Time
 try:
     from astropy.extern import six
 except ImportError:
@@ -277,7 +278,23 @@ def strip_suffix(filename, suffix):
 
 def met_to_mjd(time):
     """"Convert mission elapsed time to mean julian date."""
-    return 54682.65 + (time - 239557414.0) / (86400.)
+
+    # The LAT refrence epoch in MJD
+    # https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html
+    MJDREFF = 51910
+    MJDREFFI = 7.428703703703703 * (10**-4)
+
+    # Convert from elapsed seconds to elapsed days
+    elapsed_days = time / 86400.
+
+    # Add the elapsed days to the refrence epoch
+    MJD_added = MJDREFF + MJDREFFI + elapsed_days
+
+    # Load into astropy, specifying it is in MJD/terrestrial time
+    MJD_final = Time(MJD_added, format='mjd', scale='tt')
+
+    # Return the MJD in UTC format
+    return MJD_final.utc.mjd
 
 
 RA_NGP = np.radians(192.8594812065348)

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -16,7 +16,6 @@ from scipy.optimize import brentq
 from scipy.ndimage.measurements import label
 import scipy.special as special
 from numpy.core import defchararray
-from astropy.time import Time
 try:
     from astropy.extern import six
 except ImportError:
@@ -288,13 +287,13 @@ def met_to_mjd(time):
     elapsed_days = time / 86400.
 
     # Add the elapsed days to the refrence epoch
-    MJD_added = MJDREFF + MJDREFFI + elapsed_days
+    MJD = MJDREFF + MJDREFFI + elapsed_days
 
-    # Load into astropy, specifying it is in MJD/terrestrial time
-    MJD_final = Time(MJD_added, format='mjd', scale='tt')
-
-    # Return the MJD in UTC format
-    return MJD_final.utc.mjd
+    # Return the MJD in TT format.
+    # Note: NASA's HEASARC tool xTime returns MJD in UTC format, which differs
+    # slightly from what is returned here.
+    # Note: Some truncation occurs, as only a float is returned.
+    return MJD
 
 
 RA_NGP = np.radians(192.8594812065348)


### PR DESCRIPTION
Addresses issue #460. 

MJD reference time from [Fermi's Cicerone](https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html) is used to convert MET to MJD. 

astropy.time.Time to converts the MJD from TT to UTC time scale.

A float representing MJD in UTC is returned.

In building this function, I referenced:
[gammapy.utils.time](https://docs.gammapy.org/dev/_modules/gammapy/utils/time.html) 
[PINT's "read_fits_event_mjds"](https://github.com/nanograv/PINT/blob/33fc790782958784b0078b1e74df5e19f0b82eb8/src/pint/fits_utils.py)