### PR TITLE
Compatibility with Astropy 5.10

### DIFF
--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -176,7 +176,7 @@ def read_projection_from_fits(fitsfile, extname=None):
     return None, f, None
 
 
-def write_tables_to_fits(filepath, tablelist, clobber=False,
+def write_tables_to_fits(filepath, tablelist, overwrite=False,
                          namelist=None, cardslist=None, hdu_list=None):
     """
     Write some astropy.table.Table objects to a single fits file

--- a/fermipy/fits_utils.py
+++ b/fermipy/fits_utils.py
@@ -176,7 +176,7 @@ def read_projection_from_fits(fitsfile, extname=None):
     return None, f, None
 
 
-def write_tables_to_fits(filepath, tablelist, overwrite=False,
+def write_tables_to_fits(filepath, tablelist, clobber=False,
                          namelist=None, cardslist=None, hdu_list=None):
     """
     Write some astropy.table.Table objects to a single fits file

--- a/fermipy/ltcube.py
+++ b/fermipy/ltcube.py
@@ -443,4 +443,4 @@ class LTCube(HpxMap):
                 hdu.header['TSTOP'] = ''
                 
         with fits.HDUList(hdus) as hdulist:
-            hdulist.writeto(outfile, clobber=True)
+            hdulist.writeto(outfile, overwrite=True)

--- a/fermipy/scripts/coadd.py
+++ b/fermipy/scripts/coadd.py
@@ -34,7 +34,7 @@ def main():
                         args.files[0])
 
     if args.output:
-        hdulist.writeto(args.output, clobber=args.clobber, output_verify='silentfix')
+        hdulist.writeto(args.output, overwrite=args.clobber, output_verify='silentfix')
 
 if __name__ == '__main__':
     main()

--- a/fermipy/scripts/gather_srcmaps.py
+++ b/fermipy/scripts/gather_srcmaps.py
@@ -48,7 +48,7 @@ def main():
     hdulistout = do_gather(args.files)
     
     if args.output:
-        hdulistout.writeto(args.output, clobber=args.clobber)
+        hdulistout.writeto(args.output, overwrite=args.clobber)
 
         if args.gzip:
             os.system('gzip -9 %s'%args.output)

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -69,7 +69,7 @@ def extract_images_from_tscube(infile, outfile):
         outhdulist.append(hdu)
 
     hdulist = fits.HDUList(outhdulist)
-    hdulist.writeto(outfile, clobber=True)
+    hdulist.writeto(outfile, overwrite=True)
     return hdulist
 
 
@@ -78,7 +78,7 @@ def convert_tscube(infile, outfile):
     inhdulist = fits.open(infile)
     if 'dloglike_scan' in inhdulist['SCANDATA'].columns.names:
         if infile != outfile:
-            inhdulist.writeto(outfile, clobber=True)
+            inhdulist.writeto(outfile, overwrite=True)
         return
     elif 'E_MIN_FL' in inhdulist['EBOUNDS'].columns.names:
         return convert_tscube_old(infile, outfile)
@@ -96,7 +96,7 @@ def convert_tscube(infile, outfile):
                 colname = col.name.lower()
                 col.name = colname.replace('dfde', 'dnde')
 
-    inhdulist.writeto(outfile, clobber=True)
+    inhdulist.writeto(outfile, overwrite=True)
     return inhdulist
 
 
@@ -107,7 +107,7 @@ def convert_tscube_old(infile, outfile):
     # If already in the new-style format just write and exit
     if 'DLOGLIKE_SCAN' in inhdulist['SCANDATA'].columns.names:
         if infile != outfile:
-            inhdulist.writeto(outfile, clobber=True)
+            inhdulist.writeto(outfile, overwrite=True)
         return
 
     # Get stuff out of the input file
@@ -256,7 +256,7 @@ def convert_tscube_old(infile, outfile):
 
     hdulist['SCANDATA'].header['UL_CONF'] = 0.95
 
-    hdulist.writeto(outfile, clobber=True)
+    hdulist.writeto(outfile, overwrite=True)
 
     return hdulist
 

--- a/fermipy/validate/tools.py
+++ b/fermipy/validate/tools.py
@@ -236,9 +236,9 @@ class Validator(object):
 
         if compress:
             fp = gzip.GzipFile(outfile + '.gz', 'wb')
-            hdulist.writeto(fp, clobber=True)
+            hdulist.writeto(fp, overwrite=True)
         else:
-            hdulist.writeto(outfile, clobber=True)
+            hdulist.writeto(outfile, overwrite=True)
 
     def calc_sep(self, tab, src_list):
 

--- a/fermipy/wcs_utils.py
+++ b/fermipy/wcs_utils.py
@@ -506,4 +506,4 @@ def extract_mapcube_region(infile, skydir, outfile, maphdu=0):
 
     hdu_image = fits.PrimaryHDU(data, header=region_wcs.to_header())
     hdulist = fits.HDUList([hdu_image, h['ENERGIES']])
-    hdulist.writeto(outfile, clobber=True)
+    hdulist.writeto(outfile, overwrite=True)


### PR DESCRIPTION
Changed change `clobber` -> `overwrite` in astropy fits `writeto` function everywhere (deprecated for a while, but finally enforced in astropy 5.10).

Fixes #468 .

