### PR TITLE
Fixed the double counting on Npred

### DIFF
--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -642,7 +642,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
                 rm['npred_wt'] += np.sum(src['model_counts_wt'])
             except:
                 rm['model_counts_wt'] += src['model_counts']
-                rm['npred'] += np.sum(src['model_counts'])
+                rm['npred_wt'] += np.sum(src['model_counts'])
 
             mc = self.model_counts_spectrum(name)
             mc_wt = self.model_counts_spectrum(name, weighted=True)


### PR DESCRIPTION
This addressed the issue 649 related with the double counting of spread when model_counts_wt is not present for a source. This issue affects only the case when model_counts_wt is missing from the dictionary, which should never happen with recent version of the code.