### PR TITLE
Do not scan extension values outside of user-provided range

### DIFF
--- a/fermipy/extension.py
+++ b/fermipy/extension.py
@@ -559,12 +559,16 @@ class ExtensionFit(object):
         reoptimize = kwargs.get('reoptimize', True)
 
         src = self.roi.copy_source(name)
+        
+        if (src['SpatialModel'] in ['RadialGaussian', 'RadialDisk'] and
+                (src['SpatialWidth'] < width_min or src['SpatialWidth'] > width_max ) ):
+            self.logger.warning(f"The extension scan does not cover the nominal extension value of {src['SpatialWidth']:.2f}, consider enlarging the scan range or re-optimizing the ROI with {src['name']} at a more appropriate extension.")
 
         # If the source is extended split the likelihood scan into two
         # parts centered on the best-fit value -- this ensures better
         # fit stability
         if (src['SpatialModel'] in ['RadialGaussian', 'RadialDisk'] and
-                src['SpatialWidth'] > width_min):
+                (src['SpatialWidth'] > width_min and src['SpatialWidth'] < width_max ) ):
             width_lo = np.logspace(np.log10(width_min), np.log10(src['SpatialWidth']), width_nstep // 2 + (width_nstep % 2 > 0))
             width_hi = np.logspace(np.log10(src['SpatialWidth']), np.log10(width_max), width_nstep // 2 + 1)
             loglike_lo = self._scan_extension(name, spatial_model=spatial_model,


### PR DESCRIPTION
See discussion on [LAT slack](https://fermi-lat.slack.com/archives/C4ZCMN82E/p1654267228430679).

During the extension fit, the nominal extension value (from the model that the spectra were optimized on) is added to the list of extension values to scan over. This pull request changes adds an additional condition to the code to avoid scanning beyond the limits of the user-provided extension range. 