### PR TITLE
Refactor deprecated numpy.core.defchararray methods

### DIFF
--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -77,7 +77,7 @@ def strip_columns(tab):
     """Strip whitespace from string columns."""
     for colname in tab.colnames:
         if tab[colname].dtype.kind in ['S', 'U']:
-            tab[colname] = np.core.defchararray.strip(tab[colname])
+            tab[colname] = np.char.strip(tab[colname])
 
 
 def row_to_dict(row):

--- a/fermipy/utils.py
+++ b/fermipy/utils.py
@@ -15,7 +15,6 @@ from scipy.interpolate import UnivariateSpline
 from scipy.optimize import brentq
 from scipy.ndimage import label
 import scipy.special as special
-from numpy.core import defchararray
 from numpy.polynomial.polynomial import polyfit
 try:
     from astropy.extern import six
@@ -239,8 +238,7 @@ def find_rows_by_string(tab, names, colnames=['assoc']):
             continue
 
         col = tab[[colname]].copy()
-        col[colname] = defchararray.replace(defchararray.lower(col[colname]).astype(str),
-                                        ' ', '')
+        col[colname] = np.char.replace(np.char.lower(col[colname]).astype(str),' ', '')
         for name in names:
             mask |= col[colname] == name
     return mask


### PR DESCRIPTION
The `defchararray` is not recommended since numpy 1.4  and the preferred alias for `defchararray` is `numpy.char`.

Refactored the only two occurrences in `fermipy` - local `pytests` succeeding without issues