### PR TITLE
Fix indexing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,18 @@ Changelog
 This page is a changelog for releases of Fermipy.  You can also browse
 releases on `Github <https://github.com/fermiPy/fermipy/releases>`_.
 
+1.1.4 (06/24/2022)
+-----------------
+* Compatibility with numpy 1.23
+
+1.1.3 (06/04/2022)
+-----------------
+* Compatibility with astropy 5.1
+
 1.1.2 (05/26/2022)
 -----------------
 * Minor bug fixes & doc updates.
-* Implemented new super-exponential cutoff PL for curvature test. 
+* Implemented new super-exponential cutoff PL for curvature test.
 
 1.1.1 (05/13/2022)
 -----------------

--- a/fermipy/irfs.py
+++ b/fermipy/irfs.py
@@ -48,8 +48,8 @@ def loglog_quad(x, y, dim):
 
     xs0[dim] = slice(None, -1)
     xs1[dim] = slice(1, None)
-    log_ratio = np.log(x[xs1] / x[xs0])
-    return 0.5 * (y[ys0] * x[xs0] + y[ys1] * x[xs1]) * log_ratio
+    log_ratio = np.log(x[tuple(xs1)] / x[tuple(xs0)])
+    return 0.5 * (y[tuple(ys0)] * x[tuple(xs0)] + y[tuple(ys1)] * x[tuple(xs1)]) * log_ratio
 
 
 def bins_per_dec(edges):

--- a/fermipy/lightcurve.py
+++ b/fermipy/lightcurve.py
@@ -361,7 +361,7 @@ class LightCurve(object):
             elif isinstance(v, np.ndarray):
                 o[k] = np.nan * np.ones(o['tmin'].shape + v.shape)
                 o[k+'_fixed'] = copy.deepcopy(o[k])
-            elif isinstance(v, np.float):
+            elif isinstance(v, float):
                 o[k] = np.nan * np.ones(o['tmin'].shape)
                 o[k+'_fixed'] = copy.deepcopy(o[k])
 

--- a/fermipy/skymap.py
+++ b/fermipy/skymap.py
@@ -4,7 +4,7 @@ import copy
 import numpy as np
 import healpy as hp
 from scipy.interpolate import RegularGridInterpolator
-from scipy.ndimage.interpolation import map_coordinates
+from scipy.ndimage import map_coordinates
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.table import Table

--- a/fermipy/sourcefind_utils.py
+++ b/fermipy/sourcefind_utils.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
 import scipy
-from scipy.ndimage.filters import maximum_filter
+from scipy.ndimage import maximum_filter
 from astropy.coordinates import SkyCoord
 from fermipy import utils
 from fermipy import wcs_utils

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import copy
 import numpy as np
 from scipy.ndimage import map_coordinates
-from scipy.ndimage.interpolation import spline_filter
-from scipy.ndimage.interpolation import shift
+from scipy.ndimage import spline_filter
+from scipy.ndimage import shift
 from astropy.io import fits
 import fermipy.utils as utils
 import fermipy.wcs_utils as wcs_utils

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -13,7 +13,7 @@ import scipy.optimize
 from scipy.ndimage import map_coordinates
 from scipy.interpolate import UnivariateSpline
 from scipy.optimize import brentq
-from scipy.ndimage.measurements import label
+from scipy.ndimage import label
 import scipy.special as special
 from numpy.core import defchararray
 try:
@@ -1416,7 +1416,7 @@ def tolist(x):
         return dict(x)
     elif isinstance(x, np.bool_):
         return bool(x)
-    elif isstr(x) or isinstance(x, np.str):
+    elif isstr(x) or isinstance(x, str):
         x = str(x)  # convert unicode & numpy strings
         try:
             return int(x)


### PR DESCRIPTION
Fix the following error in `irfs.py` which has started to show up with newer numpy (??) versions.

```
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```

Also fix some more warnings before they can turn into errors. 