### PR TITLE
Basic setup for doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,193 @@
+name: Docs
+on: [push, release]
+
+jobs:
+  notebooks:
+    name: "Build the notebooks for the docs"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Init Environment
+        #shell: bash -l {0}
+        run: |
+          
+          brew update
+          brew install --cask basictex
+
+          eval "$(/usr/libexec/path_helper)"
+
+      - name: Setup base pkgs
+        #shell: bash -l {0}
+        run: |
+
+          python -m pip install --upgrade pip wheel
+
+          python -m pip install numpy numba tempita jupytext jupyterthemes jupyter_latex_envs papermill matplotlib astropy pandas tables healpy
+          python -m pip install ebltable black
+
+          
+      - name: Install the package
+        #shell: bash -l {0}
+        run: |
+
+          python setup.py install
+          
+      - name: Execute the notebooks
+        #shell: bash -l {0}
+        run: |
+
+          # do the execution and conversion
+          jupytext --to ipynb --execute docs/md_docs/*.md
+
+          # move the new notebooks into the notebooks folder
+
+          mv docs/md_docs/*.ipynb docs/notebooks/
+
+          # check that they are there
+          ls docs/notebooks
+
+
+        env:
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          NUMEXPR_NUM_THREADS: 1
+          MPLBACKEND: "Agg"
+
+          
+      - uses: actions/upload-artifact@v2
+        with:
+          name: notebooks-for-${{ github.sha }}
+          path: docs/notebooks
+
+
+      - name: Sleep for 5 min
+        uses: juliangruber/sleep-action@v1
+        with:
+          time: 5m
+
+      - name: Trigger RTDs build
+        uses: dfm/rtds-action@main
+        with:
+          webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}
+          webhook_token: ${{ secrets.RTDS_WEBHOOK_TOKEN }}
+          commit_ref: ${{ github.ref }}
+
+  api_doc:
+    name: "Create the API stubs"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build the API doc
+        run: |
+
+          brew install c-blosc
+          brew install hdf5
+
+          pip3 install tempita
+          pip3 install cython
+          pip3 install numpy scipy numba astropy
+
+          python setup.py develop
+
+          brew install sphinx-doc pandoc
+
+          pip3 install wheel
+          pip3 install mock recommonmark
+          pip3 install sphinx-rtd-dark-mode
+          pip3 install -U sphinx
+
+
+          sphinx-apidoc -f -o docs/api/ astromodels
+
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: api-stubs-for-${{ github.sha }}
+          path: docs/api
+
+
+  build_docs:
+    name: "Build the Documentation"
+    runs-on: macos-latest
+    needs: [notebooks, api_doc]
+    steps:
+
+
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install package
+        run: |
+
+          brew install c-blosc
+          brew install hdf5
+
+
+          pip3 install tempita
+          pip3 install numpy scipy numba astropy
+
+          brew install sphinx-doc pandoc
+
+          pip3 install wheel
+          pip3 install mock recommonmark
+          pip3 install sphinx-rtd-dark-mode sphinx-math-dollar
+          pip3 install -r docs/requirements.txt
+
+          python3 setup.py develop
+
+          rm -rf docs/md/*
+
+
+
+      - uses: actions/download-artifact@master
+        with:
+          name: notebooks-for-${{ github.sha }}
+          path: docs/notebooks
+
+
+      - uses: actions/download-artifact@master
+        with:
+          name: api-stubs-for-${{ github.sha }}
+          path: docs/notebooks/api
+
+      - name: Build and Commit
+        uses: sphinx-notes/pages@v2
+        with:
+          documentation_path: docs
+          sphinx_version: 5.1.1
+          requirements_path: docs/requirements.txt
+
+
+      - name: Push changes
+        if: github.event_name == 'push' #&& startsWith(github.event.ref, 'refs/tags')
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/docs/md_docs/draco.md
+++ b/docs/md_docs/draco.md
@@ -1,0 +1,306 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.14.1
+  kernelspec:
+    display_name: Python 2
+    language: python
+    name: python2
+---
+
+# Dark Matter Analysis of the Draco dSph Galaxy
+
+
+This tutorial demonstrates how to perform an analysis of the Draco dSph galaxy.  This tutorial assumes that you have first gone through the [PG 1553](pg1553.ipynb) analysis tutorial.  In this example we will use the following data selection which is chosen to match the selection used in the [6-year LAT Dwarf Analysis](http://arxiv.org/abs/1503.02641).
+
+* 10x10 degree ROI
+* Start Time (MET) = 239557417 seconds
+* Stop Time (MET) = 428903014 seconds
+* Minimum Energy = 500 MeV
+* Maximum Energy = 500000 MeV
+* zmax = 100 deg
+* P8R2_SOURCE_V6 (evclass=128)
+
+The P8 dSph paper used a multi-component analysis that used the four PSF event types in a joint likelihood.  In this example we will perform a single component analysis using all SOURCE-class events (evtype=3).
+
+
+## Get the Data and Setup the Analysis
+
+```python
+%matplotlib inline
+import os
+import numpy as np
+from fermipy.gtanalysis import GTAnalysis
+from fermipy.plotting import ROIPlotter, SEDPlotter
+import matplotlib.pyplot as plt
+import matplotlib
+```
+
+In this thread we will use a pregenerated data set which is contained in a tar archive in the *data* directory of the *fermipy-extra* repository.
+
+```python
+if os.path.isfile('../data/draco.tar.gz'):
+    !tar xzf ../data/draco.tar.gz
+else:
+    !curl -OL https://raw.githubusercontent.com/fermiPy/fermipy-extras/master/data/draco.tar.gz
+    !tar xzf draco.tar.gz
+```
+
+We will begin by looking at the contents of the configuration file.  The configuration is similar to our PG1553 example except for the addition of a 'draco' component in the ROI model.  We also set the ROI coordinates explicitly since the ROI center isn't at the position of a 3FGL source.
+
+```python
+!cat draco/config.yaml
+```
+
+<!-- #region -->
+Note that the setup for a joint analysis is identical to the above except for the modification to the components section.  The following example shows the components configuration one would use to define a joint analysis with the four PSF event types:
+```python
+components:
+  - { selection : { evtype : 4  } }
+  - { selection : { evtype : 8  } }
+  - { selection : { evtype : 16 } }
+  - { selection : { evtype : 32 } }
+```
+<!-- #endregion -->
+
+To get started we will first instantiate a GTAnalysis instance using the config file in the draco directory and the run the setup() method.  This will prepare all the ancillary files and create the pylikelihood instance for binned analysis.  Note that in this example these files have already been generated so the routines that would normally be executed to create these files will be skipped.
+
+```python
+gta = GTAnalysis('draco/config.yaml')
+matplotlib.interactive(True)
+gta.setup()
+gta.write_roi('fit0')
+```
+
+## Print the ROI model
+
+We can print the ROI object to see a list of sources in the model along with their distance from the ROI center (offset), TS, and number of predicted counts (Npred).  Since we haven't yet fit any sources, the ts of all sources will initially be assigned as nan.
+
+```python
+gta.print_roi()
+print (
+```
+
+We can assess the quality of our pre-fit model by running the residmap method.  This will generate four maps
+
+```python
+resid = gta.residmap('draco_prefit',model={'SpatialModel' : 'PointSource', 'Index' : 2.0})
+fig = plt.figure(figsize=(14,6))
+ROIPlotter(resid['data'],roi=gta.roi).plot(vmin=400,vmax=1000,subplot=121,cmap='magma')
+plt.gca().set_title('Data')
+ROIPlotter(resid['model'],roi=gta.roi).plot(vmin=400,vmax=1000,subplot=122,cmap='magma')
+plt.gca().set_title('Model')
+
+fig = plt.figure(figsize=(14,6))
+ROIPlotter(resid['sigma'],roi=gta.roi).plot(vmin=-5,vmax=5,levels=[-5,-3,3,5],subplot=121,cmap='RdBu_r')
+plt.gca().set_title('Significance')
+ROIPlotter(resid['excess'],roi=gta.roi).plot(vmin=-100,vmax=100,subplot=122,cmap='RdBu_r')
+plt.gca().set_title('Excess')
+```
+
+Now we will run the *optimize* method.  This method will iteratively optimize the parameters of all components in the ROI in several stages:
+* Simultaneously fitting the normalization of the brightest model components containing at least some fraction of the total model counts (default 95%).
+* Individually fitting the normalization of all remaining sources if they have Npred above some threshold (default 1).
+* Individually fitting the normalization and shape of any component with TS larger than some threshold (default 25).
+
+Running *optimize* gives us a baseline model that we can use as a starting point for subsequent stages of the analysis.  We will also save the results of the analysis with write_roi.  By saving the analysis state we can restore the analysis to this point at any time with the *load_roi* method. (**NOTE**: This step is computationally intensive and can take up to 5-10 minutes)
+
+```python
+gta.optimize()
+gta.write_roi('fit1')
+```
+
+After running *optimize* we can rerun *print_roi* to see a summary of the updated model.  All sources that were fit in this step now have ts values and an Npred value the reflects the optimized normalization of that source.  Note that model components that were not fit during the optimize step still have ts=nan.
+
+```python
+gta.print_roi()
+```
+
+To evaluate the quality of the optimized model we can rerun the residmap method.  In the updated residual map that we see that there is no longer a negative residual in the vicinity of J1707.
+
+```python
+resid = gta.residmap('draco_postfit',model={'SpatialModel' : 'PointSource', 'Index' : 2.0})
+fig = plt.figure(figsize=(14,6))
+ROIPlotter(resid['sigma'],roi=gta.roi).plot(vmin=-5,vmax=5,levels=[-5,-3,3,5],subplot=121,cmap='RdBu_r')
+plt.gca().set_title('Significance')
+ROIPlotter(resid['excess'],roi=gta.roi).plot(vmin=-100,vmax=100,subplot=122,cmap='RdBu_r')
+plt.gca().set_title('Excess')
+```
+
+Another diagnostic for the quality of the ROI model is the TS map.  The *tsmap* method can be used to generate a TS map of the ROI with a given test source model.  Here we use the same source model we did for the residual map -- a point source with a power-law index of 2.  
+
+```python
+tsmap_postfit = gta.tsmap('draco_postfit',model={'SpatialModel' : 'PointSource', 'Index' : 2.0})
+```
+
+Here we see that the excess in the northeast part of the ROI appears more prominent than in the residual map.  This excess is detected as a new point source with TS > 25.
+
+```python
+fig = plt.figure(figsize=(14,6))
+ROIPlotter(tsmap_postfit['sqrt_ts'],roi=gta.roi).plot(levels=[0,3,5,7],vmin=0,vmax=5,subplot=121,cmap='magma')
+plt.gca().set_title('Sqrt(TS)')
+ROIPlotter(tsmap_postfit['npred'],roi=gta.roi).plot(vmin=0,vmax=100,subplot=122,cmap='magma')
+plt.gca().set_title('NPred')
+```
+
+We can add this source into the model by running the *find_sources* method.  This method will generate a TS map of the region and add a point-source at the location of each peak with TS > 25.
+
+```python
+src = gta.find_sources()
+```
+
+From the log we can see that a new source PS J1705.4+5434 was found with TS~50.  Rerunning the *tsmap* method we can see that this source is located at the peak of the TS Map that was previously present in the northeast corner of the ROI.
+
+```python
+print(gta.roi['PS J1705.4+5434'])
+tsmap_newsrcs = gta.tsmap('draco_newsrcs',model={'SpatialModel' : 'PointSource', 'Index' : 2.0})
+fig = plt.figure(figsize=(14,6))
+ROIPlotter(tsmap_newsrcs['sqrt_ts'],roi=gta.roi).plot(levels=[0,3,5,7],vmin=0,vmax=5,subplot=121,cmap='magma')
+plt.gca().set_title('Sqrt(TS)')
+ROIPlotter(tsmap_newsrcs['npred'],roi=gta.roi).plot(vmin=0,vmax=100,subplot=122,cmap='magma')
+plt.gca().set_title('NPred')
+```
+
+## Spectral Analysis
+
+After optimizing the ROI model we are ready to perform our analysis of the source of interest (draco).  We will begin by freeing draco along with all other point sources within 3 deg of the ROI center and refitting their normalizations.
+
+```python
+gta.free_sources(distance=3.0,pars='norm')
+gta.free_sources(distance=3.0,pars='shape',minmax_ts=[100.,None])
+fit_results = gta.fit()
+```
+
+After running the fit completes we can execute the spectral analysis of draco with the sed method.  For comparison we will also perform the spectral analysis of a nearby source (3FGL J1725.3+5853).
+
+```python
+sed_draco = gta.sed('draco')
+sed_j1725 = gta.sed('3FGL J1725.3+5853')
+gta.write_roi('fit_sed')
+```
+
+We can now inspect the fit results by looking at the elements of the output dictionary.  By default the sed method will perform a likelihood scan in each energy bin which is saved in the *dloglike_scan* array.  In the following example we plot the likelihood profile in the first energy bin and overplot the flux upper limit in that bin (vertical black line).  fermiPy uses the delta-log-likelihood method to evaluate ULs and we can see that the 95% CL flux upper limit intersects with the point at which the log-likelihood has decreased by 2.71/2 from its maximum value (horizontal red line).
+
+```python
+# E^2 x Differential flux ULs in each bin in units of MeV cm^{-2} s^{-1}
+print sed_draco['e2dnde_ul95']
+
+e2dnde_scan = sed_draco['norm_scan']*sed_draco['ref_e2dnde'][:,None]
+
+plt.figure()
+plt.plot(e2dnde_scan[0],
+        sed_draco['dloglike_scan'][0]-np.max(sed_draco['dloglike_scan'][0]))
+plt.gca().set_ylim(-5,1)
+plt.gca().axvline(sed_draco['e2dnde_ul95'][0],color='k')
+plt.gca().axhline(-2.71/2.,color='r')
+```
+
+We can also visualize the results of the scan with the SEDPlotter class.  This class accepts a source object as its argument and creates a visualization of the SED as a sequence of points with errors.  Setting showlnl=True overplots the likelihood function in each bin as a color gradient (the so-called castro plot).
+
+```python
+fig = plt.figure(figsize=(14,4))
+ylim=[1E-8,1E-5]
+fig.add_subplot(121)
+SEDPlotter(sed_draco).plot()
+plt.gca().set_ylim(ylim)
+
+fig.add_subplot(122)
+SEDPlotter(sed_j1725).plot()
+plt.gca().set_ylim(ylim)
+
+fig = plt.figure(figsize=(14,4))
+
+fig.add_subplot(121)
+SEDPlotter(sed_draco).plot(showlnl=True,ylim=ylim)
+plt.gca().set_ylim(ylim)
+
+fig.add_subplot(122)
+SEDPlotter(sed_j1725).plot(showlnl=True,ylim=ylim)
+plt.gca().set_ylim(ylim)
+```
+
+# Setting DM Upper Limits
+
+Now that we have run a spectral analysis we can use the bin-by-bin likelihoods to gamma-ray flux from DM annihilations in Draco.  In the following sample code we demonstrate how to calculate the UL on the DM cross section for a given DM spectral model.  
+
+```python
+import pyLikelihood
+
+# Load the sed data structure
+data = sed_draco
+
+# Instantiate a DM Fit Function for a DM particle spectrum given the following parameters
+# Mass = 100 GeV
+# Cross-Section: 3 x 10^{-26} cm^{3} s^{-1}
+# J-Factor: 10^19 GeV^2 cm^{-5}
+# Channel: b-bbar
+dmf = pyLikelihood.DMFitFunction()
+dmf.readFunction(os.path.expandvars('$FERMIPY_ROOT/data/gammamc_dif.dat'))
+dmf.setParam('norm',1E19)
+dmf.setParam('sigmav',3E-26)
+dmf.setParam('mass',100.0)
+dmf.setParam('bratio',1.0)
+dmf.setParam('channel0',4)
+
+def integrate_eflux(fn,ebins,nstep=10):
+    """Compute energy flux within a sequence of energy bins."""
+    
+    loge = np.linspace(ebins[0],ebins[-1],100)
+    dfde = [fn(pyLikelihood.dArg(10**x)) for x in loge]        
+    dfde = np.array(dfde)
+    x = ebins
+    dx = (x[1:] - x[:-1])
+
+    yedge = x[1:,np.newaxis] + np.linspace(0,1,nstep)[np.newaxis,:]*dx[:,np.newaxis] 
+    dy = 10**yedge[:,1:]-10**yedge[:,:-1]
+    y = 0.5*(yedge[:,1:]+yedge[:,:-1])
+    eflux = np.interp(np.ravel(y),loge,dfde)
+    eflux = np.sum(eflux.reshape(y.shape)*10**y*dy,axis=1)
+
+    return eflux
+
+class SEDLike(object):
+
+    def __init__(self,sed):
+        self._sed = sed
+        self._eflux_scan = sed['norm_scan']*sed['ref_eflux'][:,None]
+
+    def __call__(self,eflux):
+        lnl = np.zeros(eflux.shape)
+        for i, ectr in enumerate(self._sed['e_ctr']):
+            v = np.interp(eflux[i],
+                          self._eflux_scan[i],
+                          self._sed['dloglike_scan'][i])
+            lnl[i] += v
+        return np.sum(lnl,axis=0)
+
+ebins = np.log10(np.array(list(data['e_min']) + list([data['e_max'][-1]])))
+eflux = integrate_eflux(dmf,ebins)
+sigmav = 3.E-26*np.logspace(-3.,1.,101)
+eflux = eflux[:,np.newaxis]*np.logspace(-3,1,101)[np.newaxis,:]
+
+slike = SEDLike(data)
+lnl = slike(eflux)
+lnl -= np.max(lnl)
+
+# Plot log-likelihood profile
+
+plt.figure()
+plt.plot(sigmav,lnl)
+plt.gca().set_xscale('log')
+plt.gca().axhline(-2.71/2.,color='k')
+plt.gca().set_ylim(-4,1)
+plt.gca().set_xlabel('Cross Section [cm$^{3}$ s$^{-1}$]')
+
+sigmav_ul = float(np.interp(2.71/2.,-lnl,sigmav))
+
+print 'Sigma-V Upper Limit: ', sigmav_ul
+```
+
+```python
+
+```


### PR DESCRIPTION
I would rather pull this to a different branch but I do not know how.

## markdown generation

This gives and example on how to do the notebook generation.

I took the draco example from the 'extra' repo. 

1) First one converts an existing notebook to markdown with:

```
jupytext --to md draco.ipynb
```

As @henrikef said, these have much smaller diffs but you can still work on them as if they are regular notebooks. 

2) Store the markdown files somewhere under the docs folder

3) In the GitHub action, once you have all the basics installed, run jupytext to convert and execute the markdown notebook. Then you can move this to a different folder for uploading to RTD 


4) The RTD action, ` dfm/rtds-action@main` does some nice magic of uploading and converting everything for RTDs.


There are probably smarter ways to do this, but this is the workflow that made sense a few years ago when actions and jupytext were a bit new. Netflix has some similar workflows and then may have improved upon this over the years. 

## host on GitHub pages

This covers the basics. The rest of the action is the way to separate from RTD and use github pages to host the docs. Nearly everything is the same except that you a) build the apidoc manually which can allow you to customize this rather than trying to get `conf.py` to obey you and b) you can more directly see where things fail rather than waiting on RTD builds. 

This also allows you to have a dev build of the docs (if you wanted to keep using RTD but see doc changes for every commit for example).


