### PR TITLE
Upgrading fermipy to numpy>2 and astropy>7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        os : ["ubuntu-latest", "macos-15-intel", "macos-latest"]                
+        os : ["ubuntu-latest", "macos-15-intel", "macos-latest", "ubuntu-24.04-arm"]                
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@v6
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-variant: Miniforge3
         activate-environment: fermipy
@@ -68,11 +68,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.12]
-        os : ["ubuntu-latest", "macos-15-intel", "macos-latest"]                
+        os : ["ubuntu-latest", "macos-15-intel", "macos-latest", "ubuntu-24.04-arm"]                
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@v6
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-variant: Miniforge3
         activate-environment: fermipy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # needed for git describe / package version
     - uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-variant: Miniforge3
@@ -67,6 +69,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # needed for git describe / package version
     - uses: conda-incubator/setup-miniconda@v4
       with:
         miniforge-variant: Miniforge3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pylint pytest pytest-cov
+        python -m pip install -e .
         python -c "import fermipy; print(fermipy.get_st_version())"
     - name: Lint with pylint
       shell: bash -l {0}
@@ -47,14 +48,8 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m pytest --cov=./fermipy --cov-report=xml fermipy
-#      if: runner.os == 'macOS'
-#    - name: Test with pytest without codecov
-#      shell: bash -l {0}
-#      run: |
-#        python -m pytest fermipy
-#      if: runner.os != 'macOS'
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         flags: unittests
@@ -84,6 +79,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pylint pytest pytest-cov
+        python -m pip install -e .
         python -c "import fermipy; print(fermipy.get_st_version())"
     - name: Lint with pylint
       shell: bash -l {0}
@@ -99,7 +95,7 @@ jobs:
       run: |
         python -m pytest --cov=./fermipy --cov-report=xml fermipy
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         flags: unittests

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,11 +5,12 @@ channels:
 dependencies:
   - python
   - pyyaml
-  - numpy>=1.16
-  - scipy
-  - astropy
+  - numpy>=2.0
+  - scipy<1.18
+  - regions<0.12
+  - astropy<8
   - matplotlib>=3.3
   - healpy
   - astropy-healpix
-  - gammapy>=1.0
+  - gammapy>=2.0
   - fermitools>=2.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,12 @@ channels:
 dependencies:
   - python
   - pyyaml
-  - numpy>=1.16
-  - scipy
-  - astropy
+  - numpy>=2.0
+  - scipy<1.18
+  - regions<0.12
+  - astropy<8
   - matplotlib>=3.3
   - healpy
   - astropy-healpix
-  - gammapy>=1.0
+  - gammapy>=2.0
   - fermitools>=2.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - pyyaml
-  - numpy>=2.0
+  - numpy
   - scipy<1.18
   - regions<0.12
   - astropy<8

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - healpy
   - astropy-healpix
   - gammapy>=2.0
-  - fermitools>=2.2.0
+  - fermitools>=2.5.0

--- a/fermipy/castro.py
+++ b/fermipy/castro.py
@@ -839,7 +839,7 @@ class CastroData_Base(object):
             mle = self._loglikes[i].mle()
             nll0 = self._loglikes[i].interp(mle)
             nll1 = self._loglikes[i].interp(x[i])
-            chi2_vals[i] = 2.0 * np.abs(nll0 - nll1)
+            chi2_vals[i] = 2.0 * np.abs(nll0 - nll1)[0]
 
         return chi2_vals
 

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -85,7 +85,7 @@ def row_to_dict(row):
     o = {}
     for colname in row.colnames:
 
-        if isinstance(row[colname], np.string_) and row[colname].dtype.kind in ['S', 'U']:
+        if isinstance(row[colname], (np.bytes_, np.str_)) and row[colname].dtype.kind in ['S', 'U']:
             o[colname] = str(row[colname])
         else:
             o[colname] = row[colname]

