### PR TITLE
Updating fermipy to Astropy 6.0 and gammapy 1.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pyyaml
   - numpy>=1.16
   - scipy<1.12
-  - astropy<6
+  - astropy=6.0.0
   - matplotlib>=3.3
   - healpy
   - astropy-healpix

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - matplotlib>=3.3
   - healpy
   - astropy-healpix
-  - gammapy>=0.18
+  - gammapy=1.2
   - fermitools>=2.2.0


### PR DESCRIPTION
Following the discussion in Madrid I wanted to understand the reason of the incompatibility of fermipy with Astropy v6.0.
This was referenced in several previous issues like in #558.

The error was the following :
`ModuleNotFoundError: No module named 'astropy.coordinates.angle_utilities' `

This error was coming from gammapy not from fermipy due to Astropy moving a method.
This has been fixed in gammapy 1.2 recent release (see [here](https://github.com/gammapy/gammapy/pull/4937) ).

I have tested to install fermipy with gammapy 1.2 and with astropy 6.0 and it works fine. 
I've done a gta.setup(), fitted the ROI, made an SED and a TS map and had no errors.

However this is not extensive so any test on your specific analysis would help to see if there are no other issues.

In this PR I've updated astropy to =6.0.0 (latest v6.0.1 throws an error in gammapy now ...) and associated it to the latest gammapy v1.2.

Any comments are welcome !

