### PR TITLE
Install RC fermitools from new rc label on conda

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,7 +33,7 @@ environment.
 
 .. code-block:: bash
 
-   $ mamba create --name fermipy -c conda-forge -c fermi -c fermi/label/dev python=3.9 "fermitools>=2.1.0" healpy gammapy
+   $ mamba create --name fermipy -c conda-forge -c fermi -c fermi/label/rc python=3.9 "fermitools>=2.1.0" healpy gammapy
    $ mamba activate fermipy
    $ pip install fermipy
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: fermipy
 channels:
-  - fermi/label/dev
+  - fermi/label/rc
   - fermi
   - conda-forge
 dependencies:


### PR DESCRIPTION
(instead of dev label which sometimes has builds that don't work).