### PR TITLE
Switch to release version 2.2 of fermitools

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -48,6 +48,10 @@ To support a new catalog will require some changes in the
    ``fermipy/data/catalogs`` area, so the catalog files should be
    added to that area.
 
+Installing development versions of fermitools
+---------------------------------------------
+
+To test fermipy against future versions of fermitools, use the ``rc`` (release candidate) or ``dev`` (development) versions in the respective conda channels, e.g. ``mamba install -c fermi/label/rc fermitools=2.1.36``.
 
 
 Creating a New Release

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,14 +5,14 @@ Installation
 
 .. warning::
 
-   Fermitools 2.1.xx and fermipy 1.1.xx are still undergoing testing.
-   Please refer to fermipy 1.0.1 and fermitools 2.0.8 for science analysis.
+   Fermipy 1.1.xx is still undergoing testing.
+   Please refer to fermipy 1.0.1 and fermitools 2.0.8 for the previous version.
    Report any issues on `github <https://github.com/fermiPy/fermipy/issues>`_.
    
 .. note::
 
-   From version 1.1.1 fermipy is only compatible with
-   fermitools version 2.1 or later, and with python version 3.9 or
+   From version 1.1.xx, fermipy is only compatible with
+   fermitools version 2.2 or later, and with python version 3.9 or
    higher.
    If you are using an earlier version, you will need to download and
    install the latest version from the `FSSC
@@ -33,7 +33,7 @@ environment.
 
 .. code-block:: bash
 
-   $ mamba create --name fermipy -c conda-forge -c fermi -c fermi/label/rc python=3.9 "fermitools>=2.1.0" healpy gammapy
+   $ mamba create --name fermipy -c conda-forge -c fermi python=3.9 "fermitools>=2.2.0" healpy gammapy
    $ mamba activate fermipy
    $ pip install fermipy
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: fermipy
 channels:
-  - fermi/label/rc
   - fermi
   - conda-forge
 dependencies:
@@ -13,4 +12,4 @@ dependencies:
   - healpy
   - astropy-healpix
   - gammapy>=0.18
-  - fermitools>=2.1.0
+  - fermitools>=2.2.0


### PR DESCRIPTION
Update instructions to refer to release version 2.2 of the fermitools.

I aim to get fermpy 1.2 released soon once the remaining issues have been ironed out.