--- a/fermipy/catalog.py
+++ b/fermipy/catalog.py
@@ -59,6 +59,19 @@ def join_tables(left, right, key_left, key_right,
     if key_left not in cols_right:
         cols_right += [key_left]
 
+    # Fill missing (masked) values in key columns before joining (astropy >6
+    # raises TableMergeError if key columns have missing values).
+    for tbl in [left, right]:
+        if key_left in tbl.colnames:
+            col = tbl[key_left]
+            if hasattr(col, 'mask') and col.mask.any():
+                if col.dtype.kind in ['S', 'U']:
+                    tbl[key_left] = col.filled('')
+                elif col.dtype.kind in ['i']:
+                    tbl[key_left] = col.filled(0)
+                else:
+                    tbl[key_left] = col.filled(np.nan)
+
     out = join(left, right[cols_right], keys=key_left,
                join_type='left')
 

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -4791,7 +4791,7 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
 
         if src['SpatialType'] == 'SkyDirFunction':
             pylike_src = pyLike.PointSource(self.like.logLike.observation())
-            pylike_src.setDir(src.skydir.ra.deg, src.skydir.dec.deg, False,
+            pylike_src.setDir(float(src.skydir.ra.deg), float(src.skydir.dec.deg), False,
                               False)
         elif src['SpatialType'] == 'SpatialMap':
             filepath = str(utils.path_to_xmlpath(src['Spatial_Filename']))
@@ -4802,20 +4802,20 @@ class GTBinnedAnalysis(fermipy.config.Configurable):
         elif src['SpatialType'] == 'RadialProfile':
             filepath = str(utils.path_to_xmlpath(src['Spatial_Filename']))
             sm = pyLike.RadialProfile(filepath)
-            sm.setCenter(src['ra'], src['dec'])
+            sm.setCenter(float(src['ra']), float(src['dec']))
             pylike_src = pyLike.DiffuseSource(sm,
                                               self.like.logLike.observation(),
                                               False)
         elif src['SpatialType'] == 'RadialGaussian':
-            sm = pyLike.RadialGaussian(src.skydir.ra.deg, src.skydir.dec.deg,
-                                       src.spatial_pars['Sigma']['value'])
+            sm = pyLike.RadialGaussian(float(src.skydir.ra.deg), float(src.skydir.dec.deg),
+                                       float(src.spatial_pars['Sigma']['value']))
             pylike_src = pyLike.DiffuseSource(sm,
                                               self.like.logLike.observation(),
                                               False)
 
         elif src['SpatialType'] == 'RadialDisk':
-            sm = pyLike.RadialDisk(src.skydir.ra.deg, src.skydir.dec.deg,
-                                   src.spatial_pars['Radius']['value'])
+            sm = pyLike.RadialDisk(float(src.skydir.ra.deg), float(src.skydir.dec.deg),
+                                   float(src.spatial_pars['Radius']['value']))
             pylike_src = pyLike.DiffuseSource(sm,
                                               self.like.logLike.observation(),
                                               False)

--- a/fermipy/gtanalysis.py
+++ b/fermipy/gtanalysis.py
@@ -2830,7 +2830,7 @@ class GTAnalysis(fermipy.config.Configurable, sed.SEDGenerator,
         elif optimizer.upper() == 'NEWMINUIT':
             optObject = pyLike.NewMinuit(self.like.logLike)
         else:
-            optFactory = pyLike.OptimizerFactory_instance()
+            optFactory = pyLike.OptimizerFactory.instance()
             optObject = optFactory.create(str(optimizer), self.like.logLike)
         return optObject
 

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -15,7 +15,7 @@ import BinnedAnalysis as ba
 
 pyIrfLoader.Loader.go()
 
-_funcFactory = pyLike.SourceFactory_funcFactory()
+_funcFactory = pyLike.SourceFactory.funcFactory()
 
 
 
@@ -116,7 +116,7 @@ def init_function_pars():
     FUNCTION_PAR_NAMES = {}
     FUNCTION_NORM_PARS = {}
 
-    funcFactory = pyLike.SourceFactory_funcFactory()
+    funcFactory = pyLike.SourceFactory.funcFactory()
 
     names = pyLike.StringVector()
     funcFactory.getFunctionNames(names)
@@ -223,7 +223,7 @@ def create_spectrum_from_dict(spectrum_type, spectral_pars, fn=None):
     """
 
     if fn is None:
-        fn = pyLike.SourceFactory_funcFactory().create(str(spectrum_type))
+        fn = pyLike.SourceFactory.funcFactory().create(str(spectrum_type))
 
     if spectrum_type == 'PiecewisePowerLaw':        
         build_piecewise_powerlaw(fn, spectral_pars)

--- a/fermipy/gtutils.py
+++ b/fermipy/gtutils.py
@@ -507,7 +507,7 @@ class SummedLikelihood(sl.SummedLikelihood):
         if tol is None:
             tol = self.tol
         if optObject is None:
-            optFactory = pyLike.OptimizerFactory_instance()
+            optFactory = pyLike.OptimizerFactory.instance()
             myOpt = optFactory.create(optimizer, self.logLike)
         else:
             myOpt = optObject
@@ -541,7 +541,7 @@ class SummedLikelihood(sl.SummedLikelihood):
         if reoptimize:
             if verbosity > 0:
                 print("** Do reoptimize")
-            optFactory = pyLike.OptimizerFactory_instance()
+            optFactory = pyLike.OptimizerFactory.instance()
             myOpt = optFactory.create(self.optimizer, self.composite)
             Niter = 1
             while Niter <= MaxIterations:
@@ -687,7 +687,7 @@ class BinnedAnalysis(ba.BinnedAnalysis):
         if reoptimize:
             if verbosity > 0:
                 print("** Do reoptimize")
-            optFactory = pyLike.OptimizerFactory_instance()
+            optFactory = pyLike.OptimizerFactory.instance()
             myOpt = optFactory.create(self.optimizer, self.logLike)
             Niter = 1
             while Niter <= MaxIterations:

--- a/fermipy/hpx_utils.py
+++ b/fermipy/hpx_utils.py
@@ -339,7 +339,7 @@ class HPX(object):
         if self._rmap is not None:
             retval = np.empty((sliced.size), 'i')
             retval.fill(-1)
-            m = np.in1d(sliced.flat, self._ipix)
+            m = np.isin(sliced.flat, self._ipix)
             retval[m] = np.searchsorted(self._ipix, sliced.flat[m])
             return retval.reshape(sliced.shape)
         return sliced

--- a/fermipy/srcmap_utils.py
+++ b/fermipy/srcmap_utils.py
@@ -76,7 +76,7 @@ class MapInterpolator(object):
                 idx += [0]
             else:
                 npix1 = int(self.shape[i])
-                pix0 = int(pix[i - 1]) - npix1 // 2
+                pix0 = int(pix[i - 1][0]) - npix1 // 2
                 idx += [pix0]
 
         return idx
@@ -90,7 +90,7 @@ class MapInterpolator(object):
         for i in range(len(self.shape) - 1):
             x = self.rebin * (pix[i] - pix_offset[i + 1]
                               ) + (self.rebin - 1.0) / 2.
-            dpix[i] = x - self._pix_ref[i]
+            dpix[i] = x[0] - self._pix_ref[i]
 
         pos = [pix_offset[i] + self.shape[i] // 2
                for i in range(self.data.ndim)]

--- a/fermipy/tsmap.py
+++ b/fermipy/tsmap.py
@@ -1096,7 +1096,7 @@ class TSCubeGenerator(object):
 
         skyproj = pyLike.FitScanner.buildSkyProj(str("AIT"), refdir, float(pixsize), int(npix), galactic)
 
-        optFactory = pyLike.OptimizerFactory_instance()
+        optFactory = pyLike.OptimizerFactory.instance()
         optObject = optFactory.create(str("MINUIT"), self.like.composite)
 
         fitScanner = pyLike.FitScanner(self.like.composite, optObject, skyproj,

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "matplotlib>=3.3",
         "gammapy>=2.0",
         "healpy",
-        "astropy-healpix"
+        "astropy-healpix",
         "regions<0.12",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -114,11 +114,12 @@ setup(
     install_requires=[
         "numpy>=1.16",
         "pyyaml",
-        "scipy",
-        "astropy",
+        "scipy<1.18",
+        "astropy<8",
         "matplotlib>=3.3",
-        "gammapy>=1.0",
+        "gammapy>=2.0",
         "healpy",
         "astropy-healpix"
+        "regions<0.12",
     ],
 )


### PR DESCRIPTION
This PR proposes to fix remaining issues with numpy2 and also issues that I discovered with astropy 6&7.

This follows the [PR](https://github.com/fermi-lat/sane/pull/4) fixing numpy2  in the fermitools and this PR should be tested in a numpy and astropy 7 environment in conjunction with the fermitools numpy2 version.

##  Issues solved: 
All issues (for now) were related to `catalog.py`.
I haven't yet tested a longer fermipy analysis than just `gta.setup()`.
I will try later and report if any other bugs are found.

So far this is what I've done.

### Numpy 2 related 

As  numpy2 deprecated the `np.string_`  call [here](https://github.com/fermiPy/fermipy/blob/5594f2c41bff0a73369cc1b6c84744dffbd5eae5/fermipy/catalog.py#L88)  was failing.

the fix was to use : `(np.bytes_, np.str_)` to handle both string and bytes columns
Maybe just `np.str_` was enough. But at least we should be safe with both.

### Astropy >6 related 

In astropy >6 , `table.join()` [here](https://github.com/fermiPy/fermipy/blob/5594f2c41bff0a73369cc1b6c84744dffbd5eae5/fermipy/catalog.py#L62) strictly rejects missing values in key columns. The join_tables() function in catalog.py was calling join() directly on tables where the left key column (Extended_Source_Name) had masked/NaN values for non-extended sources, causing:
`astropy.table.np_utils.TableMergeError: Left key column 'Extended_Source_Name' has missing values `

The fix here is more painful and I'm not completly sure that the proposed solution is the best.
The solution is to add a pre-processing step before the `join()` call that fills masked values in the key column for both tables with 0 or empty strings.

Maybe this entire `join_tables` function could be revisited and simplified as it is a bit cryptic now.
But let's try this fix first.


